### PR TITLE
[probes.http] Really fix the nil config problem (#219)

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -176,10 +176,6 @@ func (p *Probe) getTransport() (*http.Transport, error) {
 
 // Init initializes the probe with the given params.
 func (p *Probe) Init(name string, opts *options.Options) error {
-	if opts.ProbeConf == nil {
-		opts.ProbeConf = &configpb.ProbeConf{}
-	}
-
 	c, ok := opts.ProbeConf.(*configpb.ProbeConf)
 	if !ok {
 		return fmt.Errorf("not http config")
@@ -190,6 +186,9 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 		p.l = &logger.Logger{}
 	}
 	p.c = c
+	if p.c == nil {
+		p.c = &configpb.ProbeConf{}
+	}
 
 	totalDuration := time.Duration(p.c.GetRequestsIntervalMsec()*p.c.GetRequestsPerProbe())*time.Millisecond + p.opts.Timeout
 	if totalDuration > p.opts.Interval {


### PR DESCRIPTION
There is a difference between nil interface and interface pointing to a nil value. My earlier fix in #223 was checking for interface being nil (that condition was never met), while we had to check for interface pointing to a nil value.