### PR TITLE
[probes.http] Fix a bug in prepareRequest.

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -290,7 +290,7 @@ func (l *Logger) Close() error {
 
 // Debug logs messages with logging level set to "Debug".
 func (l *Logger) Debug(payload ...string) {
-	if l.debugLog {
+	if l != nil && l.debugLog {
 		l.log(logging.Debug, payload...)
 	}
 }

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -96,24 +96,6 @@ type probeResult struct {
 	sslEarliestExpirationSeconds int64
 }
 
-func (p *Probe) oauthToken() (string, error) {
-	tok, err := p.oauthTS.Token()
-	if err != nil {
-		return "", err
-	}
-	p.l.Debug("Got OAuth token, len: ", strconv.FormatInt(int64(len(tok.AccessToken)), 10), ", expirationTime: ", tok.Expiry.String())
-
-	if tok.AccessToken != "" {
-		return tok.AccessToken, nil
-	}
-	idToken, ok := tok.Extra("id_token").(string)
-	if ok {
-		return idToken, nil
-	}
-
-	return "", fmt.Errorf("got unknown token: %v", tok)
-}
-
 func (p *Probe) getTransport() (*http.Transport, error) {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	dialer := &net.Dialer{


### PR DESCRIPTION
* My past PR introduced a bug where the request body was not
  not if we were using oauth token source "and" body was too large.
* Add tests to catch this scenario.
* While here, fix a small bug in Logger.Debug().