### PR TITLE
Set Content-Length header on outgoing requests

### DIFF
--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -139,6 +139,8 @@ func (p *Probe) httpRequestForTarget(target endpoint.Endpoint, resolveF resolveF
 		return nil
 	}
 
+	req.ContentLength = int64(len(p.requestBody))
+
 	var probeHostHeader string
 	for _, header := range p.c.GetHeaders() {
 		if header.GetName() == "Host" {


### PR DESCRIPTION
This avoids Transfer-Encoding: chunked, which the Go HTTP client
otherwise adds for us by default because it can't figure out the length
of the body.

Chunked transfer encoding is harder to handle on some servers, e.g.
wsgi+Django. It's also pretty unnecessary when we actually know the
exact length of the body in advance.