### PR TITLE
[probes] Return an error if interval is smaller than timeout

### DIFF
--- a/probes/options/options.go
+++ b/probes/options/options.go
@@ -150,6 +150,10 @@ func BuildProbeOptions(p *configpb.ProbeDef, ldLister endpoint.Lister, globalTar
 		}
 	}
 
+	if intervalDuration < timeoutDuration && p.GetType() != configpb.ProbeDef_UDP {
+		return nil, fmt.Errorf("interval (%v) cannot be smaller than timeout (%v)", intervalDuration, timeoutDuration)
+	}
+
 	if p.GetNegativeTest() && !negativeTestSupported[p.GetType()] {
 		return nil, fmt.Errorf("negative_test is not supported by %s probes", p.GetType().String())
 	}

--- a/probes/options/options_test.go
+++ b/probes/options/options_test.go
@@ -218,7 +218,7 @@ func TestStatsExportInterval(t *testing.T) {
 			name:         "Timeout bigger than intervalMsec",
 			intervalMsec: 10,
 			timeoutMsec:  12,
-			want:         12,
+			wantError:    true,
 		},
 		{
 			name:         "Interval and timeout less than default",


### PR DESCRIPTION
- No probe types, except for UDP, support starting a new probe before the previous one has finished.
- UDP probe's implementation to support this behavior is quite complicated and I wouldn't want to repeat it for other probe types.