### PR TITLE
[probes.grpc] Disable gRPC XDS support by default.

### DIFF
--- a/probes/grpc/grpc.go
+++ b/probes/grpc/grpc.go
@@ -57,8 +57,6 @@ import (
 
 	// Import grpclb module so it can be used by name for DirectPath connections.
 	_ "google.golang.org/grpc/balancer/grpclb"
-	// Register google-c2p resolver for Traffic Director
-	_ "google.golang.org/grpc/xds/googledirectpath"
 )
 
 const loadBalancingPolicy = `{"loadBalancingConfig":[{"grpclb":{"childPolicy":[{"pick_first":{}}]}}]}`

--- a/probes/grpc/grpc_xds.go
+++ b/probes/grpc/grpc_xds.go
@@ -1,0 +1,21 @@
+// Copyright 2023 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// To build xds support, use '-tags grpc_xds' flag.
+//go:build grpc_xds
+
+package grpc
+
+// Register google-c2p resolver for Traffic Director
+import _ "google.golang.org/grpc/xds/googledirectpath"


### PR DESCRIPTION
* gRPC XDS is not used widely, but if you really need it you can enable it by building cloudprober with the `-tags grpc_xds` flag.
* This reduces cloudprober binary file size by 25% (41M -> 31M). I think it's criminal for a package to add that much to the binary size.