### PR TITLE
add a simple certificate expiry metric

### DIFF
--- a/docs/content/concepts/probe.md
+++ b/docs/content/concepts/probe.md
@@ -18,8 +18,8 @@ A probe is defined as a set of the following fields:
 `interval_msec` | How often to run the probe (in milliseconds).
 `timeout_msec`  | Probe timeout (in milliseconds).
 `targets`       | Targets to run probe against.
-`validator`     | Probe validators, further explained [here](/how-to/validators). 
-`<type>_probe`  | Probe type specific configuration. 
+`validator`     | Probe validators, further explained [here](/how-to/validators).
+`<type>_probe`  | Probe type specific configuration.
 
 Please take a look at the [ProbeDef protobuf](https://github.com/cloudprober/cloudprober/blob/master/probes/proto/config.proto) for further details on various fields and options. All probe types export following metrics at a minimum:
 
@@ -28,7 +28,6 @@ Please take a look at the [ProbeDef protobuf](https://github.com/cloudprober/clo
 |`total`   | Total number of probes. |
 |`success` | Number of successful probes. Deficit between _total_ and _success_ indicates failures.|
 |`latency` | Cumulative probe latency (by default in microseconds). Latency can also be configured to be a [distribution](/how-to/percentiles/) (histogram) metric through a config option (`latency_distribution`). By default it's just the sum of the latencies observed so far. Average latency can be computed using _rate(latency) / rate(success)_.|
-
 
 ## Probe Types
 
@@ -67,6 +66,11 @@ response is received. Apart from the core probe metrics (total, success, and
 latency), HTTP probes also export a map of response code counts. Requests are
 marked as failed if there is a timeout.
 
+* __SSL Certificate Expiry__:
+   If the target serves a SSL Certificate, cloudprober will walk the certificate chain and
+   export the earliest expiry time in seconds as a metric. The metric is named `ssl_earliest_cert_expiry_sec`,
+   and will only be exported when the expiry time in seconds is a positive number.
+
 ### UDP
 
 [`Code`](http://github.com/cloudprober/cloudprober/tree/master/probes/udp) | [`Config
@@ -98,7 +102,7 @@ data through the standard channel.
 
 External probe can be configured in two modes:
 
-*  __ONCE__:
+* __ONCE__:
    In this mode, an external program is executed for each probe run. Exit
    status of the program determines the success or failure of the probe.
    External probe can optionally be configured to interpret external program's
@@ -106,7 +110,7 @@ External probe can be configured in two modes:
    program to maintain state and multiple forks can be expensive depending on
    the frequency of the probes.
 
-*  __SERVER__:
+* __SERVER__:
    In this mode, external program is expected to run in server mode. Cloudprober
    automatically starts the external program if it's not running at the time of
    the probe execution. Cloudprober and external probe process communicate with

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -94,13 +94,13 @@ type Probe struct {
 }
 
 type probeResult struct {
-	total, success, timeouts int64
-	connEvent                int64
-	latency                  metrics.Value
-	respCodes                *metrics.Map
-	respBodies               *metrics.Map
-	validationFailure        *metrics.Map
-	sslExpirationSeconds     *int64
+	total, success, timeouts     int64
+	connEvent                    int64
+	latency                      metrics.Value
+	respCodes                    *metrics.Map
+	respBodies                   *metrics.Map
+	validationFailure            *metrics.Map
+	sslEarliestExpirationSeconds int64
 }
 
 func (p *Probe) oauthToken() (string, error) {
@@ -334,9 +334,17 @@ func (p *Probe) doHTTPRequest(req *http.Request, client *http.Client, targetName
 	resp.Body.Close()
 	result.respCodes.IncKey(strconv.FormatInt(int64(resp.StatusCode), 10))
 
-	if resp.TLS != nil {
-		expiry := int64(resp.TLS.PeerCertificates[0].NotAfter.Sub(time.Now()).Seconds())
-		result.sslExpirationSeconds = &expiry
+	if resp.TLS != nil && len(resp.TLS.PeerCertificates) > 0 {
+		now := time.Now()
+		minExpirySeconds := resp.TLS.PeerCertificates[0].NotAfter.Sub(now).Seconds()
+
+		for i := 1; i < len(resp.TLS.PeerCertificates); i++ {
+			if resp.TLS.PeerCertificates[i].NotAfter.Sub(now).Seconds() < minExpirySeconds {
+				minExpirySeconds = resp.TLS.PeerCertificates[i].NotAfter.Sub(now).Seconds()
+			}
+		}
+
+		result.sslEarliestExpirationSeconds = int64(minExpirySeconds)
 	}
 
 	if p.opts.Validators != nil {
@@ -387,7 +395,8 @@ func (p *Probe) runProbe(ctx context.Context, target endpoint.Endpoint, req *htt
 
 func (p *Probe) newResult() *probeResult {
 	result := &probeResult{
-		respCodes: metrics.NewMap("code", metrics.NewInt(0)),
+		respCodes:                    metrics.NewMap("code", metrics.NewInt(0)),
+		sslEarliestExpirationSeconds: -1,
 	}
 
 	if p.opts.Validators != nil {
@@ -418,8 +427,8 @@ func (p *Probe) exportMetrics(ts time.Time, result *probeResult, targetName stri
 		AddLabel("probe", p.name).
 		AddLabel("dst", targetName)
 
-	if result.sslExpirationSeconds != nil {
-		em.AddMetric("ssl_expiration_seconds", metrics.NewInt(*result.sslExpirationSeconds))
+	if result.sslEarliestExpirationSeconds >= 0 {
+		em.AddMetric("ssl_earliest_cert_expiry_sec", metrics.NewInt(result.sslEarliestExpirationSeconds))
 	}
 
 	if result.respBodies != nil {


### PR DESCRIPTION
This PR adds a very simple pass at exposing the x509 peer certificate expiry in seconds as a metric, as defined in issue #119 

```
cloudprober 1653310360629045004 1653310377 labels=ptype=http,probe=google_homepage,dst=www.google.com total=4 success=4 latency=467677.880 timeouts=0 resp-code=map:code,200:4 ssl_expiration_seconds=5633226

cloudprober 1653310360629045008 1653310387 labels=ptype=http,probe=google_homepage,dst=www.google.com total=6 success=6 latency=704211.588 timeouts=0 resp-code=map:code,200:6 ssl_expiration_seconds=5633216
```