### PR TITLE
Add the ability to add target IP to labels.

### DIFF
--- a/examples/additional_label/cloudprober.cfg
+++ b/examples/additional_label/cloudprober.cfg
@@ -2,14 +2,14 @@
 # "additional_label".  An additional label's value can be static or it can be
 # derived from the target labels.
 #
-# For the following config:
-#   if ingress target has label "fqdn:app.example.com",
-#   and prober is running in the GCE zone "us-east1-c",
-#   and prober's GCE instance has label "env:prod".
-# 
+# For the following config, if:
+#   1) Ingress target has label "fqdn:app.example.com",
+#   2) Prober is running in the GCE zone "us-east1-c",
+#   3) Prober's GCE instance has label "env:prod".
+#
 # Probe results will look like the following:
-#   total{probe="my_ingress",ptype="http",metrictype="prober",env="prod",src_zone="us-east1-c",host="app.example.com"}: 90
-# success{probe="my_ingress",ptype="http",metrictype="prober",env="prod",src_zone="us-east1-c",host="app.example.com"}: 80
+#   total{probe="my_ingress",ptype="http",metrictype="prober",env="prod",src_zone="us-east1-c",host="app.example.com",addr="10.1.12.21:3141"}: 90
+# success{probe="my_ingress",ptype="http",metrictype="prober",env="prod",src_zone="us-east1-c",host="app.example.com",addr="10.1.12.21:3141"}: 80
 probe {
   name: "my_ingress"
   type: HTTP
@@ -23,29 +23,35 @@ probe {
       }
     }
   }
-  
+
   # Static label
   additional_label {
     key: "metrictype"
     value: "prober"
   }
-  
+
   # Label is configured at the run time, based on the prober instance label (GCE).
   additional_label {
     key: "env"
     value: "{{.label_env}}"
   }
-  
+
   # Label is configured at the run time, based on the prober environment (GCE).
   additional_label {
     key: "src_zone"
     value: "{{.zone}}"
   }
-  
-  # Label is configured based on the target labels.
+
+  # Label "host" is configured based on the target label "fqdn".
   additional_label {
     key: "host"
     value: "@target.label.fqdn@"
+  }
+
+  # Label "addr" is configured based on the target IP and port.
+  additional_label {
+    key: "addr"
+    value: "@target.ip@:@target.port@"
   }
 
   http_probe {}

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -429,9 +429,6 @@ func (p *Probe) startForTarget(ctx context.Context, target endpoint.Endpoint, da
 	// We use this counter to decide when to export stats.
 	var runCnt int64
 
-	for _, al := range p.opts.AdditionalLabels {
-		al.UpdateForTarget(target)
-	}
 	result := p.newResult()
 	req := p.httpRequestForTarget(target, nil)
 

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -98,6 +98,7 @@ func (p *Probe) httpRequestForTarget(target endpoint.Endpoint, resolveF resolveF
 	}
 
 	urlHost := urlHostForTarget(target)
+	ipForLabel := ""
 
 	if p.c.GetResolveFirst() {
 		if resolveF == nil {
@@ -109,7 +110,13 @@ func (p *Probe) httpRequestForTarget(target endpoint.Endpoint, resolveF resolveF
 			p.l.Error("target: ", target.Name, ", resolve error: ", err.Error())
 			return nil
 		}
-		urlHost = ip.String()
+
+		ipStr := ip.String()
+		urlHost, ipForLabel = ipStr, ipStr
+	}
+
+	for _, al := range p.opts.AdditionalLabels {
+		al.UpdateForTargetWithIP(target, ipForLabel)
 	}
 
 	// Put square brackets around literal IPv6 hosts. This is the same logic as

--- a/probes/proto/config.proto
+++ b/probes/proto/config.proto
@@ -143,6 +143,7 @@ message ProbeDef {
   //     key: "app"
   //     value: "@target.label.app@"
   //   }
+  // (See a more detailed example at: examples/additional_label/cloudprober.cfg)
   repeated AdditionalLabel additional_label = 14;
 
   oneof probe {


### PR DESCRIPTION
Tested this change with the following config:

```
probe {
  type: HTTP
  name: "http_test"

  targets {
    host_names: "localhost:3141,www.google.com:80"
  }

  additional_label {
    key: "server-addr"
    value: "@target.ip@:@target.port@"
  }

  http_probe {
    resolve_first: true
  }
}

server {
  type: HTTP
}
```

and got results like this:

```
cloudprober 1644744713276298452 1644744769 labels=ptype=http,probe=http_test,dst=www.google.com,server-addr=172.217.1.228:80 total=28 success=28 latency=2383530.500 timeouts=0 resp-code=map:code,200:28
cloudprober 1644744713276298453 1644744773 labels=ptype=http,probe=http_test,dst=localhost,server-addr=127.0.0.1:3141 total=30 success=30 latency=26085.200 timeouts=0 resp-code=map:code,200:30
```
^ Note the IP in the server-addr label.