### PR TITLE
[website] A few fixes to the website.

### DIFF
--- a/docs/content/docs/how-to/k8s_targets.md
+++ b/docs/content/docs/how-to/k8s_targets.md
@@ -2,15 +2,14 @@
 menu:
   docs:
     parent: "how-to"
-    weight: 11
+    weight: 12
 title: "Kubernetes Targets"
 date: 2022-11-01T17:24:32-07:00
 ---
 
-If you're running on Kubernetes, you'd probably want to monitor Kubernetes
-resources (e.g. pods, endpoints, ingresses, etc) as well. Cloudprober supports
-[dynamic discovery]({{< ref targets.md >}}#dynamically-discovered-targets) of
-Kubernetes resources through the targets type
+Cloudprober supports [dynamic
+discovery]({{< ref targets.md >}}#dynamically-discovered-targets) of Kubernetes
+resources (e.g. pods, endpoints, ingresses, etc) through the targets type
 [`k8s`](https://github.com/cloudprober/cloudprober/blob/ad73fe489ea3ac69e7b0f81a465671df9adc8321/targets/proto/targets.proto#L40).
 
 For example, the following config adds an HTTP probe for the endpoints named

--- a/docs/content/docs/how-to/targets/index.md
+++ b/docs/content/docs/how-to/targets/index.md
@@ -3,7 +3,7 @@ menu:
   docs:
     parent: how-to
     name: "Targets"
-    weight: 12
+    weight: 11
 title: "Targets"
 date: 2016-10-25T17:24:32-07:00
 ---
@@ -114,7 +114,7 @@ don't want to rely on DNS for resolving its IP address.
 ### K8s targets
 
 K8s targets are explained at [Kubernetes
-Targets]({{< ref run-on-kubernetes.md >}}#kubernetes-targets).
+Targets]({{< ref k8s_targets.md >}}#kubernetes-targets).
 
 ### GCP targets
 

--- a/docs/content/docs/overview/cloudprober/index.md
+++ b/docs/content/docs/overview/cloudprober/index.md
@@ -11,17 +11,26 @@ title: Overview
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=cloudprober_cloudprober&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=cloudprober_cloudprober)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=cloudprober_cloudprober&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=cloudprober_cloudprober)
 
-Cloudprober is a monitoring software that makes it super-easy to monitor
-availability and performance of various components of your system. Cloudprober
-uses the "active" monitoring model. It runs probes against (or on) your
-components to verify that they are working as expected. For example, it can run
-a probe to verify that your frontends can reach your backends. Similarly it can
-run a probe to verify that your in-Cloud VMs can actually reach your on-premise
-systems. This kind of monitoring makes it possible to monitor your systems'
-interfaces regardless of the implementation and helps you quickly pin down
-what's broken in your system.
+Cloudprober provides a reliable and easy-to-use solution to monitor the
+availability and performance of your systems. Employing an "active" monitoring
+approach, Cloudprober executes probes on or against these systems to verify
+their proper functioning.
+
+For example, you could use Cloudprober to run a probe to verify that your users
+can access your website and your APIs, your microservices can talk to each
+other, your kubernetes clusters can schedule pods, your CI/CD pipelines are
+functioning as epxected, or VPN connectivity with your partners is working as
+expected, and much more.
+
+This kind of monitoring makes it possible to monitor your systems' interfaces
+regardless of the implementation, and helps you quickly pin down what's broken
+in your systems.
+
+<br/>
 
 ![Cloudprober Use Case](http://cloudprober.org/diagrams/cloudprober_use_case.svg)
+
+<br/>
 
 ## Features
 


### PR DESCRIPTION
- Reduce duplication of the K8s targets content. Within the running on K8s page, link to the K8s targets page, instead of duplicating it.
- Change the overview page's first paragraph a bit to make it less dense.