### PR TITLE
[docs] Fix one more quirk of Firefox.

### DIFF
--- a/docs/static/configdoc.js
+++ b/docs/static/configdoc.js
@@ -170,6 +170,10 @@ function addTOC() {
 
 document.addEventListener("DOMContentLoaded", function () {
   setConfigLang();
+  const e = document.querySelector(window.location.hash);
+  if (e) {
+    e.scrollIntoView();
+  }
   markConfigDocLinkActive();
   addTOC();
 });


### PR DESCRIPTION
Scroll to the selected heading after config doc div is processed.