### PR TITLE
[startup] Improve Cloudprober startup time.

### DIFF
--- a/sysvars/sysvars.go
+++ b/sysvars/sysvars.go
@@ -113,7 +113,8 @@ func initCloudMetadata(fv string) error {
 				return err
 			}
 		case cloudProviders.ec2:
-			onEC2, err := ec2Vars(sysVars, l)
+			tryHard := fv == cloudProviders.ec2
+			onEC2, err := ec2Vars(sysVars, tryHard, l)
 			// Once we know it's EC2, don't continue checking.
 			if onEC2 {
 				return err

--- a/sysvars/sysvars_test.go
+++ b/sysvars/sysvars_test.go
@@ -107,7 +107,7 @@ func TestInitCloudMetadata(t *testing.T) {
 			gceVars = func(vars map[string]string, l *logger.Logger) (bool, error) {
 				return testSetVars(vars, testGCEVars, test.onGCE)
 			}
-			ec2Vars = func(vars map[string]string, l *logger.Logger) (bool, error) {
+			ec2Vars = func(vars map[string]string, tryHard bool, l *logger.Logger) (bool, error) {
 				return testSetVars(vars, testEC2Vars, test.onEC2)
 			}
 


### PR DESCRIPTION
* Don't wait too long for EC2 metadata if we are not explicitly looking for EC2 metadata (--cloud_metadata=ec2 is not set).
* This improves the startup speed on non-EC2 machines by up to 6s.