### PR TITLE
Added custom labels option for cloud log entries

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -150,15 +150,14 @@ func NewCloudproberLog(component string) (*Logger, error) {
 func New(ctx context.Context, logName string, opts ...Option) (*Logger, error) {
 	l := &Logger{
 		name:                logName,
+		labels:              make(map[string]string),
 		debugLog:            enableDebugLog(*debugLog, *debugLogList, logName),
 		disableCloudLogging: *disableCloudLogging,
 	}
 	for _, opt := range opts {
 		opt(l)
 	}
-	if l.labels == nil {
-		l.labels = make(map[string]string)
-	}
+
 	if !metadata.OnGCE() || l.disableCloudLogging {
 		return l, nil
 	}
@@ -170,7 +169,8 @@ func New(ctx context.Context, logName string, opts ...Option) (*Logger, error) {
 	return l, nil
 }
 
-// WithLabels function can be used to set any parameter in Logger struct.
+// WithLabels option can be used to add a set of labels to all logs, e.g.
+// logger.New(ctx, logName, logger.WithLabels(myLabels))
 func WithLabels(labels map[string]string) Option {
 	return func(l *Logger) {
 		l.labels = labels


### PR DESCRIPTION
Added a custom label option in cloudprober's logger.go file for having custom labels in cloud logger entries. Currently we are logging all error message and details in cloud logger and these logs are needed for better debugging experience. And there is no way to get any particular log, so, a probe_id is generated and we need this probe_id in the labels of log entry, so, that we can search any particular log. 

Screenshot of cloud logger after using label option is attached.
![cloud logger label](https://user-images.githubusercontent.com/83967398/214331329-f8d682f5-62ac-40e2-98c9-d9696a27b83f.png)