### PR TITLE
[logger] Streamline logger interface.

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -16,7 +16,6 @@ package config
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"os"
 	"strings"
@@ -251,7 +250,7 @@ func TestSubstEnvVars(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			l, _ := logger.New(context.Background(), "config_test", logger.WithWriter(&buf))
+			l := logger.New(logger.WithWriter(&buf))
 			assert.Equal(t, tt.want, substEnvVars(tt.configStr, l))
 			assert.Contains(t, buf.String(), tt.wantLog)
 		})

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -67,8 +67,8 @@ var EnvVars = struct {
 }
 
 const (
-	// Prefix for the cloudprober stackdriver log names.
-	cloudproberPrefix = "cloudprober"
+	// Default "system" label and stackdriver log name prefix.
+	defaultSystemName = "cloudprober"
 )
 
 const (
@@ -204,13 +204,14 @@ func newLogger(opts ...Option) *Logger {
 		labels:              make(map[string]string),
 		disableCloudLogging: *disableCloudLogging,
 		gcpLoggingEndpoint:  *gcpLoggingEndpoint,
-		systemAttr:          "cloudprober", // default
+		systemAttr:          defaultSystemName,
 	}
 	for _, opt := range opts {
 		opt(l)
 	}
 
 	l.attrs = append([]slog.Attr{slog.String("system", l.systemAttr)}, l.attrs...)
+	fmt.Println(l.attrs)
 
 	// Initialize the traditional logger.
 	l.slogger = slog.New(slogHandler(l.writer).WithAttrs(l.attrs))
@@ -273,7 +274,7 @@ func verifySDLogName(logName string) (string, error) {
 }
 
 func (l *Logger) sdLogName() (string, error) {
-	prefix := cloudproberPrefix
+	prefix := l.systemAttr
 	envLogPrefix := os.Getenv(LogPrefixEnvVar)
 	if os.Getenv(LogPrefixEnvVar) != "" {
 		prefix = envLogPrefix

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -16,7 +16,6 @@ package logger
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -57,12 +56,6 @@ func TestEnvVarSet(t *testing.T) {
 }
 
 func TestWithLabels(t *testing.T) {
-	panicOnErr := func(l *Logger, err error) *Logger {
-		if err != nil {
-			panic(err)
-		}
-		return l
-	}
 	tests := []struct {
 		name       string
 		l          *Logger
@@ -70,12 +63,12 @@ func TestWithLabels(t *testing.T) {
 	}{
 		{
 			name:       "new-withlabels",
-			l:          panicOnErr(New(context.Background(), "newWithLabels", WithLabels(map[string]string{"k1": "v1"}))),
+			l:          New(WithLabels(map[string]string{"k1": "v1"})),
 			wantLabels: map[string]string{"k1": "v1"},
 		},
 		{
 			name:       "new-withlabels-overridden",
-			l:          panicOnErr(New(context.Background(), "newWithLabels", WithLabels(map[string]string{"k1": "v1"}), WithLabels(map[string]string{"k1": "v2"}))),
+			l:          New(WithLabels(map[string]string{"k1": "v1"}), WithLabels(map[string]string{"k1": "v2"})),
 			wantLabels: map[string]string{"k1": "v2"},
 		},
 		{

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -88,6 +88,31 @@ func TestWithLabels(t *testing.T) {
 	}
 }
 
+func TestWithAttr(t *testing.T) {
+	tests := []struct {
+		name      string
+		l         *Logger
+		wantAttrs []slog.Attr
+	}{
+		{
+			name:      "new-withAttrs",
+			l:         New(WithAttr(slog.String("probe", "testprobe"))),
+			wantAttrs: []slog.Attr{slog.String("system", "cloudprober"), slog.String("probe", "testprobe")},
+		},
+		{
+			name:      "new-withAttrs-different-system",
+			l:         New(WithAttr(slog.String("probe", "testprobe"), slog.String("system", "testsystem"))),
+			wantAttrs: []slog.Attr{slog.String("system", "testsystem"), slog.String("probe", "testprobe")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantAttrs, tt.l.attrs)
+		})
+	}
+
+}
+
 func testVerifyJSONLog(t *testing.T, b []byte, wantLabels map[string]string) {
 	t.Helper()
 
@@ -287,9 +312,14 @@ func TestSDLogName(t *testing.T) {
 			want:  "cloudprober.rds-server",
 		},
 		{
-			name:  "cloudwatch",
+			name:  "surfacer_cloudwatch",
 			attrs: []slog.Attr{slog.String("surfacer", "cloudwatch")},
 			want:  "cloudprober.cloudwatch",
+		},
+		{
+			name:  "different_system",
+			attrs: []slog.Attr{slog.String("system", "protodoc"), slog.String("surfacer", "cloudwatch")},
+			want:  "protodoc.cloudwatch",
 		},
 		{
 			name:    "invalid char",

--- a/probes/options/options_test.go
+++ b/probes/options/options_test.go
@@ -16,7 +16,6 @@ package options
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"net"
 	"testing"
@@ -380,7 +379,7 @@ func TestRecordMetrics(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	l, _ := logger.New(context.Background(), "test-probe", logger.WithWriter(&buf))
+	l := logger.New(logger.WithWriter(&buf))
 	opts.AdditionalLabels = []*AdditionalLabel{additionalLabel}
 	alertHandler, _ := alerting.NewAlertHandler(&alerting_configpb.AlertConf{}, "test-probe", l)
 	opts.AlertHandlers = []*alerting.AlertHandler{alertHandler}


### PR DESCRIPTION
- Rename old New function to NewLegacy. This function is now deprecated.
- Add a new, simpler, New function that takes only optional arguments.