### PR TITLE
[probes.tcp] Fix a bug in TCP probe scheduler

### DIFF
--- a/probes/common/sched/sched.go
+++ b/probes/common/sched/sched.go
@@ -133,11 +133,11 @@ func (s *Scheduler) Wait() {
 	s.waitGroup.Wait()
 }
 
-// UpdateTargetsAndStartProbes refreshes targets and starts probe loop for
+// refreshTargets refreshes targets and starts probe loop for
 // new targets and cancels probe loops for targets that are no longer active.
 // Note that this function is not concurrency safe. It is never called
 // concurrently by Start().
-func (s *Scheduler) updateTargetsAndStartProbes(ctx context.Context) {
+func (s *Scheduler) refreshTargets(ctx context.Context) {
 	s.targets = s.Opts.Targets.ListEndpoints()
 
 	s.Opts.Logger.Debugf("Probe(%s) got %d targets", s.ProbeName, len(s.targets))
@@ -199,7 +199,7 @@ func (s *Scheduler) UpdateTargetsAndStartProbes(ctx context.Context) {
 	// Initialize scheduler.
 	s.init()
 
-	s.updateTargetsAndStartProbes(ctx)
+	s.refreshTargets(ctx)
 
 	// Do more frequent listing of targets until we get a non-zero list of
 	// targets.
@@ -216,7 +216,7 @@ func (s *Scheduler) UpdateTargetsAndStartProbes(ctx context.Context) {
 		if len(s.targets) != 0 {
 			break
 		}
-		s.UpdateTargetsAndStartProbes(ctx)
+		s.refreshTargets(ctx)
 		time.Sleep(initialRefreshInterval)
 	}
 
@@ -228,7 +228,7 @@ func (s *Scheduler) UpdateTargetsAndStartProbes(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-targetsUpdateTicker.C:
-			s.UpdateTargetsAndStartProbes(ctx)
+			s.refreshTargets(ctx)
 		}
 	}
 }

--- a/probes/common/sched/sched_test.go
+++ b/probes/common/sched/sched_test.go
@@ -87,7 +87,7 @@ func TestUpdateTargetsAndStartProbes(t *testing.T) {
 	s.init()
 
 	ctx, cancelF := context.WithCancel(context.Background())
-	s.updateTargetsAndStartProbes(ctx)
+	s.refreshTargets(ctx)
 	if len(s.cancelFuncs) != 2 {
 		t.Errorf("len(s.cancelFunc)=%d, want=2", len(s.cancelFuncs))
 	}
@@ -98,7 +98,7 @@ func TestUpdateTargetsAndStartProbes(t *testing.T) {
 	// Updates targets to just one target. This should cause one probe loop to
 	// exit. We should get only one data stream after that.
 	opts.Targets = targets.StaticTargets(testTargets[0])
-	s.updateTargetsAndStartProbes(ctx)
+	s.refreshTargets(ctx)
 	if len(s.cancelFuncs) != 1 {
 		t.Errorf("len(s.cancelFunc)=%d, want=1", len(s.cancelFuncs))
 	}


### PR DESCRIPTION
This is a relatively new probe, probably not being used by many yet. Overall probe works but it'll end up creating endless recursion I believe.