### PR TITLE
[bugfix] Add IP to endpoint key. (#535)

### DIFF
--- a/targets/endpoint/endpoint.go
+++ b/targets/endpoint/endpoint.go
@@ -47,7 +47,11 @@ func (ep *Endpoint) Key() string {
 	}
 	sort.Strings(labelSlice)
 
-	return strings.Join(append([]string{ep.Name, strconv.Itoa(ep.Port)}, labelSlice...), "_")
+	ip := ""
+	if ep.IP != nil {
+		ip = ep.IP.String()
+	}
+	return strings.Join(append([]string{ep.Name, ip, strconv.Itoa(ep.Port)}, labelSlice...), "_")
 }
 
 // Lister should implement the ListEndpoints method.

--- a/targets/endpoint/endpoint_test.go
+++ b/targets/endpoint/endpoint_test.go
@@ -72,6 +72,7 @@ func TestKey(t *testing.T) {
 		ep := Endpoint{
 			Name:   test.name,
 			Port:   test.port,
+			IP:     test.ip,
 			Labels: test.labels,
 		}
 		t.Run(fmt.Sprintf("%v", ep), func(t *testing.T) {

--- a/targets/endpoint/endpoint_test.go
+++ b/targets/endpoint/endpoint_test.go
@@ -16,6 +16,7 @@ package endpoint
 
 import (
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,24 +46,27 @@ func TestKey(t *testing.T) {
 		name   string
 		port   int
 		labels map[string]string
+		ip     net.IP
 		key    string
 	}{
 		{
 			name: "t1",
 			port: 80,
-			key:  "t1_80",
+			ip:   net.ParseIP("10.0.0.1"),
+			key:  "t1_10.0.0.1_80",
 		},
 		{
 			name:   "t1",
 			port:   80,
+			ip:     net.ParseIP("1234:5678::72"),
 			labels: map[string]string{"app": "cloudprober", "dc": "xx"},
-			key:    "t1_80_app:cloudprober_dc:xx",
+			key:    "t1_1234:5678::72_80_app:cloudprober_dc:xx",
 		},
 		{
 			name:   "t1",
 			port:   80,
 			labels: map[string]string{"dc": "xx", "app": "cloudprober"},
-			key:    "t1_80_app:cloudprober_dc:xx",
+			key:    "t1__80_app:cloudprober_dc:xx",
 		},
 	} {
 		ep := Endpoint{


### PR DESCRIPTION
HTTP probes use endpoint key as identifier to decide when to recreate probes. During VM recreations, it is possible for VM name to stay the same but VM IP changes. By adding IP to key, we ensure that in such cases, HTTP probes are recreated.