### PR TITLE
[metrics] Remove (now) unnecessary metric size check.

### DIFF
--- a/prober/prober.go
+++ b/prober/prober.go
@@ -44,7 +44,6 @@ import (
 	"github.com/cloudprober/cloudprober/targets"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
 	"github.com/cloudprober/cloudprober/targets/lameduck"
-	"github.com/golang/glog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -212,11 +211,6 @@ func (pr *Prober) Start(ctx context.Context) {
 		var em *metrics.EventMetrics
 		for {
 			em = <-pr.dataChan
-			var s = em.String()
-			if len(s) > logger.MaxLogEntrySize {
-				glog.Warningf("Metric entry for timestamp %v dropped due to large size: %d", em.Timestamp, len(s))
-				continue
-			}
 
 			// Replicate the surfacer message to every surfacer we have
 			// registered. Note that s.Write() is expected to be


### PR DESCRIPTION
* This check is wasteful. Eventmetrics to String conversion is not cheap.
* This is the commit that introduced this check: https://github.com/cloudprober/cloudprober/commit/b1147ad723a2bedf6ba441717b95212a44907e4f
* Here is more context on this check:
https://github.com/cloudprober/cloudprober/blob/33b78ba5b89953a0bea4d38f8cd5f0c8cfb8e858/logger/logger.go#L69
 (Note: I think it's okay to continue to check logs for really big lines as there is nothing wasteful there)