### PR TITLE
[labels] Fix a bug in additional labels processing.

### DIFF
--- a/probes/common/sched/sched.go
+++ b/probes/common/sched/sched.go
@@ -120,7 +120,7 @@ func (s *Scheduler) startForTarget(ctx context.Context, target endpoint.Endpoint
 			em.LatencyUnit = s.Opts.LatencyUnit
 
 			for _, al := range s.Opts.AdditionalLabels {
-				em.AddLabel(al.KeyValueForTarget(target.Name))
+				em.AddLabel(al.KeyValueForTarget(target))
 			}
 
 			s.Opts.LogMetrics(em)

--- a/probes/common/statskeeper/statskeeper.go
+++ b/probes/common/statskeeper/statskeeper.go
@@ -87,7 +87,7 @@ func StatsKeeper(ctx context.Context, ptype, name string, opts *options.Options,
 					em.LatencyUnit = opts.LatencyUnit
 
 					for _, al := range opts.AdditionalLabels {
-						em.AddLabel(al.KeyValueForTarget(t.Name))
+						em.AddLabel(al.KeyValueForTarget(t))
 					}
 
 					if opts.LogMetrics != nil {

--- a/probes/dns/dns.go
+++ b/probes/dns/dns.go
@@ -244,7 +244,7 @@ func (p *Probe) runProbe(resultsChan chan<- statskeeper.ProbeResult) {
 			}
 
 			for _, al := range p.opts.AdditionalLabels {
-				al.UpdateForTargetWithIPPort(target, ipLabel, port)
+				al.UpdateForTarget(target, ipLabel, port)
 			}
 
 			// Generate a new question for each probe so transaction IDs aren't repeated.

--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -333,7 +333,7 @@ func (p *Probe) readProbeReplies(done chan struct{}) error {
 
 func (p *Probe) withAdditionalLabels(em *metrics.EventMetrics, target string) *metrics.EventMetrics {
 	for _, al := range p.opts.AdditionalLabels {
-		em.AddLabel(al.KeyValueForTarget(target))
+		em.AddLabel(al.KeyValueForTarget(endpoint.Endpoint{Name: target}))
 	}
 	return em
 }
@@ -609,7 +609,10 @@ func (p *Probe) updateTargets() {
 		}
 
 		for _, al := range p.opts.AdditionalLabels {
-			al.UpdateForTarget(target)
+			// Note it's a bit convoluted right now because we want to use the
+			// same key while updating additional labels that we use while
+			// retrieving additional labels in withAdditionalLabels.
+			al.UpdateForTarget(endpoint.Endpoint{Name: target.Name}, "", 0)
 		}
 	}
 }

--- a/probes/grpc/grpc.go
+++ b/probes/grpc/grpc.go
@@ -295,6 +295,10 @@ func (p *Probe) healthCheckProbe(ctx context.Context, conn *grpc.ClientConn, msg
 func (p *Probe) oneTargetLoop(ctx context.Context, tgt string, index int, result *probeRunResult) {
 	msgPattern := fmt.Sprintf("%s,%s%s,%03d", p.src, p.c.GetUriScheme(), tgt, index)
 
+	for _, al := range p.opts.AdditionalLabels {
+		al.UpdateForTarget(endpoint.Endpoint{Name: tgt}, "", 0)
+	}
+
 	conn := p.connectWithRetry(ctx, tgt, msgPattern, result)
 	if conn == nil {
 		return
@@ -432,7 +436,7 @@ func (p *Probe) Start(ctx context.Context, dataChan chan *metrics.EventMetrics) 
 			result.Unlock()
 			em.LatencyUnit = p.opts.LatencyUnit
 			for _, al := range p.opts.AdditionalLabels {
-				em.AddLabel(al.KeyValueForTarget(targetName))
+				em.AddLabel(al.KeyValueForTarget(endpoint.Endpoint{Name: targetName}))
 			}
 			p.opts.LogMetrics(em)
 			dataChan <- em

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -418,11 +418,11 @@ func (p *Probe) newResult() *probeResult {
 	return result
 }
 
-func (p *Probe) exportMetrics(ts time.Time, result *probeResult, targetName string, dataChan chan *metrics.EventMetrics) {
+func (p *Probe) exportMetrics(ts time.Time, result *probeResult, target endpoint.Endpoint, dataChan chan *metrics.EventMetrics) {
 	addLabelsAndPublish := func(em *metrics.EventMetrics) {
-		em.AddLabel("ptype", "http").AddLabel("probe", p.name).AddLabel("dst", targetName)
+		em.AddLabel("ptype", "http").AddLabel("probe", p.name).AddLabel("dst", target.Name)
 		for _, al := range p.opts.AdditionalLabels {
-			em.AddLabel(al.KeyValueForTarget(targetName))
+			em.AddLabel(al.KeyValueForTarget(target))
 		}
 		p.opts.LogMetrics(em)
 		dataChan <- em
@@ -521,7 +521,7 @@ func (p *Probe) startForTarget(ctx context.Context, target endpoint.Endpoint, da
 		// Export stats if it's the time to do so.
 		runCnt++
 		if (runCnt % p.statsExportFrequency) == 0 {
-			p.exportMetrics(ts, result, target.Name, dataChan)
+			p.exportMetrics(ts, result, target, dataChan)
 
 			// If we are resolving first, this is also a good time to recreate HTTP
 			// request in case target's IP has changed.

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -112,7 +112,7 @@ func (p *Probe) httpRequestForTarget(target endpoint.Endpoint) *http.Request {
 	}
 
 	for _, al := range p.opts.AdditionalLabels {
-		al.UpdateForTargetWithIPPort(target, ipForLabel, port)
+		al.UpdateForTarget(target, ipForLabel, port)
 	}
 
 	// Put square brackets around literal IPv6 hosts. This is the same logic as

--- a/probes/options/labels.go
+++ b/probes/options/labels.go
@@ -66,7 +66,7 @@ type AdditionalLabel struct {
 }
 
 // UpdateForTarget updates addtional label based on target's name and labels.
-func (al *AdditionalLabel) UpdateForTargetWithIPPort(ep endpoint.Endpoint, ipAddr string, probePort int) {
+func (al *AdditionalLabel) UpdateForTarget(ep endpoint.Endpoint, ipAddr string, probePort int) {
 	al.mu.Lock()
 	defer al.mu.Unlock()
 
@@ -96,23 +96,18 @@ func (al *AdditionalLabel) UpdateForTargetWithIPPort(ep endpoint.Endpoint, ipAdd
 			parts[2*i+1] = ep.Labels[tok.labelKey]
 		}
 	}
-	al.valueForTarget[ep.Name] = strings.Join(parts, "")
-}
-
-// UpdateForTarget updates addtional label based on target's name and labels.
-func (al *AdditionalLabel) UpdateForTarget(ep endpoint.Endpoint) {
-	al.UpdateForTargetWithIPPort(ep, "", 0)
+	al.valueForTarget[ep.Key()] = strings.Join(parts, "")
 }
 
 // KeyValueForTarget returns key, value pair for the given target.
-func (al *AdditionalLabel) KeyValueForTarget(targetName string) (key, val string) {
+func (al *AdditionalLabel) KeyValueForTarget(ep endpoint.Endpoint) (key, val string) {
 	al.mu.RLock()
 	defer al.mu.RUnlock()
 
 	if al.staticValue != "" {
 		return al.Key, al.staticValue
 	}
-	return al.Key, al.valueForTarget[targetName]
+	return al.Key, al.valueForTarget[ep.Key()]
 }
 
 // ParseAdditionalLabel parses an additional label proto message into an

--- a/probes/options/labels_test.go
+++ b/probes/options/labels_test.go
@@ -116,12 +116,18 @@ func TestParseAdditionalLabel(t *testing.T) {
 func TestUpdateAdditionalLabel(t *testing.T) {
 	aLabels := parseAdditionalLabels(configWithAdditionalLabels)
 
+	endpoints := map[string]endpoint.Endpoint{
+		"target1": {Name: "target1", Labels: map[string]string{}, Port: 80},
+		"target2": {Name: "target2", Labels: map[string]string{"zone": "zoneB"}, Port: 8080},
+		"target3": {Name: "target3", Port: 8080},
+	}
+
 	// Verify that we got the correct additional lables and also update them while
 	// iterating over them.
 	for _, al := range aLabels {
-		al.UpdateForTarget(endpoint.Endpoint{Name: "target1", Labels: map[string]string{}, Port: 80})
-		al.UpdateForTarget(endpoint.Endpoint{Name: "target2", Labels: map[string]string{"zone": "zoneB"}, Port: 8080})
-		al.UpdateForTargetWithIPPort(endpoint.Endpoint{Name: "target3", Port: 8080}, "target3-ip", 9000)
+		al.UpdateForTarget(endpoints["target1"], "", 0)
+		al.UpdateForTarget(endpoints["target2"], "", 0)
+		al.UpdateForTarget(endpoints["target3"], "target3-ip", 9000)
 	}
 
 	expectedLabels := map[string][][2]string{
@@ -161,7 +167,7 @@ func TestUpdateAdditionalLabel(t *testing.T) {
 		var gotLabels [][2]string
 
 		for _, al := range aLabels {
-			k, v := al.KeyValueForTarget(target)
+			k, v := al.KeyValueForTarget(endpoints[target])
 			gotLabels = append(gotLabels, [2]string{k, v})
 		}
 

--- a/probes/ping/ping.go
+++ b/probes/ping/ping.go
@@ -231,7 +231,7 @@ func (p *Probe) updateTargets() {
 		}
 
 		for _, al := range p.opts.AdditionalLabels {
-			al.UpdateForTargetWithIPPort(target, ip.String(), 0)
+			al.UpdateForTarget(target, ip.String(), 0)
 		}
 
 		var a net.Addr
@@ -536,7 +536,7 @@ func (p *Probe) Start(ctx context.Context, dataChan chan *metrics.EventMetrics) 
 			em.LatencyUnit = p.opts.LatencyUnit
 
 			for _, al := range p.opts.AdditionalLabels {
-				em.AddLabel(al.KeyValueForTarget(target.Name))
+				em.AddLabel(al.KeyValueForTarget(target))
 			}
 
 			if p.opts.Validators != nil {

--- a/probes/tcp/tcp.go
+++ b/probes/tcp/tcp.go
@@ -147,7 +147,7 @@ func (p *Probe) runProbe(ctx context.Context, target endpoint.Endpoint, res sche
 	}
 
 	for _, al := range p.opts.AdditionalLabels {
-		al.UpdateForTargetWithIPPort(target, ipLabel, 0)
+		al.UpdateForTarget(target, ipLabel, 0)
 	}
 
 	port := int(p.c.GetPort())

--- a/probes/udp/udp.go
+++ b/probes/udp/udp.go
@@ -105,7 +105,7 @@ func (prr probeResult) eventMetrics(probeName string, opts *options.Options, f f
 		AddLabel("dst", f.target)
 
 	for _, al := range opts.AdditionalLabels {
-		m.AddLabel(al.KeyValueForTarget(f.target))
+		m.AddLabel(al.KeyValueForTarget(endpoint.Endpoint{Name: f.target}))
 	}
 
 	if c.GetExportMetricsByPort() {
@@ -425,7 +425,7 @@ func (p *Probe) runProbe() {
 		}
 
 		for _, al := range p.opts.AdditionalLabels {
-			al.UpdateForTargetWithIPPort(target, ip.String(), dstPort)
+			al.UpdateForTarget(endpoint.Endpoint{Name: target.Name}, ip.String(), dstPort)
 		}
 
 		for i := 0; i < packetsPerTarget; i++ {

--- a/probes/udplistener/udplistener.go
+++ b/probes/udplistener/udplistener.go
@@ -154,7 +154,7 @@ func (p *Probe) updateTargets() {
 
 	for _, target := range p.targets {
 		for _, al := range p.opts.AdditionalLabels {
-			al.UpdateForTarget(target)
+			al.UpdateForTarget(target, "", 0)
 		}
 	}
 }


### PR DESCRIPTION
This bug gets triggered if you're using additional_label with targets that have same name (but different labels or ports) within a probe, e.g. "host_names: www.google.com:80,www.google.com:443".

Additional labels will get mixed up if you've different targets with the same name because so far we were using only target names to maintain additional labels.

To fix this issue, use the same endpoint.Key() function while updating labels for the targets and retrieving them. In all the probes use a consistent argument for AdditionalLabel functions.

Also, add a wiki page about current status of additional labels (that I found while working this bug):
https://github.com/cloudprober/cloudprober/wiki/Additional-Labels-Rollout-Status