### PR TITLE
[probes.http] Don't overwrite server_name if set in tls_config

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -479,7 +479,9 @@ func (p *Probe) clientsForTarget(target endpoint.Endpoint) []*http.Client {
 				if t.TLSClientConfig == nil {
 					t.TLSClientConfig = &tls.Config{}
 				}
-				t.TLSClientConfig.ServerName = urlHostForTarget(target)
+				if t.TLSClientConfig.ServerName == "" {
+					t.TLSClientConfig.ServerName = urlHostForTarget(target)
+				}
 			}
 			clients[i] = &http.Client{Transport: t}
 		} else {


### PR DESCRIPTION
Fixes #294.