### PR TITLE
Consider probe's port for the additional label.

### DIFF
--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -116,7 +116,7 @@ func (p *Probe) httpRequestForTarget(target endpoint.Endpoint, resolveF resolveF
 	}
 
 	for _, al := range p.opts.AdditionalLabels {
-		al.UpdateForTargetWithIP(target, ipForLabel)
+		al.UpdateForTargetWithIPPort(target, ipForLabel, port)
 	}
 
 	// Put square brackets around literal IPv6 hosts. This is the same logic as

--- a/probes/options/labels.go
+++ b/probes/options/labels.go
@@ -66,7 +66,7 @@ type AdditionalLabel struct {
 }
 
 // UpdateForTarget updates addtional label based on target's name and labels.
-func (al *AdditionalLabel) UpdateForTargetWithIP(ep endpoint.Endpoint, ipAddr string) {
+func (al *AdditionalLabel) UpdateForTargetWithIPPort(ep endpoint.Endpoint, ipAddr string, probePort int) {
 	al.mu.Lock()
 	defer al.mu.Unlock()
 
@@ -79,13 +79,17 @@ func (al *AdditionalLabel) UpdateForTargetWithIP(ep endpoint.Endpoint, ipAddr st
 		al.valueForTarget = make(map[string]string)
 	}
 
+	if probePort == 0 {
+		probePort = ep.Port
+	}
+
 	parts := append([]string{}, al.valueParts...)
 	for i, tok := range al.tokens {
 		switch tok.tokenType {
 		case name:
 			parts[2*i+1] = ep.Name
 		case port:
-			parts[2*i+1] = strconv.Itoa(ep.Port)
+			parts[2*i+1] = strconv.Itoa(probePort)
 		case ip:
 			parts[2*i+1] = ipAddr
 		case label:
@@ -97,7 +101,7 @@ func (al *AdditionalLabel) UpdateForTargetWithIP(ep endpoint.Endpoint, ipAddr st
 
 // UpdateForTarget updates addtional label based on target's name and labels.
 func (al *AdditionalLabel) UpdateForTarget(ep endpoint.Endpoint) {
-	al.UpdateForTargetWithIP(ep, "")
+	al.UpdateForTargetWithIPPort(ep, "", 0)
 }
 
 // KeyValueForTarget returns key, value pair for the given target.

--- a/probes/options/labels_test.go
+++ b/probes/options/labels_test.go
@@ -18,9 +18,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	configpb "github.com/cloudprober/cloudprober/probes/proto"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
+	"github.com/golang/protobuf/proto"
 )
 
 var configWithAdditionalLabels = &configpb.ProbeDef{
@@ -44,6 +44,10 @@ var configWithAdditionalLabels = &configpb.ProbeDef{
 		{
 			Key:   proto.String("dst"),
 			Value: proto.String("@target.label.zone@:@target.name@:@target.port@"),
+		},
+		{
+			Key:   proto.String("dst_ip_port"),
+			Value: proto.String("@target.ip@:@target.port@"),
 		},
 		{
 			Key:   proto.String("bad_label"),
@@ -113,6 +117,7 @@ func TestUpdateAdditionalLabel(t *testing.T) {
 	for _, al := range aLabels {
 		al.UpdateForTarget(endpoint.Endpoint{Name: "target1", Labels: map[string]string{}, Port: 80})
 		al.UpdateForTarget(endpoint.Endpoint{Name: "target2", Labels: map[string]string{"zone": "zoneB"}, Port: 8080})
+		al.UpdateForTargetWithIPPort(endpoint.Endpoint{Name: "target3", Port: 8080}, "target3-ip", 9000)
 	}
 
 	expectedLabels := map[string][][2]string{
@@ -122,6 +127,7 @@ func TestUpdateAdditionalLabel(t *testing.T) {
 			{"dst_zone_label", "zone:"},
 			{"dst_name", "target1"},
 			{"dst", ":target1:80"},
+			{"dst_ip_port", ":80"},
 			{"bad_label", "@target.metadata@:@unknown@"},
 			{"incomplete_label", ":@target.name"},
 		},
@@ -131,8 +137,19 @@ func TestUpdateAdditionalLabel(t *testing.T) {
 			{"dst_zone_label", "zone:zoneB"},
 			{"dst_name", "target2"},
 			{"dst", "zoneB:target2:8080"},
+			{"dst_ip_port", ":8080"},
 			{"bad_label", "@target.metadata@:@unknown@"},
 			{"incomplete_label", "zoneB:@target.name"},
+		},
+		"target3": {
+			{"src_zone", "zoneA"},
+			{"dst_zone", ""},
+			{"dst_zone_label", "zone:"},
+			{"dst_name", "target3"},
+			{"dst", ":target3:9000"},
+			{"dst_ip_port", "target3-ip:9000"},
+			{"bad_label", "@target.metadata@:@unknown@"},
+			{"incomplete_label", ":@target.name"},
 		},
 	}
 

--- a/probes/options/labels_test.go
+++ b/probes/options/labels_test.go
@@ -88,6 +88,10 @@ func TestParseAdditionalLabel(t *testing.T) {
 			tokens:     []targetToken{{tokenType: label, labelKey: "zone"}, {tokenType: name}, {tokenType: port}},
 		},
 		{
+			Key:        "dst_ip_port",
+			valueParts: []string{"", "target.ip", ":", "target.port", ""},
+			tokens:     []targetToken{{tokenType: ip}, {tokenType: port}}},
+		{
 			Key:         "bad_label",
 			staticValue: "@target.metadata@:@unknown@",
 			valueParts:  []string{"", "target.metadata", ":", "unknown", ""},

--- a/probes/ping/ping.go
+++ b/probes/ping/ping.go
@@ -207,7 +207,7 @@ func (p *Probe) updateTargets() {
 		}
 
 		for _, al := range p.opts.AdditionalLabels {
-			al.UpdateForTargetWithIP(target, ip.String())
+			al.UpdateForTargetWithIPPort(target, ip.String(), 0)
 		}
 
 		var a net.Addr


### PR DESCRIPTION
This change enhances the logic of the additional label: `@target.port@`.  So far, we've been using only the port available in the target's specification. After this change, we'll use probe's port if available.