### PR TITLE
[probes.http] Fix HTTP request body handling.

### DIFF
--- a/common/httputils/httputils.go
+++ b/common/httputils/httputils.go
@@ -35,10 +35,7 @@ func IsHandled(mux *http.ServeMux, url string) bool {
 	return matchedPattern == url
 }
 
-// RequestBody returns a reusable HTTP request body if its size is smaller than
-// largeBodyThreshold. This is the most common use case in probing. If the body
-// is larger than largeBodyThreshold, it returns a buffered reader. We do that
-// because HTTP transport reads limited bytes at a time.
+// RequestBody implements an HTTP request body.
 type RequestBody struct {
 	b  []byte
 	ct string
@@ -65,14 +62,7 @@ func (rb *RequestBody) Reader() io.ReadCloser {
 	if rb == nil || len(rb.b) == 0 {
 		return nil
 	}
-	if len(rb.b) > largeBodyThreshold {
-		return io.NopCloser(bytes.NewReader(rb.b))
-	}
-	return io.NopCloser(rb)
-}
-
-func (rb *RequestBody) Buffered() bool {
-	return rb != nil && len(rb.b) > largeBodyThreshold
+	return io.NopCloser(bytes.NewReader(rb.b))
 }
 
 func (rb *RequestBody) Len() int64 {

--- a/common/httputils/httputils_test.go
+++ b/common/httputils/httputils_test.go
@@ -92,8 +92,9 @@ func TestNewRequest(t *testing.T) {
 			assert.Equal(t, tt.wantReqBody, string(got))
 			assert.Equal(t, tt.wantCT, req.Header.Get("Content-Type"), "Content-Type Header")
 
+			// We want an empty read next time.
 			got, _ = io.ReadAll(req.Body)
-			assert.Equal(t, tt.wantReqBody, string(got))
+			assert.Equal(t, "", string(got))
 		})
 	}
 }
@@ -109,41 +110,36 @@ func TestRequestBody(t *testing.T) {
 		wantData       string
 		wantLen        int64
 		wantCT         string
-		wantBuffered   bool
 		wantNilReader  bool
 		nilRequestBody bool
 	}{
 		{
-			name:         "large_data",
-			data:         data,
-			wantLen:      1579,
-			wantData:     strings.Join(data, "&"),
-			wantCT:       "",
-			wantBuffered: true,
+			name:     "large_data",
+			data:     data,
+			wantLen:  1579,
+			wantData: strings.Join(data, "&"),
+			wantCT:   "",
 		},
 		{
-			name:         "small_data",
-			data:         data[:10],
-			wantData:     strings.Join(data[:10], "&"),
-			wantLen:      139,
-			wantCT:       "application/x-www-form-urlencoded",
-			wantBuffered: false,
+			name:     "small_data",
+			data:     data[:10],
+			wantData: strings.Join(data[:10], "&"),
+			wantLen:  139,
+			wantCT:   "application/x-www-form-urlencoded",
 		},
 		{
-			name:         "single_data_string",
-			data:         []string{"clientId=testID&clientSecret=testSecret"},
-			wantData:     "clientId=testID&clientSecret=testSecret",
-			wantLen:      39,
-			wantCT:       "application/x-www-form-urlencoded",
-			wantBuffered: false,
+			name:     "single_data_string",
+			data:     []string{"clientId=testID&clientSecret=testSecret"},
+			wantData: "clientId=testID&clientSecret=testSecret",
+			wantLen:  39,
+			wantCT:   "application/x-www-form-urlencoded",
 		},
 		{
-			name:         "json_data",
-			data:         []string{`{"clientId":"testID", "clientSecret":"testSecret"}`},
-			wantData:     `{"clientId":"testID", "clientSecret":"testSecret"}`,
-			wantLen:      50,
-			wantCT:       "application/json",
-			wantBuffered: false,
+			name:     "json_data",
+			data:     []string{`{"clientId":"testID", "clientSecret":"testSecret"}`},
+			wantData: `{"clientId":"testID", "clientSecret":"testSecret"}`,
+			wantLen:  50,
+			wantCT:   "application/json",
 		},
 		{
 			name:          "no_data",
@@ -165,7 +161,6 @@ func TestRequestBody(t *testing.T) {
 
 			assert.Equal(t, tt.wantLen, body.Len(), "length mismatch")
 			assert.Equal(t, tt.wantCT, body.ContentType(), "content-type mismatch")
-			assert.Equal(t, tt.wantBuffered, body.Buffered(), "buffered mismatch")
 
 			// Verify reader is good
 			reader := body.Reader()
@@ -176,9 +171,7 @@ func TestRequestBody(t *testing.T) {
 
 			gotData, _ := io.ReadAll(reader)
 			assert.Equal(t, tt.wantData, string(gotData), "body data mismatch 1st read")
-			if tt.wantBuffered {
-				reader = body.Reader()
-			}
+			reader = body.Reader()
 			gotData, _ = io.ReadAll(reader)
 			assert.Equal(t, tt.wantData, string(gotData), "body data mismatch 2nd read")
 		})

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -160,12 +160,12 @@ func getToken(ts oauth2.TokenSource, l *logger.Logger) (string, error) {
 
 func (p *Probe) prepareRequest(req *http.Request) *http.Request {
 	// We clone the request for the cases where we modify the request:
-	//   -- if request body is large (buffered), each request gets its own Body
+	//   -- if request has a body, each request gets its own Body
 	//      as HTTP transport reads body in a streaming fashion, and we can't
 	//      share it across multiple requests.
 	//   -- if OAuth token is used, each request gets its own Authorization
 	//      header.
-	if p.oauthTS == nil && !p.requestBody.Buffered() {
+	if p.oauthTS == nil && p.requestBody.Len() == 0 {
 		return req
 	}
 
@@ -183,9 +183,7 @@ func (p *Probe) prepareRequest(req *http.Request) *http.Request {
 		req.Header.Set("Authorization", "Bearer "+tok)
 	}
 
-	if p.requestBody.Buffered() {
-		req.Body = p.requestBody.Reader()
-	}
+	req.Body = p.requestBody.Reader()
 
 	return req
 }

--- a/probes/http/request_test.go
+++ b/probes/http/request_test.go
@@ -343,6 +343,12 @@ func TestPrepareRequest(t *testing.T) {
 			wantNewBody:  true,
 		},
 		{
+			name:         "token source, no body",
+			token:        "test-token",
+			wantIsCloned: true,
+			wantNewBody:  false, // Only request is cloned.
+		},
+		{
 			name:         "token source, small body",
 			data:         data[0:20],
 			token:        "test-token",

--- a/probes/http/request_test.go
+++ b/probes/http/request_test.go
@@ -331,8 +331,10 @@ func TestPrepareRequest(t *testing.T) {
 			name: "No token source, no body",
 		},
 		{
-			name: "No token source, small body",
-			data: data[0:20],
+			name:         "No token source, small body",
+			data:         data[0:20],
+			wantIsCloned: true,
+			wantNewBody:  true,
 		},
 		{
 			name:         "No token source, large body",
@@ -345,7 +347,7 @@ func TestPrepareRequest(t *testing.T) {
 			data:         data[0:20],
 			token:        "test-token",
 			wantIsCloned: true,
-			wantNewBody:  false,
+			wantNewBody:  true,
 		},
 		{
 			name:         "token source, large body",


### PR DESCRIPTION
= Currently all probes with request body are broken. See the bug report https://github.com/cloudprober/cloudprober/issues/407 for more details. = Looking at Go's internal code for HTTP transport and transfer, it's pretty clear that anything other than a dedicated buffered reader will not work for request body.
= During data transfer over the connection, transfer tries to read the body again after reading for the content-length and even after receiving
 EOF in the first read. This is probably a bug in Go: it's reasonable to
 see if there is more to be read, but I think it should not ignore the
 first EOF.
= This bug has existed since Cloudprober version v0.11.9 when we added Content-Length header: https://github.com/cloudprober/cloudprober/pull/168 = I'll add tests in the follow up PRs to detect such issues.