### PR TITLE
[rds.k8s] Refresh in-cluster token every minute

### DIFF
--- a/common/oauth/bearer_test.go
+++ b/common/oauth/bearer_test.go
@@ -163,6 +163,10 @@ func TestNewBearerToken(t *testing.T) {
 			// Call counter should always increase during token source creation.
 			expectedC := callCounter() + 1
 			cts, err := newBearerTokenSource(testC, nil)
+			if err != nil {
+				t.Errorf("error while creating new token source: %v", err)
+				return
+			}
 
 			// verify token cache
 			tc := cts.(*bearerTokenSource).cache
@@ -171,7 +175,6 @@ func TestNewBearerToken(t *testing.T) {
 			}
 			assert.Equal(t, tc.ignoreExpiryIfZero, true)
 
-			assert.NoError(t, err, "error while creating new token source")
 			assert.Equal(t, expectedC, callCounter(), "unexpected call counter (1st call)")
 
 			// Get token again


### PR DESCRIPTION
* Kubernetes version [1.21.14](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume) introduced the option of expiring/rotating tokens.
* Kubernetes automatically refreshes the locally mounted token file. This PR configures RDS' k8s client to reload the token from the file on a regular basis (every minute).
* This is similar to what client-go library does (see: https://github.com/cloudprober/cloudprober/issues/283#issuecomment-1441114178). 