### PR TITLE
[http] Set request's GetBody explicitly to make redirect work.

### DIFF
--- a/common/httputils/httputils.go
+++ b/common/httputils/httputils.go
@@ -108,7 +108,7 @@ func contentType(data []string) string {
 }
 
 // NewRequest returns a new HTTP request object, with the given method, url,
-// data and headers.
+// request body.
 func NewRequest(method, url string, reqBody *RequestBody) (*http.Request, error) {
 	req, err := http.NewRequest(method, url, reqBody.Reader())
 	if err != nil {

--- a/common/oauth/http_token.go
+++ b/common/oauth/http_token.go
@@ -85,9 +85,13 @@ func (ts *httpTokenSource) tokenFromHTTP(req *http.Request) (*oauth2.Token, erro
 }
 
 func newHTTPTokenSource(c *configpb.HTTPRequest, refreshExpiryBuffer time.Duration, l *logger.Logger) (oauth2.TokenSource, error) {
-	req, err := httputils.HTTPRequest(c.GetMethod(), c.GetTokenUrl(), c.GetData(), c.GetHeader())
+	req, err := httputils.NewRequest(c.GetMethod(), c.GetTokenUrl(), httputils.NewRequestBody(c.GetData()...))
 	if err != nil {
 		return nil, fmt.Errorf("error creating HTTP request: %v", err)
+	}
+
+	for k, v := range c.GetHeader() {
+		req.Header.Set(k, v)
 	}
 
 	ts := &httpTokenSource{

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cloudprober/cloudprober/common/httputils"
 	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
 	"golang.org/x/oauth2"
@@ -112,15 +113,10 @@ func (p *Probe) httpRequestForTarget(target endpoint.Endpoint) *http.Request {
 
 	url := fmt.Sprintf("%s://%s%s", p.protocol, hostWithPort(urlHost, port), relURLForTarget(target, p.url))
 
-	req, err := http.NewRequest(p.method, url, p.requestBody.Reader())
+	req, err := httputils.NewRequest(p.method, url, p.requestBody)
 	if err != nil {
 		p.l.Error("target: ", target.Name, ", error creating HTTP request: ", err.Error())
 		return nil
-	}
-
-	req.ContentLength = p.requestBody.Len()
-	if p.requestBody.ContentType() != "" {
-		req.Header.Set("Content-Type", p.requestBody.ContentType())
 	}
 
 	var probeHostHeader string

--- a/probes/http/request_test.go
+++ b/probes/http/request_test.go
@@ -17,7 +17,6 @@ package http
 import (
 	"fmt"
 	"net"
-	"net/http"
 	"testing"
 
 	"github.com/cloudprober/cloudprober/common/httputils"
@@ -365,7 +364,7 @@ func TestPrepareRequest(t *testing.T) {
 				p.oauthTS = &fakeTokenSource{token: tt.token}
 			}
 
-			inReq, _ := http.NewRequest("GET", "http://cloudprober.org", p.requestBody.Reader())
+			inReq, _ := httputils.NewRequest("GET", "http://cloudprober.org", p.requestBody)
 			got := p.prepareRequest(inReq)
 
 			if tt.wantIsCloned != (inReq != got) {
@@ -378,6 +377,11 @@ func TestPrepareRequest(t *testing.T) {
 
 			if tt.token != "" {
 				assert.Equal(t, "Bearer "+tt.token, got.Header.Get("Authorization"), "Token mismatch")
+			}
+
+			if len(tt.data) != 0 {
+				assert.NotNil(t, inReq.GetBody, "GetBody is nil")
+				assert.NotNil(t, got.GetBody, "GetBody is nil")
 			}
 		})
 	}


### PR DESCRIPTION
Redirects with data don't work if GetBody is not set.

Ref: This is the net/http.Client code that disables redirect for data + 307:
https://cs.opensource.google/go/go/+/refs/tags/go1.20.4:src/net/http/client.go;l=522