### PR TITLE
[metrics.latency] Add a new value type LatencyValue

### DIFF
--- a/docs/content/docs/how-to/extensions.md
+++ b/docs/content/docs/how-to/extensions.md
@@ -6,22 +6,22 @@ menu:
 title: "Extending Cloudprober"
 ---
 
-Cloudprober allows you to extend it across "probe" and "target" dimensions,
-that is, you can add new probe and target types to it without having to fork
-the entire codebase. Note that to extend cloudprober in this way, you will have
-to maintain your own cloudprober binary (which is mostly a wrapper around the
+Cloudprober allows you to extend it across "probe" and "target" dimensions, that
+is, you can add new probe and target types to it without having to fork the
+entire codebase. Note that to extend cloudprober in this way, you will have to
+maintain your own cloudprober binary (which is mostly a wrapper around the
 "cloudprober package"), but you'll be able to use rest of the cloudprober code
 from the common location.
 
 ## Sample probe type
 
 To demonstrate how it works, let's add a new probe-type to Cloudprober. We'll
-take the sample redis probe that we added in the
-[external probe how-to]({{< ref "external-probe/index.md#sample-probe" >}}),
-and convert it into a probe type that one can easily re-use. Let's say that
-this probe-type provides a way to test redis server functionality and it takes
-the following options - operation (GET vs SET vs DELETE), key, value. This
-probe's configuration looks like this:
+take the sample redis probe that we added in the [external probe
+how-to]({{< ref "external-probe/index.md#sample-probe" >}}), and convert it into
+a probe type that one can easily re-use. Let's say that this probe-type provides
+a way to test redis server functionality and it takes the following options -
+operation (GET vs SET vs DELETE), key, value. This probe's configuration looks
+like this:
 
 ```bash
 probe {
@@ -43,8 +43,8 @@ To make cloudprober understand this config, we'll have to do a few things:
 - Define the probe config in a protobuf (.proto) file and mark it as an
   extension of the overall config.
 
-- Implement the probe type, possibly as a Go package, even though it can
-  be embedded directly into the top-level binary.
+- Implement the probe type, possibly as a Go package, even though it can be
+  embedded directly into the top-level binary.
 
 - Create a new cloudprober binary that includes the new probe type package.
 
@@ -88,7 +88,8 @@ myprobe.pb.go  myprobe.proto
 ## Implement the probe type
 
 Now let's implement our probe type. Our probe type should implement the
-[probes.Probe](https://godoc.org/github.com/cloudprober/cloudprober/probes#Probe) interface.
+[probes.Probe](https://godoc.org/github.com/cloudprober/cloudprober/probes#Probe)
+interface.
 
 ```go
 package myprobe
@@ -143,15 +144,16 @@ func (p *Probe) runProbe(ctx context.Context) {
 
     go func(target string, em *metrics.EventMetrics) {
       defer wg.Done()
-      em.Metric("total").AddInt64(1)
+      em.Metric("total").(*metrics.Int).Inc()
       start := time.Now()
       err := p.runProbeForTarget(ctx, target) // run probe just for a single target
       if err != nil {
         p.l.Errorf(err.Error())
         return
       }
-      em.Metric("success").AddInt64(1)
-      em.Metric("latency").AddFloat64(time.Now().Sub(start).Seconds() / p.opts.LatencyUnit.Seconds())
+      em.Metric("success").(*metrics.Int).Inc()
+      em.Metric("latency").(metrics.LatencyValue).AddFloat64(
+        time.Since(start).   Seconds() / p.opts.LatencyUnit.Seconds())
     }(target, p.res[target])
 
   }

--- a/examples/extensions/myprober/myprobe/myprobe.go
+++ b/examples/extensions/myprober/myprobe/myprobe.go
@@ -120,14 +120,14 @@ func (p *Probe) runProbe(ctx context.Context) {
 			defer wg.Done()
 			start := time.Now()
 			em.Timestamp = start
-			em.Metric("total").AddInt64(1)
+			em.Metric("total").(*metrics.Int).Inc()
 			err := p.runProbeForTarget(ctx, target) // run probe just for a single target
 			if err != nil {
 				p.l.Errorf(err.Error())
 				return
 			}
-			em.Metric("success").AddInt64(1)
-			em.Metric("latency").AddFloat64(time.Now().Sub(start).Seconds() / p.opts.LatencyUnit.Seconds())
+			em.Metric("success").(*metrics.Int).Inc()
+			em.Metric("latency").(metrics.LatencyValue).AddFloat64(time.Since(start).Seconds() / p.opts.LatencyUnit.Seconds())
 		}(target, p.res[target.Name])
 	}
 

--- a/metrics/dist.go
+++ b/metrics/dist.go
@@ -326,14 +326,17 @@ func (d *Distribution) StackdriverTypedValue() *monitoring.TypedValue {
 }
 
 // Clone returns a copy of the receiver distribution.
-func (d *Distribution) Clone() Value {
+func (d *Distribution) CloneDist() *Distribution {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	newD := NewDistribution(d.lowerBounds[1:])
 	newD.sum = d.sum
 	newD.count = d.count
-	for i := range d.bucketCounts {
-		newD.bucketCounts[i] = d.bucketCounts[i]
-	}
+	copy(newD.bucketCounts, d.bucketCounts)
 	return newD
+}
+
+// Clone returns a copy of the receiver distribution.
+func (d *Distribution) Clone() Value {
+	return d.CloneDist()
 }

--- a/metrics/dist.go
+++ b/metrics/dist.go
@@ -110,11 +110,6 @@ func (d *Distribution) AddSample(sample float64) {
 	d.count++
 }
 
-// AddInt64 adds an int64 to the receiver distribution.
-func (d *Distribution) AddInt64(i int64) {
-	d.AddSample(float64(i))
-}
-
 // AddFloat64 adds an float64 to the receiver distribution.
 func (d *Distribution) AddFloat64(f float64) {
 	d.AddSample(f)

--- a/metrics/eventmetrics_test.go
+++ b/metrics/eventmetrics_test.go
@@ -67,10 +67,6 @@ func verifyEventMetrics(t *testing.T, m *EventMetrics, sent, rcvd, rtt int64, re
 }
 
 func TestEventMetricsUpdate(t *testing.T) {
-	rttVal := NewInt(0)
-	rttVal.Str = func(i int64) string {
-		return fmt.Sprintf("%.3f", float64(i)/1000)
-	}
 	m := newEventMetrics(0, 0, 0, make(map[string]int64))
 	m.AddLabel("ptype", "http")
 
@@ -114,10 +110,6 @@ func TestEventMetricsUpdate(t *testing.T) {
 }
 
 func TestEventMetricsSubtractCounters(t *testing.T) {
-	rttVal := NewInt(0)
-	rttVal.Str = func(i int64) string {
-		return fmt.Sprintf("%.3f", float64(i)/1000)
-	}
 	m := newEventMetrics(10, 10, 1000, make(map[string]int64))
 	m.AddLabel("ptype", "http")
 

--- a/metrics/float.go
+++ b/metrics/float.go
@@ -56,12 +56,6 @@ func (f *Float) Inc() {
 	f.f++
 }
 
-// IncBy increments the receiver Float by "delta" NumValue.
-// It's part of the NumValue interface.
-func (f *Float) IncBy(delta NumValue) {
-	f.f += delta.Float64()
-}
-
 // Add adds a Value to the receiver Float. If Value is not Float, an error is returned.
 // It's part of the Value interface.
 func (f *Float) Add(val Value) error {
@@ -89,11 +83,6 @@ func (f *Float) SubtractCounter(lastVal Value) (bool, error) {
 	return false, nil
 }
 
-// AddInt64 adds an int64 to the receiver Float.
-func (f *Float) AddInt64(i int64) {
-	f.f += float64(i)
-}
-
 // AddFloat64 adds a float64 to the receiver Float.
 func (f *Float) AddFloat64(ff float64) {
 	f.f += ff
@@ -107,7 +96,7 @@ func FloatToString(f float64) string {
 // It's part of the Value interface.
 func (f *Float) String() string {
 	if f.Str != nil {
-		return f.Str(f.Float64())
+		return f.Str(f.f)
 	}
 	return FloatToString(f.f)
 }

--- a/metrics/int.go
+++ b/metrics/int.go
@@ -56,8 +56,8 @@ func (i *Int) Inc() {
 
 // IncBy increments the receiver Int by "delta" NumValue.
 // It's part of the NumValue interface.
-func (i *Int) IncBy(delta NumValue) {
-	i.i += delta.Int64()
+func (i *Int) IncBy(delta int64) {
+	i.i += delta
 }
 
 // Add adds a Value to the receiver Int. If Value is not Int, an error is returned.

--- a/metrics/int.go
+++ b/metrics/int.go
@@ -24,8 +24,6 @@ import (
 // safe, if you want a concurrency safe integer NumValue, use AtomicInt.
 type Int struct {
 	i int64
-	// If Str is defined, this is method used to convert Int into a string.
-	Str func(int64) string
 }
 
 // NewInt returns a new Int
@@ -36,8 +34,7 @@ func NewInt(i int64) *Int {
 // Clone returns a copy the receiver Int
 func (i *Int) Clone() Value {
 	return &Int{
-		i:   i.i,
-		Str: i.Str,
+		i: i.i,
 	}
 }
 
@@ -91,22 +88,9 @@ func (i *Int) SubtractCounter(lastVal Value) (bool, error) {
 	return false, nil
 }
 
-// AddInt64 adds an int64 to the receiver Int.
-func (i *Int) AddInt64(ii int64) {
-	i.i += ii
-}
-
-// AddFloat64 adds a float64 to the receiver Int.
-func (i *Int) AddFloat64(f float64) {
-	i.i += int64(f)
-}
-
 // String returns the string representation of Int.
 // It's part of the Value interface.
 func (i *Int) String() string {
-	if i.Str != nil {
-		return i.Str(i.Int64())
-	}
 	return strconv.FormatInt(i.Int64(), 10)
 }
 
@@ -185,16 +169,6 @@ func (i *AtomicInt) SubtractCounter(lastVal Value) (bool, error) {
 	}
 	atomic.StoreInt64(&i.i, valS-lvS)
 	return false, nil
-}
-
-// AddInt64 adds an int64 to the receiver Int.
-func (i *AtomicInt) AddInt64(ii int64) {
-	atomic.AddInt64(&i.i, ii)
-}
-
-// AddFloat64 adds a float64 to the receiver Int.
-func (i *AtomicInt) AddFloat64(f float64) {
-	atomic.AddInt64(&i.i, int64(f))
 }
 
 // String returns the string representation of AtomicInt.

--- a/metrics/map.go
+++ b/metrics/map.go
@@ -178,18 +178,6 @@ func (m *Map[T]) addOrSubtract(val Value, subtract bool) (bool, error) {
 	return false, nil
 }
 
-// AddInt64 generates a panic for the Map type. This is added only to satisfy
-// the Value interface.
-func (m *Map[T]) AddInt64(i int64) {
-	panic("Map type doesn't implement AddInt64()")
-}
-
-// AddFloat64 generates a panic for the Map type. This is added only to
-// satisfy the Value interface.
-func (m *Map[T]) AddFloat64(f float64) {
-	panic("Map type doesn't implement AddFloat64()")
-}
-
 func MapValueToString[T Number](v T) string {
 	if f, ok := any(v).(float64); ok {
 		return FloatToString(f)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -39,7 +39,6 @@ type NumValue interface {
 	Value
 	Int64() int64
 	Float64() float64
-	IncBy(delta NumValue)
 }
 
 type LatencyValue interface {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -25,8 +25,6 @@ import (
 type Value interface {
 	Clone() Value
 	Add(delta Value) error
-	AddInt64(i int64)
-	AddFloat64(f float64)
 	String() string
 
 	// SubtractCounter subtracts the provided "lastVal", assuming that value
@@ -39,10 +37,14 @@ type Value interface {
 // It's a superset of Value interface.
 type NumValue interface {
 	Value
-	Inc()
 	Int64() int64
 	Float64() float64
 	IncBy(delta NumValue)
+}
+
+type LatencyValue interface {
+	Value
+	AddFloat64(float64)
 }
 
 // ParseValueFromString parses a value from its string representation

--- a/metrics/string.go
+++ b/metrics/string.go
@@ -39,18 +39,6 @@ func (s String) SubtractCounter(val Value) (bool, error) {
 	return false, errors.New("string value type doesn't support SubtractCounter() operation")
 }
 
-// AddInt64 generates a panic for the String type. This is added only to satisfy
-// the Value interface.
-func (s String) AddInt64(i int64) {
-	panic("String type doesn't implement AddInt64()")
-}
-
-// AddFloat64 generates a panic for the String type. This is added only to
-// satisfy the Value interface.
-func (s String) AddFloat64(f float64) {
-	panic("String type doesn't implement AddFloat64()")
-}
-
 // String simply returns the stored string.
 func (s String) String() string {
 	return "\"" + s.s + "\""

--- a/probes/common/statskeeper/statskeeper_test.go
+++ b/probes/common/statskeeper/statskeeper_test.go
@@ -82,7 +82,7 @@ func TestStatsKeeper(t *testing.T) {
 		prr := newProbeRunResult(target.Name)
 		prr.sent.Inc()
 		prr.rcvd.Inc()
-		prr.rtt.IncBy(metrics.NewInt(20000))
+		prr.rtt.IncBy(20000)
 		resultsChan <- prr
 	}
 	time.Sleep(3 * time.Second)

--- a/probes/dns/dns.go
+++ b/probes/dns/dns.go
@@ -92,7 +92,7 @@ type probeRunResult struct {
 	target            string
 	total             metrics.Int
 	success           metrics.Int
-	latency           metrics.Value
+	latency           metrics.LatencyValue
 	timeouts          metrics.Int
 	validationFailure *metrics.Map[int64]
 	latencyMetricName string
@@ -212,7 +212,7 @@ func (p *Probe) runProbe(resultsChan chan<- statskeeper.ProbeResult) {
 			}
 
 			if p.opts.LatencyDist != nil {
-				result.latency = p.opts.LatencyDist.Clone()
+				result.latency = p.opts.LatencyDist.CloneDist()
 			} else {
 				result.latency = metrics.NewFloat(0)
 			}

--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -69,7 +69,7 @@ var (
 
 type result struct {
 	total, success    int64
-	latency           metrics.Value
+	latency           metrics.LatencyValue
 	validationFailure *metrics.Map[int64]
 }
 
@@ -579,9 +579,9 @@ func (p *Probe) updateTargets() {
 			continue
 		}
 
-		var latencyValue metrics.Value
+		var latencyValue metrics.LatencyValue
 		if p.opts.LatencyDist != nil {
-			latencyValue = p.opts.LatencyDist.Clone()
+			latencyValue = p.opts.LatencyDist.CloneDist()
 		} else {
 			latencyValue = metrics.NewFloat(0)
 		}

--- a/probes/grpc/grpc.go
+++ b/probes/grpc/grpc.go
@@ -97,7 +97,7 @@ type probeRunResult struct {
 	target        string
 	total         metrics.Int
 	success       metrics.Int
-	latency       metrics.Value
+	latency       metrics.LatencyValue
 	connectErrors metrics.Int
 }
 
@@ -389,9 +389,9 @@ func (p *Probe) oneTargetLoop(ctx context.Context, tgt endpoint.Endpoint, index 
 }
 
 func (p *Probe) newResult(tgt string) *probeRunResult {
-	var latencyValue metrics.Value
+	var latencyValue metrics.LatencyValue
 	if p.opts.LatencyDist != nil {
-		latencyValue = p.opts.LatencyDist.Clone()
+		latencyValue = p.opts.LatencyDist.CloneDist()
 	} else {
 		latencyValue = metrics.NewFloat(0)
 	}

--- a/probes/grpc/grpc.go
+++ b/probes/grpc/grpc.go
@@ -338,7 +338,7 @@ func (p *Probe) oneTargetLoop(ctx context.Context, tgt endpoint.Endpoint, index 
 		reqCtx, cancelFunc := context.WithTimeout(ctx, timeout)
 		reqCtx = p.ctxWithHeaders(reqCtx)
 
-		var success int64
+		var success bool
 		var delta time.Duration
 		start := time.Now()
 		var err error
@@ -376,13 +376,15 @@ func (p *Probe) oneTargetLoop(ctx context.Context, tgt endpoint.Endpoint, index 
 			}
 			p.l.Warningf("ProbeId(%s) request failed: %v. ConnState: %v. Peer: %v", msgPattern, err, conn.GetState(), peerAddr)
 		} else {
-			success = 1
+			success = true
 			delta = time.Since(start)
 		}
 		// TODO(ls692): add validators for probe result.
 		result.Lock()
 		result.total.Inc()
-		result.success.AddInt64(success)
+		if success {
+			result.success.Inc()
+		}
 		result.latency.AddFloat64(delta.Seconds() / p.opts.LatencyUnit.Seconds())
 		result.Unlock()
 	}

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -90,7 +90,7 @@ type Probe struct {
 type probeResult struct {
 	total, success, timeouts     int64
 	connEvent                    int64
-	latency                      metrics.Value
+	latency                      metrics.LatencyValue
 	respCodes                    *metrics.Map[int64]
 	respBodies                   *metrics.Map[int64]
 	validationFailure            *metrics.Map[int64]
@@ -372,7 +372,7 @@ func (p *Probe) newResult() *probeResult {
 	}
 
 	if p.opts.LatencyDist != nil {
-		result.latency = p.opts.LatencyDist.Clone()
+		result.latency = p.opts.LatencyDist.CloneDist()
 	} else {
 		result.latency = metrics.NewFloat(0)
 	}

--- a/probes/ping/ping.go
+++ b/probes/ping/ping.go
@@ -71,7 +71,7 @@ const (
 
 type result struct {
 	sent, rcvd        int64
-	latency           metrics.Value
+	latency           metrics.LatencyValue
 	validationFailure *metrics.Map[int64]
 }
 
@@ -251,9 +251,9 @@ func (p *Probe) updateResultForTarget(t string) {
 		return
 	}
 
-	var latencyValue metrics.Value
+	var latencyValue metrics.LatencyValue
 	if p.opts.LatencyDist != nil {
-		latencyValue = p.opts.LatencyDist.Clone()
+		latencyValue = p.opts.LatencyDist.CloneDist()
 	} else {
 		latencyValue = metrics.NewFloat(0)
 	}

--- a/probes/tcp/tcp.go
+++ b/probes/tcp/tcp.go
@@ -45,7 +45,7 @@ type Probe struct {
 
 type probeResult struct {
 	total, success    int64
-	latency           metrics.Value
+	latency           metrics.LatencyValue
 	validationFailure *metrics.Map[int64]
 }
 
@@ -57,7 +57,7 @@ func (p *Probe) newResult() sched.ProbeResult {
 	}
 
 	if p.opts.LatencyDist != nil {
-		result.latency = p.opts.LatencyDist.Clone()
+		result.latency = p.opts.LatencyDist.CloneDist()
 	} else {
 		result.latency = metrics.NewFloat(0)
 	}

--- a/probes/udp/udp.go
+++ b/probes/udp/udp.go
@@ -86,7 +86,7 @@ type Probe struct {
 // That's the reason we use metrics.Int types instead of metrics.AtomicInt.
 type probeResult struct {
 	total, success, delayed int64
-	latency                 metrics.Value
+	latency                 metrics.LatencyValue
 	target                  endpoint.Endpoint
 }
 
@@ -118,9 +118,9 @@ func (prr probeResult) eventMetrics(probeName string, opts *options.Options, f f
 }
 
 func (p *Probe) newProbeResult(target endpoint.Endpoint) *probeResult {
-	var latVal metrics.Value
+	var latVal metrics.LatencyValue
 	if p.opts.LatencyDist != nil {
-		latVal = p.opts.LatencyDist.Clone()
+		latVal = p.opts.LatencyDist.CloneDist()
 	} else {
 		latVal = metrics.NewFloat(0)
 	}

--- a/probes/udplistener/udplistener.go
+++ b/probes/udplistener/udplistener.go
@@ -239,9 +239,9 @@ func (p *Probe) processMessage(buf []byte, rxTS time.Time, srcAddr *net.UDPAddr)
 	probeRes.total.Inc()
 	if msgRes.Success {
 		probeRes.success.Inc()
-		probeRes.ipdUS.IncBy(metrics.NewInt(msgRes.InterPktDelay.Nanoseconds() / 1000))
+		probeRes.ipdUS.IncBy(msgRes.InterPktDelay.Nanoseconds() / 1000)
 	} else if msgRes.LostCount > 0 {
-		probeRes.lost.IncBy(metrics.NewInt(int64(msgRes.LostCount)))
+		probeRes.lost.IncBy(int64(msgRes.LostCount))
 	} else if msgRes.Delayed {
 		probeRes.delayed.Inc()
 	}
@@ -254,7 +254,7 @@ func (p *Probe) outputResults(expectedCt int64, stats chan<- statskeeper.ProbeRe
 	for _, r := range p.res {
 		delta := expectedCt - r.total.Int64()
 		if delta > 0 {
-			r.total.AddInt64(delta)
+			r.total.IncBy(delta)
 		}
 		stats <- *r
 	}


### PR DESCRIPTION
Changes:
* Remove `AddInt64` and `AddFloat64` from the Value interface. This lets us clean up all the implementations.
* Introduce a new interface type LatencyValue that supports the Values interface and `AddFloat64()`. Only Float and Distribution types need to meet this interface. As the name says, this interface will be used for latency values.
* Remove `Inc` and `IncBy` from the NumValue interface. Only "Int" type needs to support these methods.
* Add CloneDist method to Distribution type and use that instead of generic Clone() method that returns a Value.