### PR TITLE
[alerting] Kill the concept of condition id as it's defined today

### DIFF
--- a/docs/content/docs/how-to/alerting/index.md
+++ b/docs/content/docs/how-to/alerting/index.md
@@ -89,12 +89,12 @@ You can customize the information included in the alert notification. The
 following table shows the top-level notification parameters, corresponding
 config fields, and their default values.
 
-| Info          | Configuration Field      | Default                                                                                                                                                                                                                                                  |
-| ------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Dashboard URL | `dashboard_url_template` | http://localhost:9313/status?probe=@probe@                                                                                                                                                                                                               |
-| Playbook URL  | `playbook_url_template`  | ""                                                                                                                                                                                                                                                       |
-| Summary       | `summary_template`       | Cloudprober alert "`@alert@`" for "`@target@`"                                                                                                                                                                                                           |
-| Details       | `details_template`       | Cloudprober alert "`@alert@`" for "`@target@`":<br/>Failures: `@failures@` out of `@total@` probes<br/>Failing since: `@since@`<br>Probe: `@probe@`<br/> Dashboard: `@dashboard_url@`<br/> Playbook: `@playbook_url@`<br/>Condition ID: `@condition_id@` |
+| Info          | Configuration Field      | Default                                                                                                                                                                                                               |
+| ------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Dashboard URL | `dashboard_url_template` | http://localhost:9313/status?probe=@probe@                                                                                                                                                                            |
+| Playbook URL  | `playbook_url_template`  | ""                                                                                                                                                                                                                    |
+| Summary       | `summary_template`       | Cloudprober alert "`@alert@`" for "`@target@`"                                                                                                                                                                        |
+| Details       | `details_template`       | Cloudprober alert "`@alert@`" for "`@target@`":<br/>Failures: `@failures@` out of `@total@` probes<br/>Failing since: `@since@`<br>Probe: `@probe@`<br/> Dashboard: `@dashboard_url@`<br/> Playbook: `@playbook_url@` |
 
 As you see here, you can embed alert information in notifications using
 placeholders like `@field@`. For example if you host your alert playbooks at

--- a/probes/alerting/alertinfo/alertinfo.go
+++ b/probes/alerting/alertinfo/alertinfo.go
@@ -30,22 +30,24 @@ import (
 type AlertInfo struct {
 	Name         string
 	ProbeName    string
-	ConditionID  string
 	Target       endpoint.Endpoint
 	Failures     int
 	Total        int
 	FailingSince time.Time
+
+	// DeDuplicationID is used to de-duplicate alerts. It is set to a UUID
+	// created using the alert name, probe name and target.
+	DeDuplicationID string
 }
 
 func (ai *AlertInfo) Fields(templateDetails map[string]string) map[string]string {
 	fields := map[string]string{
-		"alert":        ai.Name,
-		"probe":        ai.ProbeName,
-		"target":       ai.Target.Dst(),
-		"condition_id": ai.ConditionID,
-		"failures":     strconv.Itoa(ai.Failures),
-		"total":        strconv.Itoa(ai.Total),
-		"since":        ai.FailingSince.Format(time.RFC3339),
+		"alert":    ai.Name,
+		"probe":    ai.ProbeName,
+		"target":   ai.Target.Dst(),
+		"failures": strconv.Itoa(ai.Failures),
+		"total":    strconv.Itoa(ai.Total),
+		"since":    ai.FailingSince.Format(time.RFC3339),
 	}
 
 	for k, v := range ai.Target.Labels {

--- a/probes/alerting/alertinfo/alertinfo.go
+++ b/probes/alerting/alertinfo/alertinfo.go
@@ -35,9 +35,9 @@ type AlertInfo struct {
 	Total        int
 	FailingSince time.Time
 
-	// DeDuplicationID is used to de-duplicate alerts. It is set to a UUID
+	// DeduplicationID is used to de-duplicate alerts. It is set to a UUID
 	// created using the alert name, probe name and target.
-	DeDuplicationID string
+	DeduplicationID string
 }
 
 func (ai *AlertInfo) Fields(templateDetails map[string]string) map[string]string {

--- a/probes/alerting/alertinfo/alertinfo_test.go
+++ b/probes/alerting/alertinfo/alertinfo_test.go
@@ -46,7 +46,7 @@ func TestAlertInfoFields(t *testing.T) {
 			ai: &AlertInfo{
 				Name:            "test-alert",
 				ProbeName:       "test-probe",
-				DeDuplicationID: "122333444",
+				DeduplicationID: "122333444",
 				Target:          testTarget,
 				Failures:        8,
 				Total:           12,
@@ -69,7 +69,7 @@ func TestAlertInfoFields(t *testing.T) {
 			ai: &AlertInfo{
 				Name:            "test-alert",
 				ProbeName:       "test-probe",
-				DeDuplicationID: "122333444",
+				DeduplicationID: "122333444",
 				Target:          testTarget,
 				Failures:        8,
 				Total:           12,

--- a/probes/alerting/alertinfo/alertinfo_test.go
+++ b/probes/alerting/alertinfo/alertinfo_test.go
@@ -44,18 +44,17 @@ func TestAlertInfoFields(t *testing.T) {
 		{
 			name: "no_template_details",
 			ai: &AlertInfo{
-				Name:         "test-alert",
-				ProbeName:    "test-probe",
-				ConditionID:  "122333444",
-				Target:       testTarget,
-				Failures:     8,
-				Total:        12,
-				FailingSince: time.Time{}.Add(time.Second),
+				Name:            "test-alert",
+				ProbeName:       "test-probe",
+				DeDuplicationID: "122333444",
+				Target:          testTarget,
+				Failures:        8,
+				Total:           12,
+				FailingSince:    time.Time{}.Add(time.Second),
 			},
 			want: map[string]string{
 				"alert":                 "test-alert",
 				"probe":                 "test-probe",
-				"condition_id":          "122333444",
 				"target":                "test-target",
 				"target_ip":             "10.11.12.13",
 				"failures":              "8",
@@ -68,13 +67,13 @@ func TestAlertInfoFields(t *testing.T) {
 		{
 			name: "with_template_details",
 			ai: &AlertInfo{
-				Name:         "test-alert",
-				ProbeName:    "test-probe",
-				ConditionID:  "122333444",
-				Target:       testTarget,
-				Failures:     8,
-				Total:        12,
-				FailingSince: time.Time{}.Add(time.Second),
+				Name:            "test-alert",
+				ProbeName:       "test-probe",
+				DeDuplicationID: "122333444",
+				Target:          testTarget,
+				Failures:        8,
+				Total:           12,
+				FailingSince:    time.Time{}.Add(time.Second),
 			},
 			templateDetails: map[string]string{
 				"summary":       "Cloudprober alert \"@alert@\" for \"@target@\"",
@@ -84,7 +83,6 @@ func TestAlertInfoFields(t *testing.T) {
 			want: map[string]string{
 				"alert":                 "test-alert",
 				"probe":                 "test-probe",
-				"condition_id":          "122333444",
 				"target":                "test-target",
 				"target_ip":             "10.11.12.13",
 				"failures":              "8",
@@ -107,9 +105,8 @@ func TestAlertInfoFields(t *testing.T) {
 
 func TestFieldsToString(t *testing.T) {
 	fields := map[string]string{
-		"alert":        "test-alert",
-		"probe":        "test-probe",
-		"condition_id": "122333444",
+		"alert": "test-alert",
+		"probe": "test-probe",
 	}
 
 	tests := []struct {
@@ -119,12 +116,12 @@ func TestFieldsToString(t *testing.T) {
 	}{
 		{
 			name: "skip_none",
-			want: "alert: test-alert\ncondition_id: 122333444\nprobe: test-probe",
+			want: "alert: test-alert\nprobe: test-probe",
 		},
 		{
 			name:     "skip_probe",
-			skipKeys: []string{"condition_id"},
-			want:     "alert: test-alert\nprobe: test-probe",
+			skipKeys: []string{"probe"},
+			want:     "alert: test-alert",
 		},
 	}
 	for _, tt := range tests {

--- a/probes/alerting/alerting.go
+++ b/probes/alerting/alerting.go
@@ -134,7 +134,7 @@ func (ah *AlertHandler) notify(ep endpoint.Endpoint, ts *targetState, totalFailu
 	alertInfo := &alertinfo.AlertInfo{
 		Name:            ah.name,
 		ProbeName:       ah.probeName,
-		DeDuplicationID: conditionID(alertKey),
+		DeduplicationID: conditionID(alertKey),
 		Target:          ep,
 		Failures:        totalFailures,
 		Total:           int(ah.condition.Total),

--- a/probes/alerting/alerting.go
+++ b/probes/alerting/alerting.go
@@ -132,13 +132,13 @@ func (ah *AlertHandler) notify(ep endpoint.Endpoint, ts *targetState, totalFailu
 	alertKey := ah.globalKey(ep)
 
 	alertInfo := &alertinfo.AlertInfo{
-		Name:         ah.name,
-		ProbeName:    ah.probeName,
-		ConditionID:  conditionID(alertKey),
-		Target:       ep,
-		Failures:     totalFailures,
-		Total:        int(ah.condition.Total),
-		FailingSince: ts.failingSince,
+		Name:            ah.name,
+		ProbeName:       ah.probeName,
+		DeDuplicationID: conditionID(alertKey),
+		Target:          ep,
+		Failures:        totalFailures,
+		Total:           int(ah.condition.Total),
+		FailingSince:    ts.failingSince,
 	}
 
 	if ah.notifyCh != nil {

--- a/probes/alerting/alerting_status.go
+++ b/probes/alerting/alerting_status.go
@@ -31,18 +31,20 @@ var statusTmpl = template.Must(template.New("status").Parse(`
 {{ else }}
 <table class="status-list">
 <tr>
-  <th>Failing Since</th>
+  <th>Alert</th>
   <th>Probe</th>
+  <th>Failing Since</th>
   <th>Target</th>
-  <th>Condition ID</th>
+  <th>Deduplication ID</th>
   <th>Failures / Total</th>
 </tr>
 {{ range .CurrentAlerts }}
 <tr>
-  <td>{{ .FailingSince }}</td>
+  <td>{{ .Name }}</td>
   <td>{{ .ProbeName }}</td>
-  <td>{{ .Target.Name }}</td>
-  <td>{{ .ConditionID }}</td>
+  <td>{{ .FailingSince }}</td>
+  <td>{{ .Target.Dst }}</td>
+  <td>{{ .DeduplicationID }}</td>
   <td>{{ .Failures }} / {{ .Total }}</td>
 </tr>
 {{- end }}
@@ -56,18 +58,20 @@ var statusTmpl = template.Must(template.New("status").Parse(`
 <p>[Showing last {{ len .PreviousAlerts }} resolved alerts..]</p>
 <table class="status-list">
 <tr>
-  <th>Started At</th>
+  <th>Alert</th>
   <th>Probe</th>
+  <th>Started At</th>
   <th>Target</th>
-  <th>Condition ID</th>
+  <th>Deduplication ID</th>
   <th>Resolved At</th>
 </tr>
 {{ range .PreviousAlerts }}
 <tr>
-  <td>{{ .AlertInfo.FailingSince }}</td>
+  <td>{{ .AlertInfo.Name }}</td>
   <td>{{ .AlertInfo.ProbeName }}</td>
-  <td>{{ .AlertInfo.Target.Name }}</td>
-  <td>{{ .AlertInfo.ConditionID }}</td>
+  <td>{{ .AlertInfo.FailingSince }}</td>
+  <td>{{ .AlertInfo.Target.Dst }}</td>
+  <td>{{ .AlertInfo.DeduplicationID }}</td>
   <td>{{ .ResolvedAt }}</td>
 </tr>
 {{- end }}

--- a/probes/alerting/alerting_status_test.go
+++ b/probes/alerting/alerting_status_test.go
@@ -158,23 +158,26 @@ func TestStatusHTML(t *testing.T) {
 
 <table class="status-list">
 <tr>
-  <th>Failing Since</th>
+  <th>Alert</th>
   <th>Probe</th>
+  <th>Failing Since</th>
   <th>Target</th>
-  <th>Condition ID</th>
+  <th>Deduplication ID</th>
   <th>Failures / Total</th>
 </tr>
 
 <tr>
-  <td>0001-01-01 00:00:01 &#43;0000 UTC</td>
+  <td>test-alert-1</td>
   <td>test-probe-2</td>
+  <td>0001-01-01 00:00:01 &#43;0000 UTC</td>
   <td>target1</td>
   <td></td>
   <td>0 / 0</td>
 </tr>
 <tr>
-  <td>0001-01-01 00:00:03 &#43;0000 UTC</td>
+  <td>test-alert-1</td>
   <td>test-probe-2</td>
+  <td>0001-01-01 00:00:03 &#43;0000 UTC</td>
   <td>target2</td>
   <td></td>
   <td>0 / 0</td>
@@ -195,16 +198,18 @@ func TestStatusHTML(t *testing.T) {
 
 <table class="status-list">
 <tr>
-  <th>Failing Since</th>
+  <th>Alert</th>
   <th>Probe</th>
+  <th>Failing Since</th>
   <th>Target</th>
-  <th>Condition ID</th>
+  <th>Deduplication ID</th>
   <th>Failures / Total</th>
 </tr>
 
 <tr>
-  <td>0001-01-01 00:00:03 &#43;0000 UTC</td>
+  <td>test-alert-1</td>
   <td>test-probe-2</td>
+  <td>0001-01-01 00:00:03 &#43;0000 UTC</td>
   <td>target2</td>
   <td></td>
   <td>0 / 0</td>
@@ -216,16 +221,18 @@ func TestStatusHTML(t *testing.T) {
 <p>[Showing last 1 resolved alerts..]</p>
 <table class="status-list">
 <tr>
-  <th>Started At</th>
+  <th>Alert</th>
   <th>Probe</th>
+  <th>Started At</th>
   <th>Target</th>
-  <th>Condition ID</th>
+  <th>Deduplication ID</th>
   <th>Resolved At</th>
 </tr>
 
 <tr>
-  <td>0001-01-01 00:00:01 &#43;0000 UTC</td>
+  <td>test-alert-1</td>
   <td>test-probe-2</td>
+  <td>0001-01-01 00:00:01 &#43;0000 UTC</td>
   <td>target1</td>
   <td></td>
   <td>0001-01-01 00:00:04 &#43;0000 UTC</td>

--- a/probes/alerting/alerting_test.go
+++ b/probes/alerting/alerting_test.go
@@ -15,7 +15,6 @@
 package alerting
 
 import (
-	"strconv"
 	"testing"
 	"time"
 
@@ -29,14 +28,20 @@ import (
 )
 
 func testAlertInfo(target string, failures, total, dur int) *alertinfo.AlertInfo {
+	ep := endpoint.Endpoint{Name: target}
+	ah := &AlertHandler{
+		name:      "test-probe",
+		probeName: "test-probe",
+	}
+
 	return &alertinfo.AlertInfo{
-		Name:         "test-probe",
-		ProbeName:    "test-probe",
-		Target:       endpoint.Endpoint{Name: target},
+		Name:         ah.name,
+		ProbeName:    ah.probeName,
+		Target:       ep,
 		Failures:     failures,
 		Total:        total,
 		FailingSince: time.Time{}.Add(time.Duration(dur) * time.Second),
-		ConditionID:  strconv.FormatInt(time.Time{}.Add(time.Duration(dur)*time.Second).Unix(), 10),
+		ConditionID:  conditionID(ah.globalKey(ep)),
 	}
 }
 

--- a/probes/alerting/alerting_test.go
+++ b/probes/alerting/alerting_test.go
@@ -35,13 +35,13 @@ func testAlertInfo(target string, failures, total, dur int) *alertinfo.AlertInfo
 	}
 
 	return &alertinfo.AlertInfo{
-		Name:         ah.name,
-		ProbeName:    ah.probeName,
-		Target:       ep,
-		Failures:     failures,
-		Total:        total,
-		FailingSince: time.Time{}.Add(time.Duration(dur) * time.Second),
-		ConditionID:  conditionID(ah.globalKey(ep)),
+		Name:            ah.name,
+		ProbeName:       ah.probeName,
+		Target:          ep,
+		Failures:        failures,
+		Total:           total,
+		FailingSince:    time.Time{}.Add(time.Duration(dur) * time.Second),
+		DeDuplicationID: conditionID(ah.globalKey(ep)),
 	}
 }
 

--- a/probes/alerting/alerting_test.go
+++ b/probes/alerting/alerting_test.go
@@ -347,3 +347,28 @@ func TestExtractValue(t *testing.T) {
 		})
 	}
 }
+
+func TestConditionID(t *testing.T) {
+	tests := []struct {
+		alertKey string
+		want     string
+	}{
+		{
+			alertKey: "test-probe-target1",
+			want:     "33b0ac57-887d-3205-bba1-26f0d9a97104",
+		},
+		{
+			alertKey: "test-probe-target1",
+			want:     "33b0ac57-887d-3205-bba1-26f0d9a97104",
+		},
+		{
+			alertKey: "test-probe-target2",
+			want:     "e93e4809-4dc5-3a74-972c-a30d2c253e97",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.alertKey, func(t *testing.T) {
+			assert.Equal(t, tt.want, conditionID(tt.alertKey))
+		})
+	}
+}

--- a/probes/alerting/alerting_test.go
+++ b/probes/alerting/alerting_test.go
@@ -41,7 +41,7 @@ func testAlertInfo(target string, failures, total, dur int) *alertinfo.AlertInfo
 		Failures:        failures,
 		Total:           total,
 		FailingSince:    time.Time{}.Add(time.Duration(dur) * time.Second),
-		DeDuplicationID: conditionID(ah.globalKey(ep)),
+		DeduplicationID: conditionID(ah.globalKey(ep)),
 	}
 }
 

--- a/probes/alerting/notifier/notifier_test.go
+++ b/probes/alerting/notifier/notifier_test.go
@@ -47,7 +47,7 @@ func TestAlertFields(t *testing.T) {
 			ai: &alertinfo.AlertInfo{
 				Name:            "test-alert",
 				ProbeName:       "test-probe",
-				DeDuplicationID: "122333444",
+				DeduplicationID: "122333444",
 				Target:          testTarget,
 				Failures:        8,
 				Total:           12,
@@ -82,7 +82,7 @@ func TestNotify(t *testing.T) {
 	alertInfo := &alertinfo.AlertInfo{
 		Name:            "test-alert",
 		ProbeName:       "test-probe",
-		DeDuplicationID: "cond-id",
+		DeduplicationID: "cond-id",
 		Target: endpoint.Endpoint{
 			Name:   "test-target:1234",
 			Labels: map[string]string{"owner": "manugarg@a.b"},

--- a/probes/alerting/notifier/notifier_test.go
+++ b/probes/alerting/notifier/notifier_test.go
@@ -45,18 +45,17 @@ func TestAlertFields(t *testing.T) {
 		{
 			name: "simple",
 			ai: &alertinfo.AlertInfo{
-				Name:         "test-alert",
-				ProbeName:    "test-probe",
-				ConditionID:  "122333444",
-				Target:       testTarget,
-				Failures:     8,
-				Total:        12,
-				FailingSince: time.Time{}.Add(time.Second),
+				Name:            "test-alert",
+				ProbeName:       "test-probe",
+				DeDuplicationID: "122333444",
+				Target:          testTarget,
+				Failures:        8,
+				Total:           12,
+				FailingSince:    time.Time{}.Add(time.Second),
 			},
 			want: map[string]string{
 				"alert":                 "test-alert",
 				"probe":                 "test-probe",
-				"condition_id":          "122333444",
 				"target":                "test-target",
 				"target_ip":             "10.11.12.13",
 				"failures":              "8",
@@ -81,9 +80,9 @@ func TestAlertFields(t *testing.T) {
 
 func TestNotify(t *testing.T) {
 	alertInfo := &alertinfo.AlertInfo{
-		Name:        "test-alert",
-		ProbeName:   "test-probe",
-		ConditionID: "cond-id",
+		Name:            "test-alert",
+		ProbeName:       "test-probe",
+		DeDuplicationID: "cond-id",
 		Target: endpoint.Endpoint{
 			Name:   "test-target:1234",
 			Labels: map[string]string{"owner": "manugarg@a.b"},
@@ -117,7 +116,7 @@ func TestNotify(t *testing.T) {
 			},
 			errorContains: "/random-cmd-test-alert-manugarg@a.b",
 			wantEmailFrom: "cloudprober-alert@localhost",
-			wantEmailMsg:  "From: cloudprober-alert@localhost\r\nTo: manugarg@a.b\r\nSubject: Cloudprober alert \"test-alert\" for \"test-target:1234\"\r\n\r\nCloudprober alert \"test-alert\" for \"test-target:1234\":\n\nFailures: 1 out of 2 probes\nFailing since: 0001-01-01T00:00:00Z\nProbe: test-probe\nDashboard: http://localhost:9313/status?probe=test-probe\nPlaybook: \n\nDetails:\nalert: test-alert\ncondition_id: cond-id\ndashboard_url: http://localhost:9313/status?probe=test-probe\nfailures: 1\nplaybook_url: \nprobe: test-probe\nsince: 0001-01-01T00:00:00Z\ntarget: test-target:1234\ntarget.label.owner: manugarg@a.b\ntotal: 2\r\n",
+			wantEmailMsg:  "From: cloudprober-alert@localhost\r\nTo: manugarg@a.b\r\nSubject: Cloudprober alert \"test-alert\" for \"test-target:1234\"\r\n\r\nCloudprober alert \"test-alert\" for \"test-target:1234\":\n\nFailures: 1 out of 2 probes\nFailing since: 0001-01-01T00:00:00Z\nProbe: test-probe\nDashboard: http://localhost:9313/status?probe=test-probe\nPlaybook: \n\nDetails:\nalert: test-alert\ndashboard_url: http://localhost:9313/status?probe=test-probe\nfailures: 1\nplaybook_url: \nprobe: test-probe\nsince: 0001-01-01T00:00:00Z\ntarget: test-target:1234\ntarget.label.owner: manugarg@a.b\ntotal: 2\r\n",
 		},
 	}
 

--- a/probes/alerting/notifier/opsgenie/api.go
+++ b/probes/alerting/notifier/opsgenie/api.go
@@ -148,5 +148,5 @@ func (c *Client) createAlertMessage(alertInfo *alertinfo.AlertInfo, alertFields 
 
 // dedupeKey returns a deduplication key.
 func dedupeKey(alertInfo *alertinfo.AlertInfo) string {
-	return alertInfo.DeDuplicationID
+	return alertInfo.DeduplicationID
 }

--- a/probes/alerting/notifier/opsgenie/api.go
+++ b/probes/alerting/notifier/opsgenie/api.go
@@ -148,5 +148,5 @@ func (c *Client) createAlertMessage(alertInfo *alertinfo.AlertInfo, alertFields 
 
 // dedupeKey returns a deduplication key.
 func dedupeKey(alertInfo *alertinfo.AlertInfo) string {
-	return alertInfo.ConditionID
+	return alertInfo.DeDuplicationID
 }

--- a/probes/alerting/notifier/opsgenie/api_test.go
+++ b/probes/alerting/notifier/opsgenie/api_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestAlertRequest(t *testing.T) {
 	alertInfo := &alertinfo.AlertInfo{
-		ConditionID: "test-condition",
+		DeDuplicationID: "test-condition",
 	}
 
 	testKey := "test-genie-key"

--- a/probes/alerting/notifier/opsgenie/api_test.go
+++ b/probes/alerting/notifier/opsgenie/api_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestAlertRequest(t *testing.T) {
 	alertInfo := &alertinfo.AlertInfo{
-		DeDuplicationID: "test-condition",
+		DeduplicationID: "test-condition",
 	}
 
 	testKey := "test-genie-key"

--- a/probes/alerting/notifier/opsgenie/opsgenie_test.go
+++ b/probes/alerting/notifier/opsgenie/opsgenie_test.go
@@ -159,7 +159,7 @@ func TestClientNotify(t *testing.T) {
 		{
 			name: "no-error",
 			alertInfo: &alertinfo.AlertInfo{
-				ConditionID: "test-condition",
+				DeDuplicationID: "test-condition",
 			},
 			alertFields: map[string]string{
 				"summary": "test-alert-message",
@@ -170,7 +170,7 @@ func TestClientNotify(t *testing.T) {
 		{
 			name: "alias-mismatch",
 			alertInfo: &alertinfo.AlertInfo{
-				ConditionID: "test-condition-2",
+				DeDuplicationID: "test-condition-2",
 			},
 			alertFields:   map[string]string{},
 			wantAlias:     "test-condition-3",
@@ -224,14 +224,14 @@ func TestClientNotifyResolve(t *testing.T) {
 		{
 			name: "default",
 			alertInfo: &alertinfo.AlertInfo{
-				ConditionID: "test-condition",
+				DeDuplicationID: "test-condition",
 			},
 			wantURL: "https://api.opsgenie.com/v2/alerts/test-condition/close?identifierType=alias",
 		},
 		{
 			name: "default-mismatch",
 			alertInfo: &alertinfo.AlertInfo{
-				ConditionID: "test-condition2",
+				DeDuplicationID: "test-condition2",
 			},
 			wantURL:       "https://api.opsgenie.com/v2/alerts/test-condition/close?identifierType=alias",
 			errorContains: "url mismatch",
@@ -243,7 +243,7 @@ func TestClientNotifyResolve(t *testing.T) {
 			},
 			alertInfo: &alertinfo.AlertInfo{
 				// there is mismatch but resolve is disabled
-				ConditionID: "test-condition2",
+				DeDuplicationID: "test-condition2",
 			},
 			wantURL: "https://api.opsgenie.com/v2/alerts/test-condition/close?identifierType=alias",
 		},

--- a/probes/alerting/notifier/opsgenie/opsgenie_test.go
+++ b/probes/alerting/notifier/opsgenie/opsgenie_test.go
@@ -159,7 +159,7 @@ func TestClientNotify(t *testing.T) {
 		{
 			name: "no-error",
 			alertInfo: &alertinfo.AlertInfo{
-				DeDuplicationID: "test-condition",
+				DeduplicationID: "test-condition",
 			},
 			alertFields: map[string]string{
 				"summary": "test-alert-message",
@@ -170,7 +170,7 @@ func TestClientNotify(t *testing.T) {
 		{
 			name: "alias-mismatch",
 			alertInfo: &alertinfo.AlertInfo{
-				DeDuplicationID: "test-condition-2",
+				DeduplicationID: "test-condition-2",
 			},
 			alertFields:   map[string]string{},
 			wantAlias:     "test-condition-3",
@@ -224,14 +224,14 @@ func TestClientNotifyResolve(t *testing.T) {
 		{
 			name: "default",
 			alertInfo: &alertinfo.AlertInfo{
-				DeDuplicationID: "test-condition",
+				DeduplicationID: "test-condition",
 			},
 			wantURL: "https://api.opsgenie.com/v2/alerts/test-condition/close?identifierType=alias",
 		},
 		{
 			name: "default-mismatch",
 			alertInfo: &alertinfo.AlertInfo{
-				DeDuplicationID: "test-condition2",
+				DeduplicationID: "test-condition2",
 			},
 			wantURL:       "https://api.opsgenie.com/v2/alerts/test-condition/close?identifierType=alias",
 			errorContains: "url mismatch",
@@ -243,7 +243,7 @@ func TestClientNotifyResolve(t *testing.T) {
 			},
 			alertInfo: &alertinfo.AlertInfo{
 				// there is mismatch but resolve is disabled
-				DeDuplicationID: "test-condition2",
+				DeduplicationID: "test-condition2",
 			},
 			wantURL: "https://api.opsgenie.com/v2/alerts/test-condition/close?identifierType=alias",
 		},

--- a/probes/alerting/notifier/pagerduty/event_v2.go
+++ b/probes/alerting/notifier/pagerduty/event_v2.go
@@ -220,5 +220,5 @@ func generateLinks(alertFields map[string]string) []EventV2Links {
 // those events being applied to an open alert matching that dedup_key.
 // https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgx-send-an-alert-event#alert-de-duplication
 func eventV2DedupeKey(alertInfo *alertinfo.AlertInfo) string {
-	return alertInfo.ConditionID
+	return alertInfo.DeDuplicationID
 }

--- a/probes/alerting/notifier/pagerduty/event_v2.go
+++ b/probes/alerting/notifier/pagerduty/event_v2.go
@@ -220,5 +220,5 @@ func generateLinks(alertFields map[string]string) []EventV2Links {
 // those events being applied to an open alert matching that dedup_key.
 // https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTgx-send-an-alert-event#alert-de-duplication
 func eventV2DedupeKey(alertInfo *alertinfo.AlertInfo) string {
-	return alertInfo.DeDuplicationID
+	return alertInfo.DeduplicationID
 }

--- a/probes/alerting/notifier/pagerduty/pagerduty_test.go
+++ b/probes/alerting/notifier/pagerduty/pagerduty_test.go
@@ -145,7 +145,7 @@ func TestPagerDutySendEventV2Error(t *testing.T) {
 }
 
 func TestPagerDutyEventV2DedupeKey(t *testing.T) {
-	assert.Equal(t, "testConditionId", eventV2DedupeKey(&alertinfo.AlertInfo{DeDuplicationID: "testConditionId"}))
+	assert.Equal(t, "testConditionId", eventV2DedupeKey(&alertinfo.AlertInfo{DeduplicationID: "testConditionId"}))
 }
 
 func TestPagerDutyCreateTriggerRequest(t *testing.T) {
@@ -184,7 +184,7 @@ func TestPagerDutyCreateTriggerRequest(t *testing.T) {
 			}
 
 			alertInfo := &alertinfo.AlertInfo{
-				DeDuplicationID: "test-condition-id",
+				DeduplicationID: "test-condition-id",
 			}
 
 			alertFields := map[string]string{
@@ -253,7 +253,7 @@ func TestPagerDutyCreateResolveRequest(t *testing.T) {
 	}{
 		"simple": {
 			alertInfo: &alertinfo.AlertInfo{
-				DeDuplicationID: "test-condition-id",
+				DeduplicationID: "test-condition-id",
 			},
 			alertFields: map[string]string{
 				"summary": "test-summary",

--- a/probes/alerting/notifier/pagerduty/pagerduty_test.go
+++ b/probes/alerting/notifier/pagerduty/pagerduty_test.go
@@ -145,7 +145,7 @@ func TestPagerDutySendEventV2Error(t *testing.T) {
 }
 
 func TestPagerDutyEventV2DedupeKey(t *testing.T) {
-	assert.Equal(t, "testConditionId", eventV2DedupeKey(&alertinfo.AlertInfo{ConditionID: "testConditionId"}))
+	assert.Equal(t, "testConditionId", eventV2DedupeKey(&alertinfo.AlertInfo{DeDuplicationID: "testConditionId"}))
 }
 
 func TestPagerDutyCreateTriggerRequest(t *testing.T) {
@@ -184,7 +184,7 @@ func TestPagerDutyCreateTriggerRequest(t *testing.T) {
 			}
 
 			alertInfo := &alertinfo.AlertInfo{
-				ConditionID: "test-condition-id",
+				DeDuplicationID: "test-condition-id",
 			}
 
 			alertFields := map[string]string{
@@ -192,7 +192,6 @@ func TestPagerDutyCreateTriggerRequest(t *testing.T) {
 				"summary":       "test-summary",
 				"probe":         "test-probe",
 				"target":        "test-target",
-				"condition_id":  "test-condition-id",
 				"failures":      "1",
 				"total":         "2",
 				"since":         "2020-01-01T00:00:00Z",
@@ -232,7 +231,6 @@ func TestPagerDutyCreateTriggerRequest(t *testing.T) {
 						"alert":         "test-alert",
 						"probe":         "test-probe",
 						"target":        "test-target",
-						"condition_id":  "test-condition-id",
 						"failures":      "1",
 						"total":         "2",
 						"since":         "2020-01-01T00:00:00Z",
@@ -255,12 +253,11 @@ func TestPagerDutyCreateResolveRequest(t *testing.T) {
 	}{
 		"simple": {
 			alertInfo: &alertinfo.AlertInfo{
-				ConditionID: "test-condition-id",
+				DeDuplicationID: "test-condition-id",
 			},
 			alertFields: map[string]string{
-				"condition_id": "test-condition-id",
-				"summary":      "test-summary",
-				"target":       "test-target",
+				"summary": "test-summary",
+				"target":  "test-target",
 			},
 			want: &EventV2Request{
 				RoutingKey:  "test-routing-key",


### PR DESCRIPTION
- Instead use probe, alert, target info to create a unique de-duplication key, to be used by systems that support de-duplication.