### PR TITLE
[debug] Add back debug pprof URLs.

### DIFF
--- a/cmd/cloudprober.go
+++ b/cmd/cloudprober.go
@@ -23,7 +23,6 @@ package main
 import (
 	"context"
 	"fmt"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"runtime/pprof"


### PR DESCRIPTION
* These URLs got removed when we moved to a custom http.ServerMux to implement the probe status UI.
* They can be disabled by setting the environment variable: CLOUDPROBER_DISABLE_HTTP_PPROF.