### PR TITLE
Fix a bug in OAuth handling.

### DIFF
--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -152,9 +152,5 @@ func (p *Probe) httpRequestForTarget(target endpoint.Endpoint, resolveF resolveF
 	// on various conditions.
 	req.Host = hostHeaderForTarget(target, probeHostHeader, port)
 
-	if p.bearerToken != "" {
-		req.Header.Set("Authorization", "Bearer "+p.bearerToken)
-	}
-
 	return req
 }


### PR DESCRIPTION
* Fix a bug where we were not really refreshing bearer token in HTTP request (#93).

* Stop storing OAuth bearer token in probe's state, and stop updating it in the target refresh loop. This may create concurrency issues.

* Instead of the above, get a new token before making the HTTP request. Note that most OAuth token sources already implement caching so it should be okay.