### PR TITLE
Make the order of evaluation logical for routing key

### DIFF
--- a/probes/alerting/notifier/pagerduty/pagerduty.go
+++ b/probes/alerting/notifier/pagerduty/pagerduty.go
@@ -64,17 +64,17 @@ func New(pagerdutycfg *configpb.PagerDuty, l *logger.Logger) (*Client, error) {
 
 // lookupRoutingKey looks up the routing key to use for the PagerDuty client,
 // in order of precendence:
-// 1. Routing key environment variable
-// 2. Routing key in the config
+// 1. Routing key supplied by the user in the config
+// 2. Routing key environment variable
 func lookupRoutingKey(pagerdutycfg *configpb.PagerDuty) (string, error) {
-	// check if the environment variable is set for the routing key
-	if routingKey, exists := os.LookupEnv(routingKeyEnvVar(pagerdutycfg)); exists {
-		return routingKey, nil
-	}
-
 	// check if the user supplied a routing key
 	if pagerdutycfg.GetRoutingKey() != "" {
 		return pagerdutycfg.GetRoutingKey(), nil
+	}
+
+	// check if the environment variable is set for the routing key
+	if routingKey, exists := os.LookupEnv(routingKeyEnvVar(pagerdutycfg)); exists {
+		return routingKey, nil
 	}
 
 	return "", fmt.Errorf("No routing key found")

--- a/probes/alerting/notifier/pagerduty/pagerduty_test.go
+++ b/probes/alerting/notifier/pagerduty/pagerduty_test.go
@@ -300,7 +300,7 @@ func TestGenerateLinks(t *testing.T) {
 	}
 }
 
-func TestLookupRoutingKey(t *testing.T) {
+func TestPagerDutyLookupRoutingKey(t *testing.T) {
 	tests := map[string]struct {
 		pagerdutyConfig *configpb.PagerDuty
 		env             map[string]string
@@ -331,7 +331,7 @@ func TestLookupRoutingKey(t *testing.T) {
 			want:            "",
 			wantErr:         true,
 		},
-		"env_var_overrides_config": {
+		"config_overrides_env_var": {
 			pagerdutyConfig: &configpb.PagerDuty{
 				RoutingKey:       "test-routing-key",
 				RoutingKeyEnvVar: "TEST_ROUTING_KEY",
@@ -339,7 +339,7 @@ func TestLookupRoutingKey(t *testing.T) {
 			env: map[string]string{
 				"TEST_ROUTING_KEY": "test-routing-key-env-var",
 			},
-			want:    "test-routing-key-env-var",
+			want:    "test-routing-key",
 			wantErr: false,
 		},
 	}
@@ -362,7 +362,7 @@ func TestLookupRoutingKey(t *testing.T) {
 	}
 }
 
-func TestRoutingKeyEnvVar(t *testing.T) {
+func TestPagerDutyRoutingKeyEnvVar(t *testing.T) {
 	tests := map[string]struct {
 		pagerdutyConfig *configpb.PagerDuty
 		want            string

--- a/probes/alerting/proto/config.pb.go
+++ b/probes/alerting/proto/config.pb.go
@@ -302,11 +302,11 @@ type PagerDuty struct {
 	// The routing key is used to determine which service the alerts are sent to
 	// and is generated with the service. The routing key is found under the
 	// service, when the events v2 integration is enabled, under integrations,
-	// in the pagerduty console.
-	// Note: set either routing_key or routing_key_env_var.
+	// in the pagerduty console. This field takes precedence over
+	// routing_key_env_var.
 	RoutingKey string `protobuf:"bytes,1,opt,name=routing_key,json=routingKey,proto3" json:"routing_key,omitempty"`
 	// The environment variable that is used to contain the pagerduty routing
-	// key. If this is set, the routing_key field is ignored.
+	// key.
 	RoutingKeyEnvVar string `protobuf:"bytes,2,opt,name=routing_key_env_var,json=routingKeyEnvVar,proto3" json:"routing_key_env_var,omitempty"` // Default: PAGERDUTY_ROUTING_KEY;
 	// PagerDuty API URL.
 	// Used to overwrite the default PagerDuty API URL.

--- a/probes/alerting/proto/config.proto
+++ b/probes/alerting/proto/config.proto
@@ -83,12 +83,12 @@ message PagerDuty {
     // The routing key is used to determine which service the alerts are sent to
     // and is generated with the service. The routing key is found under the 
     // service, when the events v2 integration is enabled, under integrations,
-    // in the pagerduty console.
-    // Note: set either routing_key or routing_key_env_var.
+    // in the pagerduty console. This field takes precedence over 
+    // routing_key_env_var.
     string routing_key = 1;
 
     // The environment variable that is used to contain the pagerduty routing 
-    // key. If this is set, the routing_key field is ignored.
+    // key.
     string routing_key_env_var = 2; // Default: PAGERDUTY_ROUTING_KEY;
 
     // PagerDuty API URL.

--- a/probes/alerting/proto/config_proto_gen.cue
+++ b/probes/alerting/proto/config_proto_gen.cue
@@ -78,12 +78,12 @@ package proto
 	// The routing key is used to determine which service the alerts are sent to
 	// and is generated with the service. The routing key is found under the
 	// service, when the events v2 integration is enabled, under integrations,
-	// in the pagerduty console.
-	// Note: set either routing_key or routing_key_env_var.
+	// in the pagerduty console. This field takes precedence over
+	// routing_key_env_var.
 	routingKey?: string @protobuf(1,string,name=routing_key)
 
 	// The environment variable that is used to contain the pagerduty routing
-	// key. If this is set, the routing_key field is ignored.
+	// key.
 	routingKeyEnvVar?: string @protobuf(2,string,name=routing_key_env_var) // Default: PAGERDUTY_ROUTING_KEY;
 
 	// PagerDuty API URL.


### PR DESCRIPTION
This PR changes the order of precedence for the routing key, evaluating the user supplied key in the configuration, and then falling back to the env var.

I was writing the slack integration and realized that the order of evaluation didn't follow the normal standards, and I wanted to make the Slack notifications as like for like as PagerDuty notifications as possible.