### PR TITLE
[cleanup] A bunch of cleanup

### DIFF
--- a/contrib/gcp/cmd/bigquery_probe.go
+++ b/contrib/gcp/cmd/bigquery_probe.go
@@ -25,13 +25,14 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"flag"
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
+
 	"github.com/cloudprober/cloudprober/contrib/gcp/bigquery"
 	serverpb "github.com/cloudprober/cloudprober/probes/external/proto"
 	"github.com/cloudprober/cloudprober/probes/external/serverutils"
+	"google.golang.org/protobuf/proto"
 )
 
 var (
@@ -54,14 +55,14 @@ func main() {
 	flag.Parse()
 
 	if *projectID == "" {
-		glog.Exitf("--project_id must be specified")
+		log.Fatalf("--project_id must be specified")
 	}
 
 	dstTable := *table
 	ctx := context.Background()
 	runner, err := bigquery.NewRunner(ctx, *projectID)
 	if err != nil {
-		glog.Fatal(err)
+		log.Fatal(err)
 	}
 
 	if *serverMode {
@@ -70,7 +71,7 @@ func main() {
 			opts := parseProbeRequest(request)
 			if val, ok := opts["table"]; ok {
 				dstTable = val
-				glog.Infof("--table set to %q by ProbeRequest config", val)
+				log.Printf("--table set to %q by ProbeRequest config", val)
 			}
 			payload, err := bigquery.Probe(ctx, runner, dstTable)
 			reply.Payload = proto.String(payload)
@@ -82,7 +83,7 @@ func main() {
 
 	payload, err := bigquery.Probe(ctx, runner, dstTable)
 	if err != nil {
-		glog.Fatal(err)
+		log.Fatal(err)
 	}
 	fmt.Println(payload)
 

--- a/docs/content/docs/how-to/alerting/index.md
+++ b/docs/content/docs/how-to/alerting/index.md
@@ -81,6 +81,7 @@ currently supports the following notification targets:
 - [Opsgenie](/docs/config/alerting/#cloudprober_alerting_Opsgenie)
 - [Slack](/docs/config/alerting/#cloudprober_alerting_Slack)
 - [Command](/docs/config/alerting/#cloudprober_alerting_NotifyConfig)
+- [HTTP](/docs/config/alerting/#cloudprober_alerting_NotifyConfig)
 
 Configuration documentation (linked above) has more details on each of them.
 

--- a/examples/external/redis_probe.go
+++ b/examples/external/redis_probe.go
@@ -50,8 +50,8 @@ import (
 
 	epb "github.com/cloudprober/cloudprober/probes/external/proto"
 	"github.com/cloudprober/cloudprober/probes/external/serverutils"
-	"github.com/golang/protobuf/proto"
 	"github.com/hoisie/redis"
+	"google.golang.org/protobuf/proto"
 )
 
 var server = flag.Bool("server", false, "Whether to run in server mode")

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.11
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.18.3
 	github.com/fullstorydev/grpcurl v1.8.7
-	github.com/golang/glog v1.1.2
 	github.com/golang/protobuf v1.5.3
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,6 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/goccy/go-json v0.9.11 h1:/pAaQDLHEoCq/5FFmSKBswWmK6H0e8g4159Kc/X/nqk=
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.1.2 h1:DVjP2PbBOzHyzA+dn3WhHIq4NdVu3Q+pvivFICf/7fo=
-github.com/golang/glog v1.1.2/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/rLQ=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/internal/rds/client/cmd/client.go
+++ b/internal/rds/client/cmd/client.go
@@ -17,13 +17,13 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
 	"flag"
 
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/cloudprober/cloudprober/internal/rds/client"
 	configpb "github.com/cloudprober/cloudprober/internal/rds/client/proto"
@@ -47,7 +47,7 @@ func main() {
 	flag.Parse()
 
 	if *project == "" {
-		glog.Exit("--project is a required paramater")
+		log.Fatal("--project is a required paramater")
 	}
 
 	serverName := *certServerName
@@ -90,7 +90,7 @@ func main() {
 		}
 		fParts := strings.SplitN(f, "=", 2)
 		if len(fParts) != 2 {
-			glog.Exitf("bad filter in --filters flag (%s): %s", *filtersF, f)
+			log.Fatalf("bad filter in --filters flag (%s): %s", *filtersF, f)
 		}
 		c.Request.Filter = append(c.Request.Filter, &pb.Filter{
 			Key:   proto.String(fParts[0]),
@@ -100,7 +100,7 @@ func main() {
 
 	tgts, err := client.New(c, nil, &logger.Logger{})
 	if err != nil {
-		glog.Exit(err)
+		log.Fatal(err)
 	}
 	for {
 		fmt.Printf("%s\n", time.Now())

--- a/internal/rds/gcp/rtc_variables.go
+++ b/internal/rds/gcp/rtc_variables.go
@@ -26,9 +26,9 @@ import (
 	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
 	"github.com/cloudprober/cloudprober/internal/rds/server/filter"
 	"github.com/cloudprober/cloudprober/logger"
-	"github.com/golang/protobuf/proto"
 	"golang.org/x/oauth2/google"
 	runtimeconfig "google.golang.org/api/runtimeconfig/v1beta1"
+	"google.golang.org/protobuf/proto"
 )
 
 // rtcVar is an internal representation of the runtimeconfig (RTC) variables.

--- a/internal/rds/gcp/rtc_variables_test.go
+++ b/internal/rds/gcp/rtc_variables_test.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
-	"github.com/golang/protobuf/proto"
 	runtimeconfig "google.golang.org/api/runtimeconfig/v1beta1"
+	"google.golang.org/protobuf/proto"
 )
 
 type testVar struct {

--- a/internal/rds/kubernetes/endpoints.go
+++ b/internal/rds/kubernetes/endpoints.go
@@ -27,7 +27,7 @@ import (
 	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
 	"github.com/cloudprober/cloudprober/internal/rds/server/filter"
 	"github.com/cloudprober/cloudprober/logger"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 type epLister struct {
@@ -148,7 +148,7 @@ func (epi *epInfo) resources(portFilter *filter.RegexFilter, l *logger.Logger) (
 				resources = append(resources, &pb.Resource{
 					Name:   proto.String(resName),
 					Ip:     proto.String(addr.IP),
-					Port:   proto.Int(port.Port),
+					Port:   proto.Int32(int32(port.Port)),
 					Labels: labels,
 				})
 			}

--- a/internal/rds/kubernetes/ingresses.go
+++ b/internal/rds/kubernetes/ingresses.go
@@ -26,7 +26,7 @@ import (
 	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
 	"github.com/cloudprober/cloudprober/internal/rds/server/filter"
 	"github.com/cloudprober/cloudprober/logger"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 type ingressesLister struct {

--- a/internal/rds/kubernetes/ingresses_test.go
+++ b/internal/rds/kubernetes/ingresses_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 func testIngressInfo(k resourceKey, ingressIP, hostname string, labels map[string]string) *ingressInfo {

--- a/internal/rds/kubernetes/services.go
+++ b/internal/rds/kubernetes/services.go
@@ -27,7 +27,7 @@ import (
 	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
 	"github.com/cloudprober/cloudprober/internal/rds/server/filter"
 	"github.com/cloudprober/cloudprober/logger"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 type servicesLister struct {

--- a/internal/rds/kubernetes/services_test.go
+++ b/internal/rds/kubernetes/services_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 func testServiceInfo(name, ns, ip, publicIP, hostname string, labels map[string]string, ports []int) *serviceInfo {

--- a/internal/rds/server/filter/utils_test.go
+++ b/internal/rds/server/filter/utils_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestParseFilters(t *testing.T) {

--- a/internal/rds/server/server_test.go
+++ b/internal/rds/server/server_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 type testProvider struct {

--- a/internal/servers/grpc/grpc.go
+++ b/internal/servers/grpc/grpc.go
@@ -22,10 +22,10 @@ import (
 	"net"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/reflection"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/cloudprober/cloudprober/config/runconfig"
 	configpb "github.com/cloudprober/cloudprober/internal/servers/grpc/proto"

--- a/internal/servers/grpc/grpc_test.go
+++ b/internal/servers/grpc/grpc_test.go
@@ -29,8 +29,8 @@ import (
 	pb "github.com/cloudprober/cloudprober/internal/servers/grpc/proto"
 	spb "github.com/cloudprober/cloudprober/internal/servers/grpc/proto"
 	"github.com/cloudprober/cloudprober/logger"
-	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 )
 
 var once sync.Once

--- a/internal/servers/udp/cmd/udp.go
+++ b/internal/servers/udp/cmd/udp.go
@@ -20,16 +20,15 @@ package main
 
 import (
 	"context"
+	"log"
 	"log/slog"
 
 	"github.com/cloudprober/cloudprober/internal/servers/udp"
 	configpb "github.com/cloudprober/cloudprober/internal/servers/udp/proto"
 	"github.com/cloudprober/cloudprober/logger"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 
 	"flag"
-
-	"github.com/golang/glog"
 )
 
 var (
@@ -46,7 +45,7 @@ func main() {
 	}
 	server, err := udp.New(context.Background(), config, logger.NewWithAttrs(slog.String("component", "UDP_"+*responseType)))
 	if err != nil {
-		glog.Fatalf("Error creating a new UDP server: %v", err)
+		log.Fatalf("Error creating a new UDP server: %v", err)
 	}
-	glog.Fatal(server.Start(context.Background(), nil))
+	log.Fatal(server.Start(context.Background(), nil))
 }

--- a/internal/servers/udp/udp_test.go
+++ b/internal/servers/udp/udp_test.go
@@ -27,7 +27,7 @@ import (
 
 	configpb "github.com/cloudprober/cloudprober/internal/servers/udp/proto"
 	"github.com/cloudprober/cloudprober/logger"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 // Return true if the underlying error indicates a udp.Client timeout.

--- a/metrics/payload/payload_test.go
+++ b/metrics/payload/payload_test.go
@@ -23,7 +23,8 @@ import (
 
 	"github.com/cloudprober/cloudprober/metrics"
 	configpb "github.com/cloudprober/cloudprober/metrics/payload/proto"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
 )
 
 var (
@@ -44,7 +45,7 @@ func parserForTest(t *testing.T, agg bool, additionalLabels string) *Parser {
  `
 
 	var c configpb.OutputMetricsOptions
-	if err := proto.UnmarshalText(fmt.Sprintf(testConf, agg), &c); err != nil {
+	if err := prototext.Unmarshal([]byte(fmt.Sprintf(testConf, agg)), &c); err != nil {
 		t.Error(err)
 	}
 	if additionalLabels != "" {

--- a/probes/dns/cmd/dns.go
+++ b/probes/dns/cmd/dns.go
@@ -21,17 +21,18 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"time"
 
 	"flag"
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
+
 	"github.com/cloudprober/cloudprober/metrics"
 	"github.com/cloudprober/cloudprober/probes/dns"
 	configpb "github.com/cloudprober/cloudprober/probes/dns/proto"
 	"github.com/cloudprober/cloudprober/probes/options"
 	"github.com/cloudprober/cloudprober/targets"
+	"google.golang.org/protobuf/encoding/prototext"
 )
 
 var (
@@ -51,10 +52,10 @@ func main() {
 	if *config != "" {
 		b, err := ioutil.ReadFile(*config)
 		if err != nil {
-			glog.Exit(err)
+			log.Fatal(err)
 		}
-		if err := proto.UnmarshalText(string(b), c); err != nil {
-			glog.Exitf("Error while parsing config protobuf %s: Err: %v", string(b), err)
+		if err := prototext.Unmarshal(b, c); err != nil {
+			log.Fatalf("Error while parsing config protobuf %s: Err: %v", string(b), err)
 		}
 	}
 
@@ -68,12 +69,12 @@ func main() {
 	if *sourceIP != "" {
 		opts.SourceIP = net.ParseIP(*sourceIP)
 		if opts.SourceIP == nil {
-			glog.Exitf("Error parsing source IP: %s", *sourceIP)
+			log.Fatalf("Error parsing source IP: %s", *sourceIP)
 		}
 	}
 	dp := &dns.Probe{}
 	if err := dp.Init("dns_test", opts); err != nil {
-		glog.Exitf("Error in initializing probe %s from the config. Err: %v", "dns_test", err)
+		log.Fatalf("Error in initializing probe %s from the config. Err: %v", "dns_test", err)
 	}
 	dataChan := make(chan *metrics.EventMetrics, 1000)
 	go dp.Start(context.Background(), dataChan)

--- a/probes/dns/dns_test.go
+++ b/probes/dns/dns_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/cloudprober/cloudprober/probes/options"
 	"github.com/cloudprober/cloudprober/targets"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
-	"github.com/golang/protobuf/proto"
 	"github.com/miekg/dns"
+	"google.golang.org/protobuf/proto"
 )
 
 // If question contains a bad domain or type, DNS query response status should

--- a/probes/external/cmd/external.go
+++ b/probes/external/cmd/external.go
@@ -21,16 +21,17 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"time"
 
 	"flag"
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
+
 	"github.com/cloudprober/cloudprober/metrics"
 	"github.com/cloudprober/cloudprober/probes/external"
 	configpb "github.com/cloudprober/cloudprober/probes/external/proto"
 	"github.com/cloudprober/cloudprober/probes/options"
 	"github.com/cloudprober/cloudprober/targets"
+	"google.golang.org/protobuf/encoding/prototext"
 )
 
 var (
@@ -52,10 +53,10 @@ func main() {
 	if *config != "" {
 		b, err := ioutil.ReadFile(*config)
 		if err != nil {
-			glog.Exit(err)
+			log.Fatal(err)
 		}
-		if err = proto.UnmarshalText(string(b), c); err != nil {
-			glog.Exitf("Error while parsing config protobuf %s: Err: %v", string(b), err)
+		if err = prototext.Unmarshal(b, c); err != nil {
+			log.Fatalf("Error while parsing config protobuf %s: Err: %v", string(b), err)
 		}
 	}
 
@@ -68,7 +69,7 @@ func main() {
 
 	ep := &external.Probe{}
 	if err := ep.Init("external_test", opts); err != nil {
-		glog.Exitf("Error in initializing probe %s from the config. Err: %v", "external_test", err)
+		log.Fatalf("Error in initializing probe %s from the config. Err: %v", "external_test", err)
 	}
 	dataChan := make(chan *metrics.EventMetrics, 1000)
 	go ep.Start(context.Background(), dataChan)

--- a/probes/external/serverutils/serverutils.go
+++ b/probes/external/serverutils/serverutils.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	serverpb "github.com/cloudprober/cloudprober/probes/external/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 func readPayload(r *bufio.Reader) ([]byte, error) {
@@ -103,20 +103,21 @@ func WriteMessage(pb proto.Message, w io.Writer) error {
 // Serve blocks indefinitely, servicing probe requests. Note that this function is
 // provided mainly to help external probe server implementations. Cloudprober doesn't
 // make use of it. Example usage:
-//	import (
-//		serverpb "github.com/cloudprober/cloudprober/probes/external/proto"
-//		"github.com/cloudprober/cloudprober/probes/external/serverutils"
-//	)
-//	func runProbe(opts []*cppb.ProbeRequest_Option) {
-//  	...
-//	}
-//	serverutils.Serve(func(req *serverpb.ProbeRequest, reply *serverpb.ProbeReply) {
-// 		payload, errMsg, _ := runProbe(req.GetOptions())
-//		reply.Payload = proto.String(payload)
-//		if errMsg != "" {
-//			reply.ErrorMessage = proto.String(errMsg)
+//
+//		import (
+//			serverpb "github.com/cloudprober/cloudprober/probes/external/proto"
+//			"github.com/cloudprober/cloudprober/probes/external/serverutils"
+//		)
+//		func runProbe(opts []*cppb.ProbeRequest_Option) {
+//	 	...
 //		}
-//	})
+//		serverutils.Serve(func(req *serverpb.ProbeRequest, reply *serverpb.ProbeReply) {
+//			payload, errMsg, _ := runProbe(req.GetOptions())
+//			reply.Payload = proto.String(payload)
+//			if errMsg != "" {
+//				reply.ErrorMessage = proto.String(errMsg)
+//			}
+//		})
 func Serve(probeFunc func(*serverpb.ProbeRequest, *serverpb.ProbeReply)) {
 	stdin := bufio.NewReader(os.Stdin)
 

--- a/probes/http/cmd/http.go
+++ b/probes/http/cmd/http.go
@@ -21,16 +21,17 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"time"
 
 	"flag"
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
+
 	"github.com/cloudprober/cloudprober/metrics"
 	"github.com/cloudprober/cloudprober/probes/http"
 	configpb "github.com/cloudprober/cloudprober/probes/http/proto"
 	"github.com/cloudprober/cloudprober/probes/options"
 	"github.com/cloudprober/cloudprober/targets"
+	"google.golang.org/protobuf/encoding/prototext"
 )
 
 var (
@@ -49,10 +50,10 @@ func main() {
 	if *config != "" {
 		b, err := ioutil.ReadFile(*config)
 		if err != nil {
-			glog.Exit(err)
+			log.Fatal(err)
 		}
-		if err = proto.UnmarshalText(string(b), c); err != nil {
-			glog.Exitf("Error while parsing config protobuf %s: Err: %v", string(b), err)
+		if err = prototext.Unmarshal(b, c); err != nil {
+			log.Fatalf("Error while parsing config protobuf %s: Err: %v", string(b), err)
 		}
 	}
 
@@ -65,7 +66,7 @@ func main() {
 
 	hp := &http.Probe{}
 	if err := hp.Init("http_test", opts); err != nil {
-		glog.Exitf("Error in initializing probe %s from the config. Err: %v", "http_test", err)
+		log.Fatalf("Error in initializing probe %s from the config. Err: %v", "http_test", err)
 	}
 	dataChan := make(chan *metrics.EventMetrics, 1000)
 	go hp.Start(context.Background(), dataChan)

--- a/probes/http/http_test.go
+++ b/probes/http/http_test.go
@@ -37,9 +37,9 @@ import (
 	"github.com/cloudprober/cloudprober/probes/options"
 	"github.com/cloudprober/cloudprober/targets"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
-	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
+	"google.golang.org/protobuf/proto"
 )
 
 // The Transport is mocked instead of the Client because Client is not an

--- a/probes/http/request_test.go
+++ b/probes/http/request_test.go
@@ -25,9 +25,9 @@ import (
 	"github.com/cloudprober/cloudprober/probes/options"
 	"github.com/cloudprober/cloudprober/targets"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
-	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestHostWithPort(t *testing.T) {

--- a/probes/options/labels_test.go
+++ b/probes/options/labels_test.go
@@ -20,7 +20,7 @@ import (
 
 	configpb "github.com/cloudprober/cloudprober/probes/proto"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 var configWithAdditionalLabels = &configpb.ProbeDef{

--- a/probes/ping/cmd/ping.go
+++ b/probes/ping/cmd/ping.go
@@ -21,16 +21,17 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"time"
 
 	"flag"
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
+
 	"github.com/cloudprober/cloudprober/metrics"
 	"github.com/cloudprober/cloudprober/probes/options"
 	"github.com/cloudprober/cloudprober/probes/ping"
 	configpb "github.com/cloudprober/cloudprober/probes/ping/proto"
 	"github.com/cloudprober/cloudprober/targets"
+	"google.golang.org/protobuf/encoding/prototext"
 )
 
 var (
@@ -46,10 +47,10 @@ func main() {
 	if *config != "" {
 		b, err := ioutil.ReadFile(*config)
 		if err != nil {
-			glog.Exit(err)
+			log.Fatal(err)
 		}
-		if err = proto.UnmarshalText(string(b), probeConfig); err != nil {
-			glog.Exitf("error while parsing config: %v", err)
+		if err = prototext.Unmarshal(b, probeConfig); err != nil {
+			log.Fatalf("error while parsing config: %v", err)
 		}
 	}
 
@@ -64,7 +65,7 @@ func main() {
 	}
 	p := &ping.Probe{}
 	if err := p.Init("ping", opts); err != nil {
-		glog.Exitf("error initializing ping probe from config: %v", err)
+		log.Fatalf("error initializing ping probe from config: %v", err)
 	}
 
 	dataChan := make(chan *metrics.EventMetrics, 1000)

--- a/probes/ping/ping.go
+++ b/probes/ping/ping.go
@@ -57,7 +57,7 @@ import (
 	"github.com/cloudprober/cloudprober/probes/options"
 	configpb "github.com/cloudprober/cloudprober/probes/ping/proto"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 const (

--- a/probes/ping/ping_test.go
+++ b/probes/ping/ping_test.go
@@ -30,10 +30,10 @@ import (
 	configpb "github.com/cloudprober/cloudprober/probes/ping/proto"
 	"github.com/cloudprober/cloudprober/targets"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
-	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
+	"google.golang.org/protobuf/proto"
 )
 
 func peerToIP(peer net.Addr) string {

--- a/probes/ping/pingutils_test.go
+++ b/probes/ping/pingutils_test.go
@@ -19,13 +19,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/cloudprober/cloudprober/probes/options"
 	configpb "github.com/cloudprober/cloudprober/probes/ping/proto"
 	"github.com/cloudprober/cloudprober/targets"
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestPreparePayload(t *testing.T) {

--- a/probes/tcp/cmd/tcp.go
+++ b/probes/tcp/cmd/tcp.go
@@ -20,6 +20,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"flag"
@@ -29,7 +30,6 @@ import (
 	"github.com/cloudprober/cloudprober/probes/tcp"
 	configpb "github.com/cloudprober/cloudprober/probes/tcp/proto"
 	"github.com/cloudprober/cloudprober/targets"
-	"github.com/golang/glog"
 )
 
 var (
@@ -50,7 +50,7 @@ func main() {
 
 	tp := &tcp.Probe{}
 	if err := tp.Init("tcp_test", opts); err != nil {
-		glog.Exitf("Error in initializing probe %s from the config. Err: %v", "http_test", err)
+		log.Fatalf("Error in initializing probe %s from the config. Err: %v", "http_test", err)
 	}
 	dataChan := make(chan *metrics.EventMetrics, 1000)
 	go tp.Start(context.Background(), dataChan)

--- a/probes/udp/cmd/udp.go
+++ b/probes/udp/cmd/udp.go
@@ -20,17 +20,18 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"log"
+	"os"
 	"time"
 
 	"flag"
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
+
 	"github.com/cloudprober/cloudprober/metrics"
 	"github.com/cloudprober/cloudprober/probes/options"
 	"github.com/cloudprober/cloudprober/probes/udp"
 	configpb "github.com/cloudprober/cloudprober/probes/udp/proto"
 	"github.com/cloudprober/cloudprober/targets"
+	"google.golang.org/protobuf/encoding/prototext"
 )
 
 var (
@@ -47,12 +48,12 @@ func main() {
 
 	// If we are given a config file, read it. If not, use defaults.
 	if *config != "" {
-		b, err := ioutil.ReadFile(*config)
+		b, err := os.ReadFile(*config)
 		if err != nil {
-			glog.Exit(err)
+			log.Fatalf("Error while reading config file: %v", err)
 		}
-		if err := proto.UnmarshalText(string(b), c); err != nil {
-			glog.Exitf("Error while parsing config protobuf %s: Err: %v", string(b), err)
+		if err := prototext.Unmarshal(b, c); err != nil {
+			log.Fatalf("Error while parsing config protobuf %s: Err: %v", string(b), err)
 		}
 	}
 
@@ -65,7 +66,7 @@ func main() {
 
 	up := &udp.Probe{}
 	if err := up.Init("udp_test", opts); err != nil {
-		glog.Exitf("Error in initializing probe %s from the config. Err: %v", "udp_test", err)
+		log.Fatalf("Error in initializing probe %s from the config. Err: %v", "udp_test", err)
 	}
 	dataChan := make(chan *metrics.EventMetrics, 1000)
 	go up.Start(context.Background(), dataChan)

--- a/surfacers/internal/file/file_test.go
+++ b/surfacers/internal/file/file_test.go
@@ -28,8 +28,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/kylelemons/godebug/pretty"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/cloudprober/cloudprober/metrics"
 	"github.com/cloudprober/cloudprober/surfacers/internal/common/compress"

--- a/targets/gce/gce.go
+++ b/targets/gce/gce.go
@@ -63,7 +63,7 @@ import (
 	"github.com/cloudprober/cloudprober/targets/endpoint"
 	configpb "github.com/cloudprober/cloudprober/targets/gce/proto"
 	dnsRes "github.com/cloudprober/cloudprober/targets/resolver"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/cloudprober/cloudprober/internal/rds/client"
 	clientconfigpb "github.com/cloudprober/cloudprober/internal/rds/client/proto"

--- a/targets/gce/gce_test.go
+++ b/targets/gce/gce_test.go
@@ -27,7 +27,7 @@ import (
 	rdspb "github.com/cloudprober/cloudprober/internal/rds/proto"
 	"github.com/cloudprober/cloudprober/logger"
 	configpb "github.com/cloudprober/cloudprober/targets/gce/proto"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 type testNetIf struct {

--- a/targets/gce/gce_utils.go
+++ b/targets/gce/gce_utils.go
@@ -23,9 +23,9 @@ import (
 	rdspb "github.com/cloudprober/cloudprober/internal/rds/proto"
 	configpb "github.com/cloudprober/cloudprober/targets/gce/proto"
 	dnsRes "github.com/cloudprober/cloudprober/targets/resolver"
-	"github.com/golang/protobuf/proto"
 	"golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/protobuf/proto"
 )
 
 // defaultComputeService returns the compute service to use for the GCE API

--- a/targets/gce/gce_utils_test.go
+++ b/targets/gce/gce_utils_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	rdspb "github.com/cloudprober/cloudprober/internal/rds/proto"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestParseLabels(t *testing.T) {

--- a/targets/lameduck/lameduck.go
+++ b/targets/lameduck/lameduck.go
@@ -38,7 +38,7 @@ import (
 	configpb "github.com/cloudprober/cloudprober/targets/lameduck/proto"
 	targetspb "github.com/cloudprober/cloudprober/targets/proto"
 	"github.com/cloudprober/cloudprober/targets/rtc/rtcservice"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 // Lameducker provides an interface to Lameduck/Unlameduck an instance.

--- a/targets/lameduck/lameduck_test.go
+++ b/targets/lameduck/lameduck_test.go
@@ -24,7 +24,7 @@ import (
 
 	rdspb "github.com/cloudprober/cloudprober/internal/rds/proto"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 type mockLDLister struct {


### PR DESCRIPTION
- Replace "github.com/golang/protobuf/proto" by "google.golang.org/protobuf/proto" everywhere except probes.go and targets.go as new package doesn't support proto extensions the same way.
- Replace glog by log.