### PR TITLE
[docs] Change default config language to textpb.

### DIFF
--- a/docs/static/configdoc.js
+++ b/docs/static/configdoc.js
@@ -16,7 +16,7 @@ function setConfigLang(lang) {
     lang = localStorage["preferred-language"];
   }
   if (!lang) {
-    lang = "yaml";
+    lang = "textpb";
   }
 
   const els = document.getElementsByClassName("select-content-lang");


### PR DESCRIPTION
Since textpb format is what most of the existing Cloudprober users must be using, it makes sense to use "textpb" as the default config language for documentation.