### PR TITLE
[oauth2] Fix a bug in HTTP token refresh.

### DIFF
--- a/common/oauth/http_token.go
+++ b/common/oauth/http_token.go
@@ -95,7 +95,7 @@ func newRequest(method, url string, headers map[string]string, data []string) (*
 }
 
 func newHTTPTokenSource(c *configpb.HTTPRequest, refreshExpiryBuffer time.Duration, l *logger.Logger) (oauth2.TokenSource, error) {
-	// Verify the request parameters are correct.
+	// Verify request parameters are correct.
 	_, err := newRequest(c.GetMethod(), c.GetTokenUrl(), c.GetHeader(), c.GetData())
 	if err != nil {
 		return nil, err

--- a/common/oauth/http_token.go
+++ b/common/oauth/http_token.go
@@ -28,9 +28,9 @@ import (
 )
 
 type httpTokenSource struct {
-	cache  *tokenCache
-	l      *logger.Logger
-	httpDo func(req *http.Request) (*http.Response, error)
+	cache      *tokenCache
+	l          *logger.Logger
+	httpClient *http.Client
 }
 
 func redact(s string) string {
@@ -41,13 +41,11 @@ func redact(s string) string {
 }
 
 func (ts *httpTokenSource) tokenFromHTTP(req *http.Request) (*oauth2.Token, error) {
-	var resp *http.Response
-	var err error
-	if ts.httpDo != nil {
-		resp, err = ts.httpDo(req)
-	} else {
-		resp, err = http.DefaultClient.Do(req)
+	if ts.httpClient == nil {
+		ts.httpClient = http.DefaultClient
 	}
+
+	resp, err := ts.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("token URL err: %v", err)
 	}


### PR DESCRIPTION
* While fixing the HTTP request body handling in #408, I introduced a bug: that PR changed request body to be buffered all the time to simplify it. I missed changing oauth2.http_token at that time. This PR fixes that.
* Improve tests.