### PR TITLE
Fix keep alive for HTTP probes.

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -488,6 +488,7 @@ func (p *Probe) startForTarget(ctx context.Context, target endpoint.Endpoint, da
 	ticker := time.NewTicker(p.opts.Interval)
 	defer ticker.Stop()
 
+	clients := p.clientsForTarget(target)
 	for ts := time.Now(); true; ts = <-ticker.C {
 		// Don't run another probe if context is canceled already.
 		if ctxDone(ctx) {
@@ -498,7 +499,7 @@ func (p *Probe) startForTarget(ctx context.Context, target endpoint.Endpoint, da
 		// was an invalid target), skip this probe cycle. Note that request
 		// creation gets retried at a regular interval (stats export interval).
 		if req != nil {
-			p.runProbe(ctx, target, p.clientsForTarget(target), req, result)
+			p.runProbe(ctx, target, clients, req, result)
 		}
 
 		// Export stats if it's the time to do so.

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -124,7 +124,7 @@ func (p *Probe) getTransport() (*http.Transport, error) {
 		}
 	}
 	transport.DialContext = dialer.DialContext
-	transport.MaxIdleConns = 256
+	transport.MaxIdleConns = int(p.c.GetMaxIdleConns())
 	transport.TLSHandshakeTimeout = p.opts.Timeout
 
 	if p.c.GetProxyUrl() != "" {

--- a/probes/http/proto/config.proto
+++ b/probes/http/proto/config.proto
@@ -7,7 +7,7 @@ import "github.com/cloudprober/cloudprober/common/tlsconfig/proto/config.proto";
 
 option go_package = "github.com/cloudprober/cloudprober/probes/http/proto";
 
-// Next tag: 17
+// Next tag: 18
 message ProbeConf {
   enum ProtocolType {
     HTTP = 0;
@@ -86,6 +86,9 @@ message ProbeConf {
 
   // Proxy URL, e.g. http://myproxy:3128
   optional string proxy_url = 16;
+
+  // Maximum idle connections to keep alive
+  optional int32 max_idle_conns = 17 [default = 256];
 
   // Interval between targets.
   optional int32 interval_between_targets_msec = 97 [default = 10];


### PR DESCRIPTION
One commit to move the call to clientsForTarget so new clients aren't created every probing interval, and another to make the MaxIdleConns a configurable option so that keep alive works with more than 256 targets.