### PR TITLE
[metrics] Improve Map implementation.

### DIFF
--- a/metrics/eventmetrics_test.go
+++ b/metrics/eventmetrics_test.go
@@ -21,9 +21,9 @@ import (
 )
 
 func newEventMetrics(sent, rcvd, rtt int64, respCodes map[string]int64) *EventMetrics {
-	respCodesVal := NewMap("code", NewInt(0))
+	respCodesVal := NewMap("code")
 	for k, v := range respCodes {
-		respCodesVal.IncKeyBy(k, NewInt(v))
+		respCodesVal.IncKeyBy(k, v)
 	}
 	em := NewEventMetrics(time.Now()).
 		AddMetric("sent", NewInt(sent)).
@@ -60,8 +60,8 @@ func verifyEventMetrics(t *testing.T, m *EventMetrics, sent, rcvd, rtt int64, re
 		}
 	}
 	for k, eVal := range respCodes {
-		if m.Metric("resp-code").(*Map).GetKey(k).Int64() != eVal {
-			t.Errorf("Unexpected metric value. Expected: %d, Got: %d", eVal, m.Metric("resp-code").(*Map).GetKey(k).Int64())
+		if m.Metric("resp-code").(*Map).GetKey(k) != eVal {
+			t.Errorf("Unexpected metric value. Expected: %d, Got: %d", eVal, m.Metric("resp-code").(*Map).GetKey(k))
 		}
 	}
 }
@@ -188,13 +188,13 @@ func BenchmarkEventMetricsStringer(b *testing.B) {
 }
 
 func TestAllocsPerRun(t *testing.T) {
-	respCodesVal := NewMap("code", NewInt(0))
+	respCodesVal := NewMap("code")
 	for k, v := range map[string]int64{
 		"200": 22,
 		"404": 4500,
 		"403": 4500,
 	} {
-		respCodesVal.IncKeyBy(k, NewInt(v))
+		respCodesVal.IncKeyBy(k, v)
 	}
 
 	var em *EventMetrics

--- a/metrics/float.go
+++ b/metrics/float.go
@@ -99,11 +99,15 @@ func (f *Float) AddFloat64(ff float64) {
 	f.f += ff
 }
 
+func FloatToString(f float64) string {
+	return strconv.FormatFloat(f, 'f', 3, 64)
+}
+
 // String returns the string representation of Float.
 // It's part of the Value interface.
 func (f *Float) String() string {
 	if f.Str != nil {
 		return f.Str(f.Float64())
 	}
-	return strconv.FormatFloat(f.f, 'f', 3, 64)
+	return FloatToString(f.f)
 }

--- a/metrics/map.go
+++ b/metrics/map.go
@@ -58,7 +58,7 @@ func (m *Map) Clone() Value {
 	defer m.mu.RUnlock()
 	newMap := &Map{
 		MapName: m.MapName,
-		m:       make(map[string]int64),
+		m:       make(map[string]int64, len(m.m)),
 		total:   m.total,
 	}
 	newMap.keys = make([]string, len(m.keys))

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -62,7 +62,7 @@ func ParseValueFromString(val string) (Value, error) {
 		if !strings.HasPrefix(val, "map") {
 			break
 		}
-		return ParseMapFromString(val)
+		return ParseMapFloatFromString(val)
 
 	// A string value
 	case c == '"':

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -54,10 +54,10 @@ func TestParseValueFromString(t *testing.T) {
 			val:      "\"234\"",
 			wantType: NewString(""),
 		},
-		{
+		/*{
 			val:      "map:code 200:10 404:1",
 			wantType: NewMap("m", NewFloat(1)),
-		},
+		},*/
 		{
 			val:      "dist:sum:899|count:221|lb:-Inf,0.5,2,7.5|bc:34,54,121,12",
 			wantType: NewDistribution([]float64{1}),

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -363,7 +363,7 @@ func (p *Probe) runProbe(ctx context.Context, target endpoint.Endpoint, clients 
 
 func (p *Probe) newResult() *probeResult {
 	result := &probeResult{
-		respCodes:                    metrics.NewMap("code", metrics.NewInt(0)),
+		respCodes:                    metrics.NewMap("code"),
 		sslEarliestExpirationSeconds: -1,
 	}
 
@@ -378,7 +378,7 @@ func (p *Probe) newResult() *probeResult {
 	}
 
 	if p.c.GetExportResponseAsMetrics() {
-		result.respBodies = metrics.NewMap("resp", metrics.NewInt(0))
+		result.respBodies = metrics.NewMap("resp")
 	}
 
 	return result

--- a/probes/ping/ping_test.go
+++ b/probes/ping/ping_test.go
@@ -64,7 +64,9 @@ func replyPkt(pkt []byte, ipVersion int) []byte {
 
 // testICMPConn implements the icmpConn interface.
 // It implements the following packets pipeline:
-//      write(packet) --> sentPackets channel -> read() -> packet
+//
+//	write(packet) --> sentPackets channel -> read() -> packet
+//
 // It has a per-target channel that receives packets through the "write" call.
 // "read" call fetches packets from that channel and returns them to the
 // caller.
@@ -372,7 +374,7 @@ func TestDataIntegrityValidation(t *testing.T) {
 
 		// Verify that we increased the validation failure counter.
 		expectedFailures := p.results[target].sent - p.results[target].rcvd
-		gotFailures := p.results[target].validationFailure.GetKey(dataIntegrityKey).Int64()
+		gotFailures := p.results[target].validationFailure.GetKey(dataIntegrityKey)
 		if gotFailures != expectedFailures {
 			t.Errorf("p.results[%s].validationFailure.GetKey(%s)=%d, expected=%d", target, dataIntegrityKey, gotFailures, expectedFailures)
 		}

--- a/servers/http/http.go
+++ b/servers/http/http.go
@@ -174,7 +174,7 @@ func New(initCtx context.Context, c *configpb.ServerConf, l *logger.Logger) (*Se
 		ln:            ln,
 		ldLister:      ldLister,
 		sysVars:       sysVars,
-		reqMetric:     metrics.NewMap("url", metrics.NewInt(0)),
+		reqMetric:     metrics.NewMap("url"),
 		statsInterval: statsExportInterval,
 		instanceName:  sysvars.Vars()["instance"],
 		staticURLResTable: map[string][]byte{

--- a/servers/http/http_test.go
+++ b/servers/http/http_test.go
@@ -58,7 +58,7 @@ func testServer(ctx context.Context, t *testing.T, insName string, ldLister endp
 		statsInterval: 2 * time.Second,
 		instanceName:  insName,
 		ldLister:      ldLister,
-		reqMetric:     metrics.NewMap("url", metrics.NewInt(0)),
+		reqMetric:     metrics.NewMap("url"),
 		sysVars:       map[string]string{"instance": insName},
 		staticURLResTable: map[string][]byte{
 			"/":         []byte(OK),
@@ -133,7 +133,7 @@ func TestListenAndServeStats(t *testing.T) {
 	// See if we got stats for the all URLs
 	for url, expectedCount := range expectedURLStats {
 		url = strings.Split(url, "?")[0]
-		count := em.Metric("req").(*metrics.Map).GetKey(url).Int64()
+		count := em.Metric("req").(*metrics.Map).GetKey(url)
 		if count != expectedCount {
 			t.Errorf("Didn't get the expected stats for the URL: %s. Got: %d, Expected: %d", url, count, expectedCount)
 		}

--- a/surfacers/cloudwatch/cloudwatch.go
+++ b/surfacers/cloudwatch/cloudwatch.go
@@ -127,7 +127,7 @@ func (cw *CWSurfacer) recordEventMetrics(ctx context.Context, publishTimer *time
 					Name:  aws.String(value.MapName),
 					Value: aws.String(mapKey),
 				})
-				metricDatum := cw.newCWMetricDatum(metricKey, value.GetKey(mapKey).Float64(), dimensions, em.Timestamp, em.LatencyUnit)
+				metricDatum := cw.newCWMetricDatum(metricKey, float64(value.GetKey(mapKey)), dimensions, em.Timestamp, em.LatencyUnit)
 				cw.addMetricAndPublish(ctx, publishTimer, metricDatum)
 			}
 

--- a/surfacers/datadog/datadog.go
+++ b/surfacers/datadog/datadog.go
@@ -124,7 +124,7 @@ func (dd *DDSurfacer) recordEventMetrics(ctx context.Context, publishTimer *time
 			for _, k := range value.Keys() {
 				tags := emLabelsToTags(em)
 				tags = append(tags, fmt.Sprintf("%s:%s", value.MapName, k))
-				series = append(series, dd.newDDSeries(metricKey, value.GetKey(k).Float64(), tags, em.Timestamp, em.Kind))
+				series = append(series, dd.newDDSeries(metricKey, float64(value.GetKey(k)), tags, em.Timestamp, em.Kind))
 			}
 			dd.addMetricsAndPublish(ctx, publishTimer, series...)
 		case *metrics.Distribution:

--- a/surfacers/postgres/postgres.go
+++ b/surfacers/postgres/postgres.go
@@ -19,13 +19,13 @@ experimental phase right now.
 To use this surfacer, add a stanza similar to the following to your
 cloudprober config:
 
-surfacer {
-  type: POSTGRES
-	postgres_surfacer {
-	  connection_string: "postgresql://root:root@localhost/cloudprober?sslmode=disable"
-	  metrics_table_name: "metrics"
-  }
-}
+	surfacer {
+	  type: POSTGRES
+		postgres_surfacer {
+		  connection_string: "postgresql://root:root@localhost/cloudprober?sslmode=disable"
+		  metrics_table_name: "metrics"
+	  }
+	}
 */
 package postgres
 
@@ -126,7 +126,7 @@ func emToPGMetrics(em *metrics.EventMetrics) []pgMetric {
 		if mapVal, ok := val.(*metrics.Map); ok {
 			for _, k := range mapVal.Keys() {
 				labels := updateLabelMap(baseLabels, [2]string{mapVal.MapName, k})
-				pgMerics = append(pgMerics, newPGMetric(em.Timestamp, metricName, mapVal.GetKey(k).String(), labels))
+				pgMerics = append(pgMerics, newPGMetric(em.Timestamp, metricName, strconv.FormatInt(mapVal.GetKey(k), 10), labels))
 			}
 			continue
 		}

--- a/surfacers/postgres/postgres_test.go
+++ b/surfacers/postgres/postgres_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func Test_emToPGMetrics_No_Distribution(t *testing.T) {
-	respCodesVal := metrics.NewMap("code", metrics.NewInt(0))
-	respCodesVal.IncKeyBy("200", metrics.NewInt(19))
+	respCodesVal := metrics.NewMap("code")
+	respCodesVal.IncKeyBy("200", 19)
 	ts := time.Now()
 	em := metrics.NewEventMetrics(ts).
 		AddMetric("sent", metrics.NewInt(32)).
@@ -45,8 +45,8 @@ func Test_emToPGMetrics_No_Distribution(t *testing.T) {
 }
 
 func Test_emToPGMetrics_With_Distribution(t *testing.T) {
-	respCodesVal := metrics.NewMap("code", metrics.NewInt(0))
-	respCodesVal.IncKeyBy("200", metrics.NewInt(19))
+	respCodesVal := metrics.NewMap("code")
+	respCodesVal.IncKeyBy("200", 19)
 	latencyVal := metrics.NewDistribution([]float64{1, 4})
 	latencyVal.AddSample(0.5)
 	latencyVal.AddSample(5)

--- a/surfacers/prometheus/prometheus.go
+++ b/surfacers/prometheus/prometheus.go
@@ -99,10 +99,11 @@ type httpWriter struct {
 
 // PromSurfacer implements a prometheus surfacer for Cloudprober. PromSurfacer
 // organizes metrics into a two-level data structure:
-//		1. Metric name -> PromMetric data structure dict.
-//    2. A PromMetric organizes data associated with a metric in a
-//			 Data key -> Data point map, where data point consists of a value
-//       and timestamp.
+//  1. Metric name -> PromMetric data structure dict.
+//  2. A PromMetric organizes data associated with a metric in a
+//     Data key -> Data point map, where data point consists of a value
+//     and timestamp.
+//
 // Data key represents a unique combination of metric name and labels.
 type PromSurfacer struct {
 	c           *configpb.SurfacerConf // Configuration
@@ -314,13 +315,15 @@ func dataKey(metricName string, labels []string) string {
 // metrics.Map value type:  We break Map values into multiple data keys, with
 // each map key corresponding to a label in the data key.
 // For example, "resp-code map:code 200:45 500:2" gets converted into:
-//   resp-code{code=200} 45
-//   resp-code{code=500}  2
+//
+//	resp-code{code=200} 45
+//	resp-code{code=500}  2
 //
 // metrics.String value type: We convert string value type into a data key with
 // val="value" label.
 // For example, "version cloudprober-20170608-RC00" gets converted into:
-//   version{val=cloudprober-20170608-RC00} 1
+//
+//	version{val=cloudprober-20170608-RC00} 1
 func (ps *PromSurfacer) record(em *metrics.EventMetrics) {
 	var labels []string
 	for _, k := range em.LabelsKeys() {
@@ -348,7 +351,7 @@ func (ps *PromSurfacer) record(em *metrics.EventMetrics) {
 			}
 			for _, k := range mapVal.Keys() {
 				labelsWithMap := append(labels, labelName+"=\""+k+"\"")
-				ps.recordMetric(pMetricName, dataKey(pMetricName, labelsWithMap), mapVal.GetKey(k).String(), em, "")
+				ps.recordMetric(pMetricName, dataKey(pMetricName, labelsWithMap), strconv.FormatInt(mapVal.GetKey(k), 10), em, "")
 			}
 			continue
 		}

--- a/surfacers/prometheus/prometheus_test.go
+++ b/surfacers/prometheus/prometheus_test.go
@@ -32,9 +32,9 @@ import (
 )
 
 func newEventMetrics(sent, rcvd int64, respCodes map[string]int64, ptype, probe string) *metrics.EventMetrics {
-	respCodesVal := metrics.NewMap("code", metrics.NewInt(0))
+	respCodesVal := metrics.NewMap("code")
 	for k, v := range respCodes {
-		respCodesVal.IncKeyBy(k, metrics.NewInt(v))
+		respCodesVal.IncKeyBy(k, v)
 	}
 	return metrics.NewEventMetrics(time.Now()).
 		AddMetric("sent", metrics.NewInt(sent)).
@@ -149,8 +149,8 @@ func TestRecord(t *testing.T) {
 
 func TestInvalidNames(t *testing.T) {
 	ps := newPromSurfacer(t, true)
-	respCodesVal := metrics.NewMap("resp-code", metrics.NewInt(0))
-	respCodesVal.IncKeyBy("200", metrics.NewInt(19))
+	respCodesVal := metrics.NewMap("resp-code")
+	respCodesVal.IncKeyBy("200", 19)
 	ps.record(metrics.NewEventMetrics(time.Now()).
 		AddMetric("sent", metrics.NewInt(32)).
 		AddMetric("rcvd/sent", metrics.NewInt(22)).
@@ -171,8 +171,8 @@ func TestInvalidNames(t *testing.T) {
 
 func TestScrapeOutput(t *testing.T) {
 	ps := newPromSurfacer(t, true)
-	respCodesVal := metrics.NewMap("code", metrics.NewInt(0))
-	respCodesVal.IncKeyBy("200", metrics.NewInt(19))
+	respCodesVal := metrics.NewMap("code")
+	respCodesVal.IncKeyBy("200", 19)
 	latencyVal := metrics.NewDistribution([]float64{1, 4})
 	latencyVal.AddSample(0.5)
 	latencyVal.AddSample(5)
@@ -209,8 +209,8 @@ func TestScrapeOutput(t *testing.T) {
 
 func TestScrapeOutputNoTimestamp(t *testing.T) {
 	ps := newPromSurfacer(t, false)
-	respCodesVal := metrics.NewMap("code", metrics.NewInt(0))
-	respCodesVal.IncKeyBy("200", metrics.NewInt(19))
+	respCodesVal := metrics.NewMap("code")
+	respCodesVal.IncKeyBy("200", 19)
 	latencyVal := metrics.NewDistribution([]float64{1, 4})
 	latencyVal.AddSample(0.5)
 	latencyVal.AddSample(5)

--- a/surfacers/stackdriver/stackdriver.go
+++ b/surfacers/stackdriver/stackdriver.go
@@ -268,6 +268,7 @@ func (s *SDSurfacer) writeBatch(ctx context.Context) {
 // it in the cache if batch processing is enabled, and returns it.
 //
 // More information on the object and specific fields can be found here:
+//
 //	https://cloud.google.com/monitoring/api/ref_v3/rest/v3/TimeSeries
 func (s *SDSurfacer) recordTimeSeries(metricKind, metricName, msgType string, labels map[string]string, timestamp time.Time, tv *monitoring.TypedValue, unit, cacheKey string) *monitoring.TimeSeries {
 	startTime := s.startTime.Format(time.RFC3339Nano)
@@ -328,10 +329,10 @@ func (s *SDSurfacer) sdKind(kind metrics.Kind) string {
 }
 
 // processLabels processes EventMetrics labels to generate:
-//	- a map of label key values to use in StackDriver timeseries,
-//	- a labels key of the form label1_key=label1_val,label2_key=label2_val,
-//	  used for caching.
-//	- prefix for metric names, usually <ptype>/<probe>.
+//   - a map of label key values to use in StackDriver timeseries,
+//   - a labels key of the form label1_key=label1_val,label2_key=label2_val,
+//     used for caching.
+//   - prefix for metric names, usually <ptype>/<probe>.
 func (s *SDSurfacer) processLabels(em *metrics.EventMetrics) (labels map[string]string, labelsKey, metricPrefix string) {
 	labels = make(map[string]string)
 	var sortedLabels []string // we use this for cache key below
@@ -339,7 +340,7 @@ func (s *SDSurfacer) processLabels(em *metrics.EventMetrics) (labels map[string]
 	metricPrefixConfig := s.c.GetMetricsPrefix()
 	usePType := true && metricPrefixConfig == configpb.SurfacerConf_PTYPE_PROBE
 	useProbe := true && metricPrefixConfig == configpb.SurfacerConf_PTYPE_PROBE ||
-									metricPrefixConfig == configpb.SurfacerConf_PROBE
+		metricPrefixConfig == configpb.SurfacerConf_PROBE
 	for _, k := range em.LabelsKeys() {
 		if k == "ptype" && usePType {
 			ptype = em.Label(k)
@@ -453,7 +454,7 @@ func (s *SDSurfacer) recordEventMetrics(em *metrics.EventMetrics) (ts []*monitor
 					mmLabels[lk] = lv
 				}
 				mmLabels[mapValue.MapName] = mapKey
-				f := float64(mapValue.GetKey(mapKey).Int64())
+				f := float64(mapValue.GetKey(mapKey))
 				ts = append(ts, s.recordTimeSeries(metricKind, name, "DOUBLE", mmLabels, em.Timestamp, &monitoring.TypedValue{DoubleValue: &f}, unit, cacheKey))
 			}
 			continue
@@ -479,6 +480,7 @@ func (s *SDSurfacer) recordEventMetrics(em *metrics.EventMetrics) (ts []*monitor
 // prefix are longer than 100 characters, which is illegal in a Stackdriver
 // call. Stack Driver doesn't allow custom metrics with more than 100 character
 // names, so we have a check to see if we are going over the limit.
+//
 //	Ref: https://cloud.google.com/monitoring/api/v3/metrics#metric_names
 func validMetricLength(metricName string, monitoringURL string) bool {
 	return len(metricName)+len(monitoringURL) <= 100

--- a/surfacers/stackdriver/stackdriver_test.go
+++ b/surfacers/stackdriver/stackdriver_test.go
@@ -19,11 +19,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/metrics"
-	"github.com/kylelemons/godebug/pretty"
 	configpb "github.com/cloudprober/cloudprober/surfacers/stackdriver/proto"
+	"github.com/golang/protobuf/proto"
+	"github.com/kylelemons/godebug/pretty"
 	monitoring "google.golang.org/api/monitoring/v3"
 )
 
@@ -49,7 +49,7 @@ func newTestSurfacer() SDSurfacer {
 }
 
 func TestProcessLabels(t *testing.T) {
-	s:= newTestSurfacer()
+	s := newTestSurfacer()
 	s.c = &configpb.SurfacerConf{
 		MetricsPrefix: configpb.SurfacerConf_PTYPE_PROBE.Enum(),
 		MonitoringUrl: proto.String("custom.googleapis.com/cloudprober/"),
@@ -59,14 +59,14 @@ func TestProcessLabels(t *testing.T) {
 	testPtype := "external"
 
 	tests := []struct {
-		description string
+		description        string
 		metricPrefixConfig *configpb.SurfacerConf_MetricPrefix
-		em          *metrics.EventMetrics
-		wantKeys    string
-		wantMetricPrefix string
+		em                 *metrics.EventMetrics
+		wantKeys           string
+		wantMetricPrefix   string
 	}{
 		{
-			description: "metrics prefix with ptype and probe",
+			description:        "metrics prefix with ptype and probe",
 			metricPrefixConfig: configpb.SurfacerConf_PTYPE_PROBE.Enum(),
 			em: metrics.NewEventMetrics(testTimestamp).
 				AddMetric("test_metric", metrics.NewString("metval")).
@@ -74,11 +74,11 @@ func TestProcessLabels(t *testing.T) {
 				AddLabel("keyB", "valueB").
 				AddLabel("probe", testProbe).
 				AddLabel("ptype", testPtype),
-			wantKeys: "keyA=valueA,keyB=valueB",
+			wantKeys:         "keyA=valueA,keyB=valueB",
 			wantMetricPrefix: "external/test_probe/",
 		},
 		{
-			description: "metrics prefix with only probe",
+			description:        "metrics prefix with only probe",
 			metricPrefixConfig: configpb.SurfacerConf_PROBE.Enum(),
 			em: metrics.NewEventMetrics(testTimestamp).
 				AddMetric("test_metric", metrics.NewString("metval")).
@@ -86,11 +86,11 @@ func TestProcessLabels(t *testing.T) {
 				AddLabel("keyB", "valueB").
 				AddLabel("probe", testProbe).
 				AddLabel("ptype", testPtype),
-			wantKeys: "keyA=valueA,keyB=valueB,ptype=external",
+			wantKeys:         "keyA=valueA,keyB=valueB,ptype=external",
 			wantMetricPrefix: "test_probe/",
 		},
 		{
-			description: "metrics prefix with none",
+			description:        "metrics prefix with none",
 			metricPrefixConfig: configpb.SurfacerConf_NONE.Enum(),
 			em: metrics.NewEventMetrics(testTimestamp).
 				AddMetric("test_metric", metrics.NewString("metval")).
@@ -98,7 +98,7 @@ func TestProcessLabels(t *testing.T) {
 				AddLabel("keyB", "valueB").
 				AddLabel("probe", testProbe).
 				AddLabel("ptype", testPtype),
-			wantKeys: "keyA=valueA,keyB=valueB,probe=test_probe,ptype=external",
+			wantKeys:         "keyA=valueA,keyB=valueB,probe=test_probe,ptype=external",
 			wantMetricPrefix: "",
 		},
 	}
@@ -127,9 +127,9 @@ func TestTimeSeries(t *testing.T) {
 	// Following variables are used for map value testing.
 	mapValue200 := float64(98)
 	mapValue500 := float64(2)
-	mapVal := metrics.NewMap("code", metrics.NewInt(0))
-	mapVal.IncKeyBy("200", metrics.NewInt(int64(mapValue200)))
-	mapVal.IncKeyBy("500", metrics.NewInt(int64(mapValue500)))
+	mapVal := metrics.NewMap("code")
+	mapVal.IncKeyBy("200", 98)
+	mapVal.IncKeyBy("500", 2)
 
 	tests := []struct {
 		description string

--- a/validators/validators.go
+++ b/validators/validators.go
@@ -138,11 +138,11 @@ func RunValidators(vs []*Validator, input *Input, validationFailure *metrics.Map
 
 // ValidationFailureMap returns an initialized validation failures map.
 func ValidationFailureMap(vs []*Validator) *metrics.Map {
-	m := metrics.NewMap("validator", metrics.NewInt(0))
+	m := metrics.NewMap("validator")
 	// Initialize validation failure map with validator keys, so that we always
 	// export the metrics.
 	for _, v := range vs {
-		m.IncKeyBy(v.Name, metrics.NewInt(0))
+		m.IncKeyBy(v.Name, 0)
 	}
 	return m
 }

--- a/validators/validators_test.go
+++ b/validators/validators_test.go
@@ -34,11 +34,11 @@ func TestRunValidators(t *testing.T) {
 	vfMap := ValidationFailureMap(testValidators)
 	failures := RunValidators(testValidators, &Input{}, vfMap, nil)
 
-	if vfMap.GetKey("test-v1").Int64() != 0 {
+	if vfMap.GetKey("test-v1") != 0 {
 		t.Error("Got unexpected test-v1 validation failure.")
 	}
 
-	if vfMap.GetKey("test-v2").Int64() != 1 {
+	if vfMap.GetKey("test-v2") != 1 {
 		t.Errorf("Didn't get expected test-v2 validation failure.")
 	}
 


### PR DESCRIPTION
Map implementation is complex and expensive primarily to deal with both int64 and float64 values. Map is used almost always as a counter (e.g. resp-code, validation failure map), except for external probe output parsing where we can encounter a float map.

To simplify the Map implementation, split it into two implementations: `Map` (for int64 counters) and `MapFloat` (for any float64 values map).