### PR TITLE
[probes.external] Add test for startCmdIfNotRunning.

### DIFF
--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -210,12 +210,16 @@ func (p *Probe) monitorCommand(startCtx context.Context, cmd command) error {
 
 func (p *Probe) startCmdIfNotRunning(startCtx context.Context) error {
 	// Start external probe command if it's not running already. Note that here we
-	// are trusting the cmdRunning to be set correctly. It can be false for 3 reasons:
-	// 1) This is the first call and the process has actually never been started.
-	// 2) cmd.Start() started the process but still returned an error.
-	// 3) cmd.Wait() returned incorrectly, while the process was still running.
+	// are trusting the cmdRunning to be set correctly. It can be false for 4
+	// reasons:
+	// Correct reasons:
+	// 1) This is the first call and process has actually never been started.
+	// 2) Process died for some reason and monitor set cmdRunning to false.
+	// Incorrect reasons:
+	// 3) cmd.Start() started the process but still returned an error.
+	// 4) cmd.Wait() returned incorrectly, while the process was still running.
 	//
-	// 2 or 3 should never happen as per design, but managing processes can be tricky.
+	// 3 or 4 should never really happen, but managing processes can be tricky.
 	// Documenting here to help with debugging if we run into an issue.
 	p.cmdRunningMu.Lock()
 	defer p.cmdRunningMu.Unlock()

--- a/probes/external/external_test.go
+++ b/probes/external/external_test.go
@@ -801,8 +801,6 @@ func TestShellProcessSuccess(t *testing.T) {
 }
 
 func TestProbeStartCmdIfNotRunning(t *testing.T) {
-	cmdStr := strings.Join([]string{os.Args[0], "-test.run=TestShellProcessSuccess"}, " ")
-
 	tests := []struct {
 		pauseSec int
 		wantErr  bool
@@ -816,10 +814,16 @@ func TestProbeStartCmdIfNotRunning(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("pause=%d", test.pauseSec), func(t *testing.T) {
-			p := createTestProbe(cmdStr, map[string]string{
+			// testCommand is just a placeholder here. We replace cmdName and
+			// cmdArgs after creating the probe.
+			p := createTestProbe("/testCommand", map[string]string{
 				"GO_TEST_PROCESS": "1",
 				"PAUSE":           strconv.Itoa(test.pauseSec),
 			})
+
+			p.cmdName = os.Args[0]
+			p.cmdArgs = []string{"-test.run=TestShellProcessSuccess"}
+
 			if err := p.startCmdIfNotRunning(context.Background()); err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
It catches the issue reported in #395. This also increases the code coverage from 71.4% to 79.8%

--        github.com/cloudprober/cloudprober/probes/external      coverage: 71.4% of statements
++       github.com/cloudprober/cloudprober/probes/external      coverage: 79.8% of statements