### PR TITLE
[probes.http] Include headers configured with `header` option in requests

### DIFF
--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -128,6 +128,14 @@ func (p *Probe) httpRequestForTarget(target endpoint.Endpoint) *http.Request {
 		req.Header.Set(header.GetName(), header.GetValue())
 	}
 
+	for k, v := range p.c.GetHeader() {
+		if k == "Host" {
+			probeHostHeader = v
+			continue
+		}
+		req.Header.Set(k, v)
+	}
+
 	// Host header is set by http.NewRequest based on the URL, update it based
 	// on various conditions.
 	req.Host = hostHeaderForTarget(target, probeHostHeader, port)


### PR DESCRIPTION
Hi,

I wanted to add HTTP headers to a probe configuration and I found the "header" option first, as well as a "headers" option which appeared to be the deprecated equivalent (if I'm understanding correctly).

Adding headers to the "header" option seemed to have no effect, it appears only "headers" is being checked. This should resolve that.

Hopefully this is correct. It seems to work for me :)