### PR TITLE
Allow multiple instances of cloudprober to run sequentially.

### DIFF
--- a/cloudprober.go
+++ b/cloudprober.go
@@ -32,7 +32,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/cloudprober/cloudprober/common/tlsconfig"
 	"github.com/cloudprober/cloudprober/config"
 	configpb "github.com/cloudprober/cloudprober/config/proto"
@@ -43,6 +42,7 @@ import (
 	"github.com/cloudprober/cloudprober/servers"
 	"github.com/cloudprober/cloudprober/surfacers"
 	"github.com/cloudprober/cloudprober/sysvars"
+	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/channelz/service"
 	"google.golang.org/grpc/credentials"
@@ -235,6 +235,14 @@ func Start(ctx context.Context) {
 			grpcSrv.Stop()
 		}
 		cloudProber.cancelInitCtx()
+		runconfig.ClearDefaultGRPCServer()
+		cloudProber.Lock()
+		defer cloudProber.Unlock()
+		cloudProber.defaultServerLn = nil
+		cloudProber.defaultGRPCLn = nil
+		cloudProber.textConfig = ""
+		cloudProber.config = nil
+		cloudProber.prober = nil
 	}()
 
 	go srv.Serve(cloudProber.defaultServerLn)

--- a/cloudprober_test.go
+++ b/cloudprober_test.go
@@ -200,11 +200,12 @@ func TestRestart(t *testing.T) {
 				t.Fatalf("InitFromConfig(ctx, %v): %v", string(b), err)
 			}
 			Start(ctx)
-			ctxTO, cancelTO := context.WithTimeout(ctx, time.Second*30)
-			defer cancelTO()
 
+			// Wait for results from the surfacer, or 30s,
+			// whichever comes first. Since the export rate is 1s,
+			// we should expect results well before 30s has passed.
 			select {
-			case <-ctxTO.Done():
+			case <-time.After(time.Second * 30):
 				t.Fatal("surfacer timed out before getting results")
 			case <-s.c:
 			}

--- a/cloudprober_test.go
+++ b/cloudprober_test.go
@@ -15,10 +15,22 @@
 package cloudprober
 
 import (
+	"context"
+	"net"
 	"os"
 	"testing"
+	"time"
 
 	configpb "github.com/cloudprober/cloudprober/config/proto"
+	"github.com/cloudprober/cloudprober/metrics"
+	probepb "github.com/cloudprober/cloudprober/probes/proto"
+	udpprobepb "github.com/cloudprober/cloudprober/probes/udp/proto"
+	serverspb "github.com/cloudprober/cloudprober/servers/proto"
+	udpserverpb "github.com/cloudprober/cloudprober/servers/udp/proto"
+	"github.com/cloudprober/cloudprober/surfacers"
+	surfacerspb "github.com/cloudprober/cloudprober/surfacers/proto"
+	targetspb "github.com/cloudprober/cloudprober/targets/proto"
+	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -83,4 +95,119 @@ func TestGetDefaultServerPort(t *testing.T) {
 		})
 	}
 
+}
+
+type FakeSurfacer struct {
+	c chan *metrics.EventMetrics
+}
+
+func (f *FakeSurfacer) Write(ctx context.Context, em *metrics.EventMetrics) {
+	if em.Label("ptype") != "udp" {
+		return
+	}
+	select {
+	case f.c <- em:
+	case <-ctx.Done():
+	}
+}
+
+func freePortsT(t *testing.T, n int) []int32 {
+	ports := make([]int32, 0, n)
+	for i := 0; i < n; i++ {
+		l, err := net.Listen("tcp", ":0")
+		if err != nil {
+			t.Fatalf("net.Listen(%q, %q): %v", "tcp", ":0", err)
+		}
+		defer l.Close()
+		ports = append(ports, int32(l.Addr().(*net.TCPAddr).Port))
+	}
+	return ports
+}
+
+func TestRestart(t *testing.T) {
+	type TestCase struct {
+		Name string
+	}
+	testCases := []TestCase{
+		{
+			Name: "FirstInitAndStart",
+		},
+		{
+			Name: "SecondInitAndStart",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer func() {
+				cancel()
+				// Wait required for the cloudprober instance to fully shut down.
+				time.Sleep(time.Second)
+			}()
+			ports := freePortsT(t, 3)
+			cfg := &configpb.ProberConfig{
+				Port:     proto.Int32(ports[0]),
+				GrpcPort: proto.Int32(ports[1]),
+				Server: []*serverspb.ServerDef{
+					{
+						Type: serverspb.ServerDef_UDP.Enum(),
+						Server: &serverspb.ServerDef_UdpServer{
+							UdpServer: &udpserverpb.ServerConf{
+								Port: proto.Int32(ports[2]),
+								Type: udpserverpb.ServerConf_ECHO.Enum(),
+							},
+						},
+					},
+				},
+				Probe: []*probepb.ProbeDef{
+					{
+						Name:                    proto.String("udp echo"),
+						Type:                    probepb.ProbeDef_UDP.Enum(),
+						TimeoutMsec:             proto.Int32(10),
+						IntervalMsec:            proto.Int32(10), // 100 probe per second
+						StatsExportIntervalMsec: proto.Int32(int32(1 * time.Second / time.Millisecond)),
+						Targets: &targetspb.TargetsDef{
+							Type: &targetspb.TargetsDef_HostNames{
+								HostNames: "localhost",
+							},
+						},
+						Probe: &probepb.ProbeDef_UdpProbe{
+							UdpProbe: &udpprobepb.ProbeConf{
+								Port:        proto.Int32(ports[2]),
+								PayloadSize: proto.Int32(10),
+							},
+						},
+					},
+				},
+			}
+			surfacerName := "custom"
+			cfg.Surfacer = []*surfacerspb.SurfacerDef{
+				&surfacerspb.SurfacerDef{
+					Name: proto.String(surfacerName),
+					Type: surfacerspb.Type_USER_DEFINED.Enum(),
+				},
+			}
+			s := &FakeSurfacer{c: make(chan *metrics.EventMetrics, 10)}
+			surfacers.Register(surfacerName, s)
+
+			b, err := prototext.Marshal(cfg)
+			if err != nil {
+				t.Fatalf("prototext.Marshal(%v): %v", cfg, err)
+			}
+
+			err = InitFromConfig(string(b))
+			if err != nil {
+				t.Fatalf("InitFromConfig(ctx, %v): %v", string(b), err)
+			}
+			Start(ctx)
+			ctxTO, cancelTO := context.WithTimeout(ctx, time.Second*30)
+			defer cancelTO()
+
+			select {
+			case <-ctxTO.Done():
+				t.Fatal("surfacer timed out before getting results")
+			case <-s.c:
+			}
+		})
+	}
 }

--- a/config/runconfig/runconfig.go
+++ b/config/runconfig/runconfig.go
@@ -48,6 +48,12 @@ func SetDefaultGRPCServer(s *grpc.Server) error {
 	return nil
 }
 
+func ClearDefaultGRPCServer() {
+	rc.Lock()
+	defer rc.Unlock()
+	rc.grpcSrv = nil
+}
+
 // DefaultGRPCServer returns the configured gRPC server and nil if gRPC server
 // was not set.
 func DefaultGRPCServer() *grpc.Server {

--- a/go.sum
+++ b/go.sum
@@ -327,6 +327,7 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420 h1:a8jGStKg0XqKDlKqjLrXn0ioF5MH36pT7Z0BRTqLhbk=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -407,6 +408,7 @@ golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210503080704-8803ae5d1324 h1:pAwJxDByZctfPwzlNGrDN2BQLsdPb9NkhoTJtUkAO28=
 golang.org/x/sys v0.0.0-20210503080704-8803ae5d1324/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This is most useful for tests in which a full cloudprober is
required. Each test initializes a new instance, calling
InitFromConfig and Start and when the context passed to Start is done,
the cloud prober instance will shut down fully. There is currently no
good way to ensure that the last instance has shut down before starting
a new one, so I used a time.Sleep.

- Added ClearDefaultGRPCServer() to runconfig to clear the saved gRPC
server
- On context close, Start will fully clean up the global variables found
in cloudprober.go
- Added test that starts CloudProber, stops it, and starts it again.
Before this code change, that would have always failed with the second
config ignored.