### PR TITLE
Output stderr from a command by default when running external probe with once mode

### DIFF
--- a/probes/external/external_test.go
+++ b/probes/external/external_test.go
@@ -342,11 +342,11 @@ func TestProbeOnceMode(t *testing.T) {
 	tgts := []string{"target1", "target2"}
 
 	// Set runCommand to a function that runs successfully and returns a pyload.
-	p.runCommandFunc = func(ctx context.Context, cmd string, cmdArgs []string) ([]byte, error) {
+	p.runCommandFunc = func(ctx context.Context, cmd string, cmdArgs []string) ([]byte, []byte, error) {
 		var resp []string
 		resp = append(resp, fmt.Sprintf("cmd \"%s\"", cmd))
 		resp = append(resp, fmt.Sprintf("num-args %d", len(cmdArgs)))
-		return []byte(strings.Join(resp, "\n")), nil
+		return []byte(strings.Join(resp, "\n")), nil, nil
 	}
 
 	total, success := make(map[string]int64), make(map[string]int64)
@@ -359,8 +359,8 @@ func TestProbeOnceMode(t *testing.T) {
 	runAndVerifyProbe(t, p, tgts, total, success)
 
 	// Try with failing command now
-	p.runCommandFunc = func(ctx context.Context, cmd string, cmdArgs []string) ([]byte, error) {
-		return nil, fmt.Errorf("error executing %s", cmd)
+	p.runCommandFunc = func(ctx context.Context, cmd string, cmdArgs []string) ([]byte, []byte, error) {
+		return nil, nil, fmt.Errorf("error executing %s", cmd)
 	}
 
 	for _, tgt := range tgts {

--- a/probes/external/runcmd_linux.go
+++ b/probes/external/runcmd_linux.go
@@ -30,14 +30,14 @@ import (
 	"time"
 )
 
-func (p *Probe) runCommand(ctx context.Context, cmd string, args []string) ([]byte, error) {
+func (p *Probe) runCommand(ctx context.Context, cmd string, args []string) ([]byte, []byte, error) {
 	c := exec.Command(cmd, args...)
 	c.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	var stdout, stderr bytes.Buffer
 	c.Stdout, c.Stderr = &stdout, &stderr
 
 	if err := c.Start(); err != nil {
-		return stdout.Bytes(), err
+		return stdout.Bytes(), stderr.Bytes(), err
 	}
 
 	// This goroutine is similar to the one started by exec.Start if command is
@@ -73,9 +73,5 @@ func (p *Probe) runCommand(ctx context.Context, cmd string, args []string) ([]by
 		}
 	}()
 
-	if exitErr, ok := err.(*exec.ExitError); ok {
-		exitErr.Stderr = stderr.Bytes()
-	}
-
-	return stdout.Bytes(), err
+	return stdout.Bytes(), stderr.Bytes(), err
 }

--- a/probes/external/runcmd_nonlinux.go
+++ b/probes/external/runcmd_nonlinux.go
@@ -17,10 +17,15 @@
 package external
 
 import (
+	"bytes"
 	"context"
 	"os/exec"
 )
 
-func (p *Probe) runCommand(ctx context.Context, cmd string, args []string) ([]byte, error) {
-	return exec.CommandContext(ctx, cmd, args...).Output()
+func (p *Probe) runCommand(ctx context.Context, cmd string, args []string) ([]byte, []byte, error) {
+	c := exec.CommandContext(ctx, cmd, args...)
+	var stdout, stderr bytes.Buffer
+	c.Stdout, c.Stderr = &stdout, &stderr
+	err := c.Run()
+	return stdout.Bytes(), stderr.Bytes(), err
 }


### PR DESCRIPTION
This PR addresses #299.
`runCommandFunc` and `runCommand` function return stderr from a command by default.