### PR TITLE
Pin website header title to Cloudprober.

### DIFF
--- a/docs/themes/hugo-material-docs/layouts/partials/header.html
+++ b/docs/themes/hugo-material-docs/layouts/partials/header.html
@@ -7,7 +7,7 @@
     </div>
     <div class="stretch">
       <div class="title">
-        {{ .Title }}
+        Cloudprober
       </div>
     </div>
 


### PR DESCRIPTION
Website header should always be Cloudprober. Page title is anyway shown below.