### PR TITLE
[config] Fix a bug in the /config-running disabling functiionality.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,7 +35,7 @@ var (
 	configFile = flag.String("config_file", "", "Config file")
 )
 
-var envRegex = regexp.MustCompile(`\*\*\$([^*\s]+)\*\*`)
+var EnvRegex = regexp.MustCompile(`\*\*\$([^*\s]+)\*\*`)
 
 const (
 	configMetadataKeyName = "cloudprober_config"
@@ -166,7 +166,7 @@ func DumpConfig(fileName, outFormat string, baseVars map[string]string) ([]byte,
 
 // substEnvVars substitutes environment variables in the config string.
 func substEnvVars(configStr string, l *logger.Logger) string {
-	m := envRegex.FindAllStringSubmatch(configStr, -1)
+	m := EnvRegex.FindAllStringSubmatch(configStr, -1)
 	if len(m) == 0 {
 		return configStr
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,9 @@ var (
 	configFile = flag.String("config_file", "", "Config file")
 )
 
+// EnvRegex is the regex used to find environment variable placeholders
+// in the config file. The placeholders are of the form **$<env_var_name>**,
+// and are added during Go template processing for envSecret functions.
 var EnvRegex = regexp.MustCompile(`\*\*\$([^*\s]+)\*\*`)
 
 const (

--- a/web/web.go
+++ b/web/web.go
@@ -21,10 +21,10 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
-	"strings"
 
 	"github.com/cloudprober/cloudprober"
 	"github.com/cloudprober/cloudprober/common/httputils"
+	"github.com/cloudprober/cloudprober/config"
 	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/probes"
 	"github.com/cloudprober/cloudprober/probes/alerting"
@@ -118,7 +118,7 @@ func Init() error {
 	})
 
 	var configRunning string
-	if !strings.Contains(parsedConfig, "{{ secret:$") {
+	if !config.EnvRegex.MatchString(parsedConfig) {
 		configRunning = runningConfig()
 	} else {
 		configRunning = `


### PR DESCRIPTION
Fix a bug in the functionality introduced recently in https://github.com/cloudprober/cloudprober/pull/536. We were using wrong criteria to determine if we should serve /config-running.