### PR TITLE
[surfacers.stackdriver] Use random task ID for Google Cloud Run.

### DIFF
--- a/common/metadata/metadata.go
+++ b/common/metadata/metadata.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Cloudprober Authors.
+// Copyright 2021-2023 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,9 +18,18 @@ Package metadata implements metadata related utilities.
 package metadata
 
 import (
-	"io/ioutil"
+	"math/rand"
 	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
 )
+
+var uniqueID = struct {
+	id string
+	mu sync.Mutex
+}{}
 
 // IsKubernetes return true if running on Kubernetes.
 // It uses the environment variable KUBERNETES_SERVICE_HOST to decide if we
@@ -32,7 +41,7 @@ func IsKubernetes() bool {
 // KubernetesNamespace returns the Kubernetes namespace. It returns an empty
 // string if there is an error in retrieving the namespace.
 func KubernetesNamespace() string {
-	namespaceBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	namespaceBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err == nil {
 		return string(namespaceBytes)
 	}
@@ -47,4 +56,27 @@ func IsCloudRunJob() bool {
 // IsCloudRunService return true if we are running as a CloudRun service.
 func IsCloudRunService() bool {
 	return os.Getenv("K_SERVICE") != ""
+}
+
+func UniqueID() string {
+	uniqueID.mu.Lock()
+	defer uniqueID.mu.Unlock()
+
+	if uniqueID.id != "" {
+		return uniqueID.id
+	}
+
+	t := time.Now()
+
+	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	var randomStrLen = 6
+	rand.Seed(t.UnixNano())
+
+	b := make([]rune, randomStrLen)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+
+	uniqueID.id = "cloudprober-" + strings.ToLower(string(b)) + "-" + strconv.Itoa(int(t.Unix()%10000))
+	return uniqueID.id
 }

--- a/common/metadata/metadata_test.go
+++ b/common/metadata/metadata_test.go
@@ -1,0 +1,50 @@
+// Copyright 2023 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package metadata implements metadata related utilities.
+*/
+package metadata
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUniqueID(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{name: "firstRun"},
+		{name: "fromCache"},
+	}
+
+	re := regexp.MustCompile("cloudprober-[a-z]{6}-[0-9]{4}")
+	var last string
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := UniqueID()
+			if last != "" {
+				assert.Equal(t, last, got, "Unique id not same as last time")
+				return
+			}
+
+			assert.True(t, re.MatchString(got), "Unique id doesn't match the regex")
+
+			last = got
+		})
+	}
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -108,9 +108,9 @@ func enableDebugLog(debugLog bool, debugLogRe string, logName string) bool {
 //
 // It falls back to logging through the traditional logger if:
 //
-//   * Not running on GCE,
-//   * Logging client is uninitialized (e.g. for testing),
-//   * Logging to cloud fails for some reason.
+//   - Not running on GCE,
+//   - Logging client is uninitialized (e.g. for testing),
+//   - Logging to cloud fails for some reason.
 //
 // Logger{} is a valid object that will log through the traditional logger.
 //
@@ -212,7 +212,7 @@ func (l *Logger) EnableStackdriverLogging(ctx context.Context) error {
 	}
 
 	// Add instance_name to common labels if available.
-	if !md.IsKubernetes() {
+	if !md.IsKubernetes() && !md.IsCloudRunJob() && !md.IsCloudRunService() {
 		instanceName, err := metadata.InstanceName()
 		if err != nil {
 			l.Infof("Error getting instance name on GCE: %v", err)

--- a/surfacers/stackdriver/resource.go
+++ b/surfacers/stackdriver/resource.go
@@ -66,7 +66,7 @@ func cloudRunResource(projectID, job, taskID string, l *logger.Logger) *monitori
 			"project_id": projectID,
 			"location":   location,
 			"job":        job,
-			"task_id":    taskID,
+			"task_id":    md.UniqueID(),
 			"namespace":  "cloudprober",
 		},
 	}


### PR DESCRIPTION
See #257 for the background.

Cloud Run starts/restarts the container multiple with the same revision id. This creates a problem for the Stackdriver metrics (at least in the short term) as for the cumulative metrics, a point's startTime is tied to the Cloudprober start time and its endTime cannot be before the startTime. This condition is violated if there are multiple processes exporting data to the same resource.