### PR TITLE
Add a health handler.

### DIFF
--- a/cloudprober.go
+++ b/cloudprober.go
@@ -241,7 +241,8 @@ func Start(ctx context.Context) {
 	defer cloudProber.Unlock()
 
 	// Default servers
-	httpSrv := &http.Server{Handler: runconfig.DefaultHTTPServeMux()}
+	srvMux := runconfig.DefaultHTTPServeMux()
+	httpSrv := &http.Server{Handler: srvMux}
 	grpcSrv := runconfig.DefaultGRPCServer()
 
 	// Set up a goroutine to cleanup if context ends.
@@ -271,6 +272,9 @@ func Start(ctx context.Context) {
 	}
 
 	cloudProber.prober.Start(ctx)
+	srvMux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "OK")
+	})
 }
 
 // GetConfig returns the prober config.

--- a/surfacers/probestatus/probestatus.go
+++ b/surfacers/probestatus/probestatus.go
@@ -186,7 +186,13 @@ func New(ctx context.Context, config *configpb.SurfacerConf, opts *options.Optio
 	opts.HTTPServeMux.Handle(config.GetUrl()+"/static/", http.StripPrefix(config.GetUrl(), http.FileServer(http.FS(content))))
 
 	if !httputils.IsHandled(opts.HTTPServeMux, "/") {
-		opts.HTTPServeMux.Handle("/", http.RedirectHandler(config.GetUrl(), http.StatusFound))
+		opts.HTTPServeMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/" {
+				http.NotFound(w, r)
+				return
+			}
+			http.Redirect(w, r, "/probestatus", http.StatusFound)
+		})
 	}
 
 	l.Infof("Initialized status surfacer at the URL: %s", "probesstatus")


### PR DESCRIPTION
It gets activated after Cloudprober has fully started. It can be used for readiness and liveness probes.
