### PR TITLE
[probestatus] Make dashboard durations flexible.

### DIFF
--- a/surfacers/probestatus/dashboard.go
+++ b/surfacers/probestatus/dashboard.go
@@ -1,0 +1,60 @@
+// Copyright 2022 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package probestatus
+
+import (
+	"strings"
+	"time"
+)
+
+var baseDurations = []time.Duration{
+	05 * time.Minute, 30 * time.Minute, 60 * time.Minute,
+	06 * time.Hour, 12 * time.Hour, 24 * time.Hour,
+	72 * time.Hour, 168 * time.Hour, 720 * time.Hour,
+}
+
+var hourToDayMapping = map[string]string{
+	"72h":  "3d",
+	"168h": "7d",
+	"720h": "30d",
+}
+
+func dashboardDurations(maxDuration time.Duration) []time.Duration {
+	var result []time.Duration
+	for _, td := range baseDurations {
+		if td <= maxDuration {
+			result = append(result, td)
+		}
+	}
+	return result
+}
+
+func shortDur(durations []time.Duration) []string {
+	var result []string
+	for _, td := range durations {
+		s := td.String()
+		if strings.HasSuffix(s, "m0s") {
+			s = s[:len(s)-2]
+		}
+		if strings.HasSuffix(s, "h0m") {
+			s = s[:len(s)-2]
+		}
+		if d, ok := hourToDayMapping[s]; ok {
+			s = d
+		}
+		result = append(result, s)
+	}
+	return result
+}

--- a/surfacers/probestatus/dashboard_test.go
+++ b/surfacers/probestatus/dashboard_test.go
@@ -1,0 +1,58 @@
+// Copyright 2022 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package probestatus
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestDashboardDurations(t *testing.T) {
+	testData := map[time.Duration][]time.Duration{
+		24 * time.Hour:  baseDurations[:6],
+		72 * time.Hour:  baseDurations[:7],
+		168 * time.Hour: baseDurations[:8],
+		720 * time.Hour: baseDurations,
+	}
+
+	for maxD, wantDurations := range testData {
+		t.Run(maxD.String(), func(t *testing.T) {
+			durations := dashboardDurations(maxD)
+			if !reflect.DeepEqual(durations, wantDurations) {
+				t.Errorf("Got durations=%v, wanted=%v", durations, wantDurations)
+			}
+		})
+	}
+}
+
+func TestShortDur(t *testing.T) {
+	testData := map[time.Duration]string{
+		30 * time.Minute: "30m",
+		24 * time.Hour:   "24h",
+		72 * time.Hour:   "3d",
+		168 * time.Hour:  "7d",
+		720 * time.Hour:  "30d",
+	}
+
+	for td, want := range testData {
+		t.Run(td.String(), func(t *testing.T) {
+			got := shortDur([]time.Duration{td})[0]
+			if got != want {
+				t.Errorf("Got string=%s, wanted=%s", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
= Select durations based on timeseries size and resolution.
= Improve formatting (use 3d instead of 72h).
= Add more tests.