### PR TITLE
[alerting] Start laying foundation for resolve notifications

### DIFF
--- a/probes/alerting/alerting.go
+++ b/probes/alerting/alerting.go
@@ -140,14 +140,24 @@ func (ah *AlertHandler) notify(ep endpoint.Endpoint, ts *targetState, totalFailu
 	}
 
 	ah.notifier.Notify(context.Background(), alertInfo)
-	updateGlobalState(ah.globalKey(ep), alertInfo)
+	globalAlertsState.add(ah.globalKey(ep), alertInfo)
 }
 
 func (ah *AlertHandler) resolveAlertCondition(ts *targetState, ep endpoint.Endpoint) {
+	ah.l.Infof("ALERT Resolved (%s): target: %s", ah.name, ep.Name)
+
 	ts.alerted = false
 	ts.conditionID = ""
 	ts.alertTS = time.Time{}
-	updateGlobalState(ah.globalKey(ep), nil)
+
+	key := ah.globalKey(ep)
+	ai := globalAlertsState.get(key)
+	if ai == nil {
+		ah.l.Errorf("ALERT Resolved (%s): didn't find alert for target (%s) in the global state, will not send resolve notification", ah.name, ep.Name)
+		return
+	}
+	ah.notifier.NotifyResolve(context.Background(), ai)
+	globalAlertsState.resolve(key)
 }
 
 // handleAlertCondition handles the alert condition.

--- a/probes/alerting/alerting.go
+++ b/probes/alerting/alerting.go
@@ -140,7 +140,7 @@ func (ah *AlertHandler) notify(ep endpoint.Endpoint, ts *targetState, totalFailu
 	}
 
 	ah.notifier.Notify(context.Background(), alertInfo)
-	globalAlertsState.add(ah.globalKey(ep), alertInfo)
+	globalState.add(ah.globalKey(ep), alertInfo)
 }
 
 func (ah *AlertHandler) resolveAlertCondition(ts *targetState, ep endpoint.Endpoint) {
@@ -151,13 +151,13 @@ func (ah *AlertHandler) resolveAlertCondition(ts *targetState, ep endpoint.Endpo
 	ts.alertTS = time.Time{}
 
 	key := ah.globalKey(ep)
-	ai := globalAlertsState.get(key)
+	ai := globalState.get(key)
 	if ai == nil {
 		ah.l.Errorf("ALERT Resolved (%s): didn't find alert for target (%s) in the global state, will not send resolve notification", ah.name, ep.Name)
 		return
 	}
 	ah.notifier.NotifyResolve(context.Background(), ai)
-	globalAlertsState.resolve(key)
+	globalState.resolve(key)
 }
 
 // handleAlertCondition handles the alert condition.

--- a/probes/alerting/alerting_status.go
+++ b/probes/alerting/alerting_status.go
@@ -154,10 +154,10 @@ func (st *state) statusHTML() (string, error) {
 	return statusBuf.String(), err
 }
 
-var globalAlertsState = state{
+var globalState = state{
 	currentAlerts: make(map[string]*notifier.AlertInfo),
 }
 
 func StatusHTML() (string, error) {
-	return globalAlertsState.statusHTML()
+	return globalState.statusHTML()
 }

--- a/probes/alerting/alerting_status.go
+++ b/probes/alerting/alerting_status.go
@@ -83,44 +83,45 @@ type resolvedAlert struct {
 
 var maxAlertsHistory = 20
 
-var global = struct {
+type state struct {
 	mu             sync.RWMutex
 	currentAlerts  map[string]*notifier.AlertInfo
 	previousAlerts []resolvedAlert
-}{
-	currentAlerts: make(map[string]*notifier.AlertInfo),
 }
 
-func updateGlobalState(key string, ai *notifier.AlertInfo) {
-	global.mu.Lock()
-	defer global.mu.Unlock()
+func (st *state) get(key string) *notifier.AlertInfo {
+	st.mu.RLock()
+	defer st.mu.RUnlock()
+	return st.currentAlerts[key]
+}
 
-	if ai == nil {
-		ra := resolvedAlert{global.currentAlerts[key], time.Now().Truncate(time.Second)}
-		global.previousAlerts = append([]resolvedAlert{ra}, global.previousAlerts...)
-		if len(global.previousAlerts) > maxAlertsHistory {
-			global.previousAlerts = global.previousAlerts[:maxAlertsHistory]
-		}
-		delete(global.currentAlerts, key)
-		return
+func (st *state) add(key string, ai *notifier.AlertInfo) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if st.currentAlerts == nil {
+		st.currentAlerts = make(map[string]*notifier.AlertInfo)
 	}
-
-	global.currentAlerts[key] = ai
+	st.currentAlerts[key] = ai
 }
 
-func resetGlobalState() {
-	global.mu.Lock()
-	defer global.mu.Unlock()
-	global.currentAlerts = make(map[string]*notifier.AlertInfo)
-	global.previousAlerts = nil
+func (st *state) resolve(key string) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	ra := resolvedAlert{st.currentAlerts[key], time.Now().Truncate(time.Second)}
+	st.previousAlerts = append([]resolvedAlert{ra}, st.previousAlerts...)
+	if len(st.previousAlerts) > maxAlertsHistory {
+		st.previousAlerts = st.previousAlerts[:maxAlertsHistory]
+	}
+	delete(st.currentAlerts, key)
 }
 
-func currentState() ([]*notifier.AlertInfo, []resolvedAlert) {
-	global.mu.RLock()
-	defer global.mu.RUnlock()
+func (st *state) list() ([]*notifier.AlertInfo, []resolvedAlert) {
+	st.mu.RLock()
+	defer st.mu.RUnlock()
 
 	var currentAlerts []*notifier.AlertInfo
-	for _, ai := range global.currentAlerts {
+	for _, ai := range st.currentAlerts {
 		currentAlerts = append(currentAlerts, ai)
 	}
 
@@ -128,13 +129,13 @@ func currentState() ([]*notifier.AlertInfo, []resolvedAlert) {
 		return currentAlerts[i].FailingSince.Before(currentAlerts[j].FailingSince)
 	})
 
-	return currentAlerts, append([]resolvedAlert{}, global.previousAlerts...)
+	return currentAlerts, append([]resolvedAlert{}, st.previousAlerts...)
 }
 
-func StatusHTML() (string, error) {
+func (st *state) statusHTML() (string, error) {
 	var statusBuf bytes.Buffer
 
-	currentAlerts, previousAlerts := currentState()
+	currentAlerts, previousAlerts := st.list()
 	for _, ai := range currentAlerts {
 		ai.FailingSince = ai.FailingSince.Truncate(time.Second)
 	}
@@ -150,4 +151,12 @@ func StatusHTML() (string, error) {
 	})
 
 	return statusBuf.String(), err
+}
+
+var globalAlertsState = state{
+	currentAlerts: make(map[string]*notifier.AlertInfo),
+}
+
+func StatusHTML() (string, error) {
+	return globalAlertsState.statusHTML()
 }

--- a/probes/alerting/alerting_status_test.go
+++ b/probes/alerting/alerting_status_test.go
@@ -211,6 +211,7 @@ func TestStatusHTML(t *testing.T) {
 
 <h3>Alerts History:</h3>
 
+<p>[Showing last 1 resolved alerts..]</p>
 <table class="status-list">
 <tr>
   <th>Started At</th>
@@ -241,8 +242,8 @@ func TestStatusHTML(t *testing.T) {
 			}
 
 			st.mu.Lock()
-			for i := range st.previousAlerts {
-				st.previousAlerts[i].ResolvedAt = time.Time{}.Add(4 * time.Second)
+			for i := range st.resolvedAlerts {
+				st.resolvedAlerts[i].ResolvedAt = time.Time{}.Add(4 * time.Second)
 			}
 			st.mu.Unlock()
 

--- a/probes/alerting/alerting_status_test.go
+++ b/probes/alerting/alerting_status_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUpdateGlobalState(t *testing.T) {
+func TestUpdateState(t *testing.T) {
 	st := state{}
 
 	oldMaxAlertsHistory := maxAlertsHistory

--- a/probes/alerting/notifier/notifier.go
+++ b/probes/alerting/notifier/notifier.go
@@ -69,7 +69,7 @@ type AlertInfo struct {
 	FailingSince time.Time
 }
 
-func (n *Notifier) alertFields(alertInfo *AlertInfo) (map[string]string, error) {
+func (n *Notifier) alertFields(alertInfo *AlertInfo) map[string]string {
 	fields := map[string]string{
 		"alert":        alertInfo.Name,
 		"probe":        alertInfo.ProbeName,
@@ -90,10 +90,10 @@ func (n *Notifier) alertFields(alertInfo *AlertInfo) (map[string]string, error) 
 
 	alertJSON, err := json.Marshal(fields)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling alert fields into json: %v", err)
+		n.l.Warningf("Error marshalling alert fields into json, will skip json field. Err: %v", err)
+	} else {
+		fields["json"] = string(alertJSON)
 	}
-
-	fields["json"] = string(alertJSON)
 
 	summary, _ := strtemplate.SubstituteLabels(n.summaryTmpl, fields)
 	fields["summary"] = summary
@@ -112,50 +112,51 @@ func (n *Notifier) alertFields(alertInfo *AlertInfo) (map[string]string, error) 
 	details, _ := strtemplate.SubstituteLabels(n.detailsTmpl, fields)
 	fields["details"] = details
 
-	return fields, nil
+	return fields
 }
 
 func (n *Notifier) Notify(ctx context.Context, alertInfo *AlertInfo) error {
-	var err error
+	fields := n.alertFields(alertInfo)
 
-	fields, err := n.alertFields(alertInfo)
-	if err != nil {
-		n.l.Errorf("Error getting alert fields: %v", err)
-	}
-
+	var errs error
 	if n.cmdNotifier != nil {
-		cmdErr := n.cmdNotifier.Notify(ctx, fields)
-		if cmdErr != nil {
-			n.l.Errorf("Error running notify command: %v", cmdErr)
-			err = errors.Join(err, cmdErr)
+		err := n.cmdNotifier.Notify(ctx, fields)
+		if err != nil {
+			n.l.Errorf("Error running notify command: %v", err)
+			errs = errors.Join(errs, err)
 		}
 	}
 
 	if n.emailNotifier != nil {
-		emailerr := n.emailNotifier.Notify(ctx, fields)
-		if emailerr == nil {
-			n.l.Errorf("Error sending email: %v", emailerr)
-			err = errors.Join(err, emailerr)
+		err := n.emailNotifier.Notify(ctx, fields)
+		if err == nil {
+			n.l.Errorf("Error sending email: %v", err)
+			errs = errors.Join(errs, err)
 		}
 	}
 
 	if n.pagerdutyNotifier != nil {
-		pdErr := n.pagerdutyNotifier.Notify(ctx, fields)
-		if pdErr != nil {
-			n.l.Errorf("Error sending PagerDuty event: %v", pdErr)
-			err = errors.Join(err, pdErr)
+		err := n.pagerdutyNotifier.Notify(ctx, fields)
+		if err != nil {
+			n.l.Errorf("Error sending PagerDuty event: %v", err)
+			errs = errors.Join(errs, err)
 		}
 	}
 
 	if n.slackNotifier != nil {
-		slackErr := n.slackNotifier.Notify(ctx, fields)
-		if slackErr != nil {
-			n.l.Errorf("Error sending Slack message: %v", slackErr)
-			err = errors.Join(err, slackErr)
+		err := n.slackNotifier.Notify(ctx, fields)
+		if err != nil {
+			n.l.Errorf("Error sending Slack message: %v", err)
+			errs = errors.Join(errs, err)
 		}
 	}
 
-	return err
+	return errs
+}
+
+func (n *Notifier) NotifyResolve(ctx context.Context, alertInfo *AlertInfo) error {
+	// TODO(manugarg): Implement this.
+	return nil
 }
 
 func New(alertcfg *configpb.AlertConf, l *logger.Logger) (*Notifier, error) {

--- a/probes/alerting/notifier/notifier_test.go
+++ b/probes/alerting/notifier/notifier_test.go
@@ -73,9 +73,7 @@ func TestAlertFields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			n, _ := New(nil, nil)
-			fields, err := n.alertFields(tt.ai)
-			assert.NoError(t, err, "Error getting alert fields")
-			assert.Equal(t, tt.want, fields, "Fields don't match")
+			assert.Equal(t, tt.want, n.alertFields(tt.ai), "Fields don't match")
 		})
 	}
 }


### PR DESCRIPTION
- Streamline state implementation because we'll need it to retrieve alert information while sending resolve notification.
