### PR TITLE
[config] Provide a way to hide secret environment variables.

### DIFF
--- a/cloudprober.go
+++ b/cloudprober.go
@@ -254,6 +254,7 @@ func Start(ctx context.Context) {
 		cloudProber.defaultServerLn = nil
 		cloudProber.defaultGRPCLn = nil
 		cloudProber.rawConfig = ""
+		cloudProber.parsedConfig = ""
 		cloudProber.config = nil
 		cloudProber.prober = nil
 	}()

--- a/cloudprober.go
+++ b/cloudprober.go
@@ -162,7 +162,7 @@ func InitFromConfig(configFile string) error {
 		return err
 	}
 
-	cfg, parsedConfigStr, err := config.ParseConfig(configStr, configFormat, sysvars.Vars())
+	cfg, parsedConfigStr, err := config.ParseConfig(configStr, configFormat, sysvars.Vars(), globalLogger)
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -171,12 +171,11 @@ func substEnvVars(configStr string) (string, error) {
 	}
 
 	var envVars []string
-	// Collect all the environment variables that need to be substituted.
-	for _, word := range m {
-		if len(word) != 2 {
+	for _, match := range m {
+		if len(match) != 2 {
 			continue
 		}
-		envVars = append(envVars, word[1])
+		envVars = append(envVars, match[1]) // match[0] is the whole string.
 	}
 
 	for _, v := range envVars {

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,7 @@ var (
 	configFile = flag.String("config_file", "", "Config file")
 )
 
-var envRegex = regexp.MustCompile(`{{ \$([^$]+) }}`)
+var envRegex = regexp.MustCompile(`{{ secret:\$([^$]+) }}`)
 
 const (
 	configMetadataKeyName = "cloudprober_config"

--- a/config/config_tmpl.go
+++ b/config/config_tmpl.go
@@ -184,10 +184,11 @@ func ParseTemplate(config string, sysVars map[string]string, getGCECustomMetadat
 			}
 			matches := r.FindStringSubmatch(s)
 			if len(matches) <= n {
-				return "", fmt.Errorf("Match number %d not found. Regex: %s, String: %s", n, re, s)
+				return "", fmt.Errorf("match number %d not found. Regex: %s, String: %s", n, re, s)
 			}
 			return matches[n], nil
 		},
+		"envSecret": func(s string) string { return "{{ $" + s + " }}" },
 	}
 
 	for name, f := range sprig.TxtFuncMap() {

--- a/config/config_tmpl.go
+++ b/config/config_tmpl.go
@@ -188,7 +188,7 @@ func ParseTemplate(config string, sysVars map[string]string, getGCECustomMetadat
 			}
 			return matches[n], nil
 		},
-		"envSecret": func(s string) string { return "{{ $" + s + " }}" },
+		"envSecret": func(s string) string { return "{{ secret:$" + s + " }}" },
 	}
 
 	for name, f := range sprig.TxtFuncMap() {

--- a/config/config_tmpl.go
+++ b/config/config_tmpl.go
@@ -188,7 +188,7 @@ func ParseTemplate(config string, sysVars map[string]string, getGCECustomMetadat
 			}
 			return matches[n], nil
 		},
-		"envSecret": func(s string) string { return "{{ secret:$" + s + " }}" },
+		"envSecret": func(s string) string { return "**$" + s + "**" },
 	}
 
 	for name, f := range sprig.TxtFuncMap() {

--- a/config/config_tmpl_test.go
+++ b/config/config_tmpl_test.go
@@ -63,6 +63,20 @@ func TestParseTemplate(t *testing.T) {
 			wantTargets: []string{"host_names:\"www.google.com\""},
 		},
 		{
+			desc: "config-with-secret-env",
+			config: `
+				probe {
+				name: "{{ envSecret "SECRET_PROBE_NAME" }}"
+				type: PING
+				targets {
+					host_names: "www.google.com"
+				}
+				}
+			`,
+			wantProbes:  []string{"{{ secret:$SECRET_PROBE_NAME }}"},
+			wantTargets: []string{"host_names:\"www.google.com\""},
+		},
+		{
 			desc: "config-with-map-and-template",
 			config: `
 				{{define "probeTmpl"}}

--- a/config/config_tmpl_test.go
+++ b/config/config_tmpl_test.go
@@ -73,7 +73,7 @@ func TestParseTemplate(t *testing.T) {
 				}
 				}
 			`,
-			wantProbes:  []string{"{{ secret:$SECRET_PROBE_NAME }}"},
+			wantProbes:  []string{"**$SECRET_PROBE_NAME**"},
 			wantTargets: []string{"host_names:\"www.google.com\""},
 		},
 		{

--- a/web/resources/header.go
+++ b/web/resources/header.go
@@ -33,7 +33,7 @@ var t = template.Must(template.New("header").Parse(`
   <b>Started</b>: {{.StartTime}} -- up {{.Uptime}}<br/>
   <b>Version</b>: {{.Version}}<br>
   <b>Built at</b>: {{.BuiltAt}}<br>
-  <b>Other Links</b>: <a href="/status">/status</a>, <a href="/config-running">/config</a> (<a href="/config">raw</a>), <a href="/alerts">/alerts</a>, <a href="/health">/health</a><br>
+  <b>Other Links</b>: <a href="/status">/status</a>, <a href="/config-running">/config</a> (<a href="/config-parsed">parsed</a> | <a href="/config">raw</a>), <a href="/alerts">/alerts</a>, <a href="/health">/health</a><br>
 </div>
 `))
 

--- a/web/web.go
+++ b/web/web.go
@@ -107,7 +107,10 @@ func Init() error {
 		}
 	}
 	srvMux.HandleFunc("/config", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, cloudprober.GetTextConfig())
+		fmt.Fprint(w, cloudprober.GetRawConfig())
+	})
+	srvMux.HandleFunc("/config-parsed", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, cloudprober.GetParsedConfig())
 	})
 	srvMux.HandleFunc("/config-running", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, runningConfig())


### PR DESCRIPTION
- Provide an option to specify secret environment variables, using envSecret keyword.
- When such variables are present, /config-running will be automatically disabled.
- Add another page /config-parsed that shows the parsed config and makes it clear which variables are secret.