### PR TITLE
[metrics] Clone latency and other similar metrics

### DIFF
--- a/probes/dns/dns.go
+++ b/probes/dns/dns.go
@@ -103,7 +103,7 @@ func (prr probeRunResult) Metrics() *metrics.EventMetrics {
 	return metrics.NewEventMetrics(time.Now()).
 		AddMetric("total", &prr.total).
 		AddMetric("success", &prr.success).
-		AddMetric(prr.latencyMetricName, prr.latency).
+		AddMetric(prr.latencyMetricName, prr.latency.Clone()).
 		AddMetric("timeouts", &prr.timeouts).
 		AddMetric("validation_failure", prr.validationFailure)
 }

--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -85,17 +85,17 @@ type Probe struct {
 	l       *logger.Logger
 
 	// book-keeping params
-	labelKeys  map[string]bool // Labels for substitution
-	requestID  int32
-	cmdRunning bool
+	labelKeys    map[string]bool // Labels for substitution
+	requestID    int32
+	cmdRunning   bool
 	cmdRunningMu sync.Mutex // synchronizes cmdRunning
-	cmdStdin   io.Writer
-	cmdStdout  io.ReadCloser
-	cmdStderr  io.ReadCloser
-	replyChan  chan *serverpb.ProbeReply
-	targets    []endpoint.Endpoint
-	results    map[string]*result // probe results keyed by targets
-	dataChan   chan *metrics.EventMetrics
+	cmdStdin     io.Writer
+	cmdStdout    io.ReadCloser
+	cmdStderr    io.ReadCloser
+	replyChan    chan *serverpb.ProbeReply
+	targets      []endpoint.Endpoint
+	results      map[string]*result // probe results keyed by targets
+	dataChan     chan *metrics.EventMetrics
 
 	// This is used for overriding run command logic for testing.
 	runCommandFunc func(ctx context.Context, cmd string, args, envVars []string) ([]byte, []byte, error)
@@ -313,7 +313,7 @@ func (p *Probe) defaultMetrics(target string, result *result) *metrics.EventMetr
 	em := metrics.NewEventMetrics(time.Now()).
 		AddMetric("success", metrics.NewInt(result.success)).
 		AddMetric("total", metrics.NewInt(result.total)).
-		AddMetric(p.opts.LatencyMetricName, result.latency).
+		AddMetric(p.opts.LatencyMetricName, result.latency.Clone()).
 		AddLabel("ptype", "external").
 		AddLabel("probe", p.name).
 		AddLabel("dst", target)

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -397,14 +397,14 @@ func (p *Probe) exportMetrics(ts time.Time, result *probeResult, target endpoint
 	em := metrics.NewEventMetrics(ts).
 		AddMetric("total", metrics.NewInt(result.total)).
 		AddMetric("success", metrics.NewInt(result.success)).
-		AddMetric(p.opts.LatencyMetricName, result.latency).
+		AddMetric(p.opts.LatencyMetricName, result.latency.Clone()).
 		AddMetric("timeouts", metrics.NewInt(result.timeouts)).
-		AddMetric("resp-code", result.respCodes)
+		AddMetric("resp-code", result.respCodes.Clone())
 
 	em.LatencyUnit = p.opts.LatencyUnit
 
 	if result.respBodies != nil {
-		em.AddMetric("resp-body", result.respBodies)
+		em.AddMetric("resp-body", result.respBodies.Clone())
 	}
 
 	if p.c.GetKeepAlive() {

--- a/probes/ping/ping.go
+++ b/probes/ping/ping.go
@@ -32,7 +32,8 @@ local port to find the correct destination socket.
 More about these sockets: http://lwn.net/Articles/420800/
 Note: On some linux distributions these sockets are not enabled by default; you
 can enable them by doing something like the following:
-      sudo sysctl -w net.ipv4.ping_group_range="0 5000"
+
+	sudo sysctl -w net.ipv4.ping_group_range="0 5000"
 */
 package ping
 
@@ -472,11 +473,11 @@ func (p *Probe) newRunID() uint16 {
 
 // runProbe is called by Run for each probe interval. It does the following on
 // each run:
-//   * Resolve targets if target resolve interval has elapsed.
-//   * Increment run count (runCnt).
-//   * Get a new run ID.
-//   * Starts a goroutine to receive packets.
-//   * Send packets.
+//   - Resolve targets if target resolve interval has elapsed.
+//   - Increment run count (runCnt).
+//   - Get a new run ID.
+//   - Starts a goroutine to receive packets.
+//   - Send packets.
 func (p *Probe) runProbe() {
 	// Resolve targets if target resolve interval has elapsed.
 	if (p.runCnt % uint64(p.c.GetResolveTargetsInterval())) == 0 {
@@ -528,7 +529,7 @@ func (p *Probe) Start(ctx context.Context, dataChan chan *metrics.EventMetrics) 
 			em := metrics.NewEventMetrics(ts).
 				AddMetric("total", metrics.NewInt(result.sent)).
 				AddMetric("success", metrics.NewInt(success)).
-				AddMetric(p.opts.LatencyMetricName, result.latency).
+				AddMetric(p.opts.LatencyMetricName, result.latency.Clone()).
 				AddLabel("ptype", "ping").
 				AddLabel("probe", p.name).
 				AddLabel("dst", target.Name)

--- a/probes/tcp/tcp.go
+++ b/probes/tcp/tcp.go
@@ -69,7 +69,7 @@ func (result *probeResult) Metrics(ts time.Time, opts *options.Options) *metrics
 	em := metrics.NewEventMetrics(ts).
 		AddMetric("total", metrics.NewInt(result.total)).
 		AddMetric("success", metrics.NewInt(result.success)).
-		AddMetric(opts.LatencyMetricName, result.latency).
+		AddMetric(opts.LatencyMetricName, result.latency.Clone()).
 		AddLabel("ptype", "tcp")
 
 	if result.validationFailure != nil {


### PR DESCRIPTION
One possible repercussion of this could be increased memory allocation and de-allocations for large number of probes/targets. Rough calculation for the record:

* Based on the map cloning [benchmark](https://github.com/cloudprober/cloudprober/blob/83add1a5e02d2714d71a10b7cb3ed42d8bf27009/metrics/map_test.go#L160), each map clone causes N+6 allocations where N is number of keys. Assuming each resp-code entry takes about 24 bytes (8 byte for keys array, 16 bytes for key-value map entry) and there can be say 10 resp-code in the map, and taking into account some static overhead, we're looking at around 300 bytes per resp-code map cloning.

* Latency distribution requires explicit configuration so it's less common. As per benchmark, distribution cloning requires fixed number of allocation (4), regardless of number of buckets (O(1)). Let's say there are 24 buckets. Each bucket takes 8 bytes for bucket definition (lower bounds array) and 8 bytes for counts. We're looking at about 400 bytes per latency distribution cloning.

Assuming there are 10000 targets (across all probes) exporting data every 10s, we're looking at about 700 kB/second of allocations. This is pretty much an extreme case though and all these allocations will be spread over.