### PR TITLE
Implement context handling in serverutils

### DIFF
--- a/contrib/gcp/cmd/bigquery_probe.go
+++ b/contrib/gcp/cmd/bigquery_probe.go
@@ -65,7 +65,7 @@ func main() {
 	}
 
 	if *serverMode {
-		serverutils.Serve(func(request *serverpb.ProbeRequest, reply *serverpb.ProbeReply) {
+		serverutils.ServeContext(ctx, func(ctx context.Context, request *serverpb.ProbeRequest, reply *serverpb.ProbeReply) {
 
 			opts := parseProbeRequest(request)
 			if val, ok := opts["table"]; ok {
@@ -78,6 +78,7 @@ func main() {
 				reply.ErrorMessage = proto.String(err.Error())
 			}
 		})
+		return
 	}
 
 	payload, err := bigquery.Probe(ctx, runner, dstTable)


### PR DESCRIPTION
This gives us two useful behaviours: we can cancel the context and wait for all probes to exit before cleaning up global resources, and we can propagate the probe timeout into the probe function, so that it can be respected by libraries that we call. The bigquery contrib probe is updated to reflect this, so that the network calls it makes to bigquery will be abandoned when the probe timeout is hit.