### PR TITLE
Fix the bug in OAuth handling.

### DIFF
--- a/common/oauth/bearer.go
+++ b/common/oauth/bearer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudprober/cloudprober/logger"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"google.golang.org/protobuf/proto"
 )
 
 type bearerTokenSource struct {
@@ -133,4 +134,18 @@ func (ts *bearerTokenSource) Token() (*oauth2.Token, error) {
 	}
 
 	return &oauth2.Token{AccessToken: ts.cache}, nil
+}
+
+// FileTokenSource returns a TokenSource that simply reads the token from a
+// given file. This is primarily for testing.
+func FileTokenSource(f string, l *logger.Logger) oauth2.TokenSource {
+	return &bearerTokenSource{
+		c: &configpb.BearerToken{
+			Source: &configpb.BearerToken_File{
+				File: f,
+			},
+			RefreshIntervalSec: proto.Float32(0),
+		},
+		getTokenFromBackend: getTokenFromFile,
+	}
 }

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -176,8 +176,9 @@ func (p *Probe) httpRequestForTarget(target endpoint.Endpoint, resolveF resolveF
 		tok, err := p.bearerToken()
 		if err != nil {
 			p.l.Error(err.Error())
+		} else {
+			req.Header.Set("Authorization", "Bearer "+tok)
 		}
-		req.Header.Set("Authorization", "Bearer "+tok)
 	}
 
 	return req


### PR DESCRIPTION
* Fix a bug where we were not really refreshing bearer token in HTTP request (#93).

* Stop storing OAuth bearer token in probe's state, and stop updating it in the target refresh loop. This may create concurrency issues.

* Instead of the above,  get a new token while creating the HTTP request. Note that most OAuth token sources already implement caching so it should be okay.