### PR TITLE
[alerting] Fix PagerDuty resolve request creation.

### DIFF
--- a/probes/alerting/alerting.go
+++ b/probes/alerting/alerting.go
@@ -156,6 +156,7 @@ func (ah *AlertHandler) resolveAlertCondition(ts *targetState, ep endpoint.Endpo
 		ah.l.Errorf("ALERT Resolved (%s): didn't find alert for target (%s) in the global state, will not send resolve notification", ah.name, ep.Name)
 		return
 	}
+
 	ah.notifier.NotifyResolve(context.Background(), ai)
 	globalState.resolve(key)
 }

--- a/probes/alerting/notifier/notifier.go
+++ b/probes/alerting/notifier/notifier.go
@@ -154,19 +154,12 @@ func (n *Notifier) Notify(ctx context.Context, alertInfo *AlertInfo) error {
 	return errs
 }
 
-func (n *Notifier) NotifyResolve(ctx context.Context, alertInfo *AlertInfo) error {
+func (n *Notifier) NotifyResolve(ctx context.Context, alertInfo *AlertInfo) {
 	fields := n.alertFields(alertInfo)
 
-	var errs error
 	if n.pagerdutyNotifier != nil {
-		err := n.pagerdutyNotifier.NotifyResolve(ctx, fields)
-		if err != nil {
-			errs = errors.Join(errs, err)
-		}
+		n.pagerdutyNotifier.NotifyResolve(ctx, fields)
 	}
-
-	// TODO(manugarg): Implement more notifiers.
-	return errs
 }
 
 func New(alertcfg *configpb.AlertConf, l *logger.Logger) (*Notifier, error) {

--- a/probes/alerting/notifier/pagerduty/event_v2.go
+++ b/probes/alerting/notifier/pagerduty/event_v2.go
@@ -108,14 +108,14 @@ func (c *Client) sendEventV2(event *EventV2Request) (*EventV2Response, error) {
 	}
 	defer resp.Body.Close()
 
-	// check status code, return error if not 202
-	if resp.StatusCode != http.StatusAccepted {
-		return nil, fmt.Errorf("PagerDuty API returned status code %d", resp.StatusCode)
-	}
-
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
+	}
+
+	// check status code, return error if not 202
+	if resp.StatusCode != http.StatusAccepted {
+		return nil, fmt.Errorf("PagerDuty API returned status code %d, response: %s", resp.StatusCode, string(b))
 	}
 
 	body := &EventV2Response{}
@@ -163,6 +163,11 @@ func (c *Client) createResolveRequest(alertFields map[string]string) *EventV2Req
 		RoutingKey:  c.routingKey,
 		DedupKey:    eventV2DedupeKey(alertFields),
 		EventAction: Resolve,
+		Payload: EventV2Payload{
+			Summary:  alertFields["summary"],
+			Source:   alertFields["target"],
+			Severity: "critical",
+		},
 	}
 }
 

--- a/probes/alerting/notifier/pagerduty/pagerduty.go
+++ b/probes/alerting/notifier/pagerduty/pagerduty.go
@@ -115,13 +115,13 @@ func (c *Client) NotifyResolve(ctx context.Context, alertFields map[string]strin
 	// Create the event
 	event := c.createResolveRequest(alertFields)
 
+	c.logger.Infof("PagerDuty: sending resolve event: dedupe key: %s", event.DedupKey)
+
 	// Send the event
-	response, err := c.sendEventV2(event)
+	_, err := c.sendEventV2(event)
 	if err != nil {
+		c.logger.Errorf("PagerDuty: error sending resolve event: %v", err)
 		return err
 	}
-
-	c.logger.Debugf("PagerDuty: resolved event sent successfully. Dedupe key: %s, message: %s", response.DedupKey, response.Message)
-
 	return nil
 }

--- a/probes/alerting/notifier/pagerduty/pagerduty_test.go
+++ b/probes/alerting/notifier/pagerduty/pagerduty_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	configpb "github.com/cloudprober/cloudprober/probes/alerting/proto"
+	"github.com/stretchr/testify/assert"
 )
 
 func newPagerDutyEventV2TestServer(testCallback func(r *http.Request) error) *httptest.Server {
@@ -249,11 +250,18 @@ func TestPagerDutyCreateResolveRequest(t *testing.T) {
 		"simple": {
 			alertFields: map[string]string{
 				"condition_id": "test-condition-id",
+				"summary":      "test-summary",
+				"target":       "test-target",
 			},
 			want: &EventV2Request{
 				RoutingKey:  "test-routing-key",
 				DedupKey:    "test-condition-id",
 				EventAction: Resolve,
+				Payload: EventV2Payload{
+					Summary:  "test-summary",
+					Severity: "critical",
+					Source:   "test-target",
+				},
 			},
 		},
 	}
@@ -269,10 +277,7 @@ func TestPagerDutyCreateResolveRequest(t *testing.T) {
 				t.Errorf("Error creating PagerDuty client: %v", err)
 			}
 
-			got := p.createResolveRequest(tc.alertFields)
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("createEventV2Request = \n%+v\n, want \n%+v\n", got, tc.want)
-			}
+			assert.Equal(t, tc.want, p.createResolveRequest(tc.alertFields), "Requests don't match")
 		})
 	}
 }


### PR DESCRIPTION
- Also, instead of aggregating errors from notifiers and then logging,
  log them right away and don't return errors.
- Include pagerDuty response in the error message in case of an error.