### PR TITLE
Migrate ingresses from v1beta1 to v1 API

### DIFF
--- a/rds/kubernetes/ingresses.go
+++ b/rds/kubernetes/ingresses.go
@@ -22,11 +22,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/cloudprober/cloudprober/logger"
 	configpb "github.com/cloudprober/cloudprober/rds/kubernetes/proto"
 	pb "github.com/cloudprober/cloudprober/rds/proto"
 	"github.com/cloudprober/cloudprober/rds/server/filter"
+	"github.com/golang/protobuf/proto"
 )
 
 type ingressesLister struct {
@@ -41,11 +41,10 @@ type ingressesLister struct {
 }
 
 func ingressesURL(ns string) string {
-	// TODO(manugarg): Update version to v1 once it's more widely available.
 	if ns == "" {
-		return "apis/networking.k8s.io/v1beta1/ingresses"
+		return "apis/networking.k8s.io/v1/ingresses"
 	}
-	return fmt.Sprintf("apis/networking.k8s.io/v1beta1/namespaces/%s/ingresses", ns)
+	return fmt.Sprintf("apis/networking.k8s.io/v1/namespaces/%s/ingresses", ns)
 }
 
 func (lister *ingressesLister) listResources(req *pb.ListResourcesRequest) ([]*pb.Resource, error) {

--- a/rds/kubernetes/testdata/ingresses.json
+++ b/rds/kubernetes/testdata/ingresses.json
@@ -1,8 +1,8 @@
 {
   "kind": "IngressList",
-  "apiVersion": "networking.k8s.io/v1beta1",
+  "apiVersion": "networking.k8s.io/v1",
   "metadata": {
-    "selfLink": "/apis/networking.k8s.io/v1beta1/namespaces/default/ingresses",
+    "selfLink": "/apis/networking.k8s.io/v1/namespaces/default/ingresses",
     "resourceVersion": "23189581"
   },
   "items": [
@@ -10,7 +10,7 @@
       "metadata": {
         "name": "rds-ingress",
         "namespace": "default",
-        "selfLink": "/apis/networking.k8s.io/v1beta1/namespaces/default/ingresses/rds-ingress",
+        "selfLink": "/apis/networking.k8s.io/v1/namespaces/default/ingresses/rds-ingress",
         "uid": "edff7c95-cc29-4b39-a99d-b9f5435125f1",
         "resourceVersion": "23051471",
         "generation": 4,
@@ -20,7 +20,7 @@
           "ingress.kubernetes.io/forwarding-rule": "k8s-fw-default-rds-ingress--69e25e1d9eaff894",
           "ingress.kubernetes.io/target-proxy": "k8s-tp-default-rds-ingress--69e25e1d9eaff894",
           "ingress.kubernetes.io/url-map": "k8s-um-default-rds-ingress--69e25e1d9eaff894",
-          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"networking.k8s.io/v1beta1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{},\"name\":\"rds-ingress\",\"namespace\":\"default\"},\"spec\":{\"backend\":{\"serviceName\":\"cloudprober-rds\",\"servicePort\":9314},\"rules\":[{\"host\":\"foo.bar.com\",\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"cloudprober-rds\",\"servicePort\":9313},\"path\":\"/health\"},{\"backend\":{\"serviceName\":\"cloudprober-rds\",\"servicePort\":9314},\"path\":\"/rds\"}]}},{\"host\":\"prometheus.bar.com\",\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"cloudprober-rds\",\"servicePort\":9313},\"path\":\"/\"}]}}]}}\n"
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"networking.k8s.io/v1\",\"kind\":\"Ingress\",\"metadata\":{\"annotations\":{},\"name\":\"rds-ingress\",\"namespace\":\"default\"},\"spec\":{\"backend\":{\"serviceName\":\"cloudprober-rds\",\"servicePort\":9314},\"rules\":[{\"host\":\"foo.bar.com\",\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"cloudprober-rds\",\"servicePort\":9313},\"path\":\"/health\"},{\"backend\":{\"serviceName\":\"cloudprober-rds\",\"servicePort\":9314},\"path\":\"/rds\"}]}},{\"host\":\"prometheus.bar.com\",\"http\":{\"paths\":[{\"backend\":{\"serviceName\":\"cloudprober-rds\",\"servicePort\":9313},\"path\":\"/\"}]}}]}}\n"
         },
         "finalizers": [
           "networking.gke.io/ingress-finalizer"


### PR DESCRIPTION
Hello all, as you know networking.k8s.io/v1beta1 API version of Ingress is no longer served as of v1.22 k8s version. Therefore Cloudprober fails to list the available ingress targets. 

```
client.go:72] [cloudprober.rds-server] kubernetes.client: getting URL: https://100.64.0.1:443/apis/networking.k8s.io/v1beta1/ingresses
ingresses.go:196] [cloudprober.rds-server] ingressesLister.expand(): error while getting ingresses list from API: HTTP response status code: 404, status: 404 Not Found
```

Can we please merge this change and cut a release to fix the issue. We are not able to use Cloudprober after our upgrade to v1.22.