### PR TITLE
[config] Simplify and streamline config handling code

### DIFF
--- a/cloudprober.go
+++ b/cloudprober.go
@@ -38,6 +38,7 @@ import (
 	configpb "github.com/cloudprober/cloudprober/config/proto"
 	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/internal/servers"
+	"github.com/cloudprober/cloudprober/internal/sysvars"
 	"github.com/cloudprober/cloudprober/internal/tlsconfig"
 	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/prober"
@@ -141,10 +142,7 @@ func setDebugHandlers(srvMux *http.ServeMux) {
 
 // InitFromConfig initializes Cloudprober using the provided config.
 func InitFromConfig(configFile string) error {
-	configSrc := &config.DefaultConfigSource{
-		OverrideConfigFile: configFile,
-	}
-	return Init(configSrc)
+	return Init(config.ConfigSourceWithFile(configFile))
 }
 
 func Init(configSrc config.ConfigSource) error {
@@ -154,6 +152,11 @@ func Init(configSrc config.ConfigSource) error {
 
 	if cloudProber.prober != nil {
 		return nil
+	}
+
+	// Initialize sysvars module
+	if err := sysvars.Init(logger.NewWithAttrs(slog.String("component", sysvarsModuleName)), nil); err != nil {
+		return err
 	}
 
 	cfg, err := configSrc.GetConfig()

--- a/cloudprober.go
+++ b/cloudprober.go
@@ -142,10 +142,15 @@ func setDebugHandlers(srvMux *http.ServeMux) {
 
 // InitFromConfig initializes Cloudprober using the provided config.
 func InitFromConfig(configFile string) error {
-	return Init(config.ConfigSourceWithFile(configFile))
+	return InitWithConfigSource(config.ConfigSourceWithFile(configFile))
 }
 
-func Init(configSrc config.ConfigSource) error {
+// Init initializes Cloudprober using the default config source.
+func Init() error {
+	return InitWithConfigSource(config.DefaultConfigSource())
+}
+
+func InitWithConfigSource(configSrc config.ConfigSource) error {
 	// Return immediately if prober is already initialized.
 	cloudProber.Lock()
 	defer cloudProber.Unlock()

--- a/cloudprober.go
+++ b/cloudprober.go
@@ -156,12 +156,12 @@ func Init(configSrc config.ConfigSource) error {
 		return nil
 	}
 
-	globalLogger := logger.NewWithAttrs(slog.String("component", "global"))
-
 	cfg, err := configSrc.GetConfig()
 	if err != nil {
 		return err
 	}
+
+	globalLogger := logger.NewWithAttrs(slog.String("component", "global"))
 
 	// Start default HTTP server. It's used for profile handlers and
 	// prometheus exporter.

--- a/cmd/cloudprober.go
+++ b/cmd/cloudprober.go
@@ -170,7 +170,7 @@ func main() {
 
 	setupProfiling()
 
-	if err := cloudprober.InitFromConfig(""); err != nil {
+	if err := cloudprober.Init(nil); err != nil {
 		l.Criticalf("Error initializing cloudprober. Err: %v", err)
 	}
 

--- a/cmd/cloudprober.go
+++ b/cmd/cloudprober.go
@@ -152,7 +152,7 @@ func main() {
 
 	if *dumpConfig {
 		sysvars.Init(nil, configTestVars)
-		out, err := config.DumpConfig("", *dumpConfigFormat, sysvars.Vars())
+		out, err := config.DumpConfig(*dumpConfigFormat, nil)
 		if err != nil {
 			l.Criticalf("Error dumping config. Err: %v", err)
 		}
@@ -162,7 +162,7 @@ func main() {
 
 	if *configTest {
 		sysvars.Init(nil, configTestVars)
-		if err := config.ConfigTest("", sysvars.Vars()); err != nil {
+		if err := config.ConfigTest(nil); err != nil {
 			l.Criticalf("Config test failed. Err: %v", err)
 		}
 		return

--- a/cmd/cloudprober.go
+++ b/cmd/cloudprober.go
@@ -148,7 +148,7 @@ func main() {
 
 	setupProfiling()
 
-	if err := cloudprober.Init(nil); err != nil {
+	if err := cloudprober.Init(); err != nil {
 		l.Criticalf("Error initializing cloudprober. Err: %v", err)
 	}
 

--- a/cmd/cloudprober.go
+++ b/cmd/cloudprober.go
@@ -36,7 +36,6 @@ import (
 	"github.com/cloudprober/cloudprober"
 	"github.com/cloudprober/cloudprober/config"
 	"github.com/cloudprober/cloudprober/config/runconfig"
-	"github.com/cloudprober/cloudprober/internal/sysvars"
 	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/web"
 )
@@ -50,10 +49,6 @@ var (
 	configTest       = flag.Bool("configtest", false, "Dry run to test config file")
 	dumpConfig       = flag.Bool("dumpconfig", false, "Dump processed config to stdout")
 	dumpConfigFormat = flag.String("dumpconfig_fmt", "textpb", "Dump config format (textpb, json, yaml)")
-	testInstanceName = flag.String("test_instance_name", "ig-us-central1-a-01-0000", "Instance name example to be used in tests")
-
-	// configTestVars provides a sane set of sysvars for config testing.
-	configTestVars = map[string]string(nil)
 )
 
 // These variables get overwritten by using -ldflags="-X main.<var>=<value?" at
@@ -62,19 +57,6 @@ var version string
 var buildTimestamp string
 var dirty string
 var l *logger.Logger
-
-func setupConfigTestVars() {
-	configTestVars = map[string]string{
-		"zone":              "us-central1-a",
-		"project":           "fake-domain.com:fake-project",
-		"project_id":        "12345678",
-		"instance":          *testInstanceName,
-		"internal_ip":       "192.168.0.10",
-		"external_ip":       "10.10.10.10",
-		"instance_template": "ig-us-central1-a-01",
-		"machine_type":      "e2-small",
-	}
-}
 
 func setupProfiling() {
 	sigChan := make(chan os.Signal, 1)
@@ -148,10 +130,7 @@ func main() {
 		return
 	}
 
-	setupConfigTestVars()
-
 	if *dumpConfig {
-		sysvars.Init(nil, configTestVars)
 		out, err := config.DumpConfig(*dumpConfigFormat, nil)
 		if err != nil {
 			l.Criticalf("Error dumping config. Err: %v", err)
@@ -161,7 +140,6 @@ func main() {
 	}
 
 	if *configTest {
-		sysvars.Init(nil, configTestVars)
 		if err := config.ConfigTest(nil); err != nil {
 			l.Criticalf("Config test failed. Err: %v", err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,6 @@ var EnvRegex = regexp.MustCompile(`\*\*\$([^*\s]+)\*\*`)
 
 const (
 	configMetadataKeyName = "cloudprober_config"
-	defaultConfigFile     = "/etc/cloudprober.cfg"
 )
 
 var configTestVars = map[string]string{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -108,32 +108,36 @@ func TestConfigTest(t *testing.T) {
 	tests := []struct {
 		name       string
 		configFile string
-		baseVars   map[string]string
+		cs         ConfigSource
 		wantErr    bool
 	}{
 		{
-			name: "invalid_without_vars",
-			baseVars: map[string]string{
-				"az": "us-east-1a",
-			},
+			name:       "valid_base",
+			configFile: "testdata/cloudprober_base.cfg",
+		},
+		{
+			name:       "invalid_without_vars",
 			configFile: "testdata/cloudprober_invalid.cfg",
 			wantErr:    true,
 		},
 		{
+			name:    "no_config_error",
+			wantErr: true,
+		},
+		{
 			name: "valid_with_vars",
-			baseVars: map[string]string{
-				"probetype": "HTTP",
+			cs: &defaultConfigSource{
+				BaseVars: map[string]string{
+					"probetype": "HTTP",
+				},
 			},
 			configFile: "testdata/cloudprober_invalid.cfg",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cs := &defaultConfigSource{
-				FileName: tt.configFile,
-				BaseVars: tt.baseVars,
-			}
-			if err := ConfigTest(cs); (err != nil) != tt.wantErr {
+			*configFile = tt.configFile
+			if err := ConfigTest(tt.cs); (err != nil) != tt.wantErr {
 				t.Errorf("ConfigTest() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,7 +38,7 @@ func testConfigToProto(t *testing.T, fileName string) (*configpb.ProberConfig, e
 	if err != nil {
 		t.Error(err)
 	}
-	return configToProto(configStr, configFormat)
+	return configTextToProto(configStr, configFormat)
 }
 
 func TestConfigToProto(t *testing.T) {
@@ -129,7 +129,11 @@ func TestConfigTest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := ConfigTest(tt.configFile, tt.baseVars); (err != nil) != tt.wantErr {
+			cs := &DefaultConfigSource{
+				OverrideConfigFile: tt.configFile,
+				BaseVars:           tt.baseVars,
+			}
+			if err := ConfigTest(cs); (err != nil) != tt.wantErr {
 				t.Errorf("ConfigTest() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -192,7 +196,7 @@ surfacer: {
 	}
 	for _, tt := range tests {
 		t.Run(tt.format, func(t *testing.T) {
-			got, err := DumpConfig(tt.configFile, tt.format, nil)
+			got, err := DumpConfig(tt.format, &DefaultConfigSource{OverrideConfigFile: tt.configFile})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DumpConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,7 +38,7 @@ func testConfigToProto(t *testing.T, fileName string) (*configpb.ProberConfig, e
 	if err != nil {
 		t.Error(err)
 	}
-	return configTextToProto(configStr, configFormat)
+	return unmarshalConfig(configStr, configFormat)
 }
 
 func TestConfigToProto(t *testing.T) {
@@ -129,9 +129,9 @@ func TestConfigTest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cs := &DefaultConfigSource{
-				OverrideConfigFile: tt.configFile,
-				BaseVars:           tt.baseVars,
+			cs := &defaultConfigSource{
+				FileName: tt.configFile,
+				BaseVars: tt.baseVars,
 			}
 			if err := ConfigTest(cs); (err != nil) != tt.wantErr {
 				t.Errorf("ConfigTest() error = %v, wantErr %v", err, tt.wantErr)
@@ -196,7 +196,7 @@ surfacer: {
 	}
 	for _, tt := range tests {
 		t.Run(tt.format, func(t *testing.T) {
-			got, err := DumpConfig(tt.format, &DefaultConfigSource{OverrideConfigFile: tt.configFile})
+			got, err := DumpConfig(tt.format, &defaultConfigSource{FileName: tt.configFile})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DumpConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,7 +31,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func testConfigToProto(t *testing.T, fileName string) (*configpb.ProberConfig, error) {
+func testUnmarshalConfig(t *testing.T, fileName string) (*configpb.ProberConfig, error) {
 	t.Helper()
 
 	configStr, configFormat, err := readConfigFile(fileName)
@@ -41,7 +41,7 @@ func testConfigToProto(t *testing.T, fileName string) (*configpb.ProberConfig, e
 	return unmarshalConfig(configStr, configFormat)
 }
 
-func TestConfigToProto(t *testing.T) {
+func TestUnmarshalConfig(t *testing.T) {
 	wantCfg := &configpb.ProberConfig{
 		Probe: []*probespb.ProbeDef{
 			{
@@ -86,14 +86,14 @@ func TestConfigToProto(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := testConfigToProto(t, tt.configFile)
+			got, err := testUnmarshalConfig(t, tt.configFile)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ConfigToProto() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
 			if tt.want == nil {
-				cfg, err := testConfigToProto(t, tt.baseConfigFile)
+				cfg, err := testUnmarshalConfig(t, tt.baseConfigFile)
 				if err != nil {
 					t.Errorf("Error reading the base config itself: %v", err)
 				}

--- a/config/config_tmpl.go
+++ b/config/config_tmpl.go
@@ -154,8 +154,8 @@ func DefaultConfig() string {
 	return string(b)
 }
 
-// ParseTemplate processes a config file as a Go text template.
-func ParseTemplate(config string, sysVars map[string]string, getGCECustomMetadata func(string) (string, error)) (string, error) {
+// parseTemplate processes a config file as a Go text template.
+func parseTemplate(config string, sysVars map[string]string, getGCECustomMetadata func(string) (string, error)) (string, error) {
 	if getGCECustomMetadata == nil {
 		getGCECustomMetadata = readFromGCEMetadata
 	}

--- a/config/config_tmpl.go
+++ b/config/config_tmpl.go
@@ -129,7 +129,7 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 )
 
-// ReadFromGCEMetadata returns the value of GCE custom metadata variables. To
+// readFromGCEMetadata returns the value of GCE custom metadata variables. To
 // allow for instance level as project level variables, it looks for metadata
 // variable in the following order:
 //
@@ -138,7 +138,7 @@ import (
 //
 // b. If (and only if), the key is not found in the step above, we look for
 // the same key in the project's custom metadata.
-var ReadFromGCEMetadata = func(metadataKeyName string) (string, error) {
+var readFromGCEMetadata = func(metadataKeyName string) (string, error) {
 	val, err := metadata.InstanceAttributeValue(metadataKeyName)
 	// If instance level config found, return
 	if _, notFound := err.(metadata.NotDefinedError); !notFound {
@@ -157,7 +157,7 @@ func DefaultConfig() string {
 // ParseTemplate processes a config file as a Go text template.
 func ParseTemplate(config string, sysVars map[string]string, getGCECustomMetadata func(string) (string, error)) (string, error) {
 	if getGCECustomMetadata == nil {
-		getGCECustomMetadata = ReadFromGCEMetadata
+		getGCECustomMetadata = readFromGCEMetadata
 	}
 
 	gceCustomMetadataFunc := func(v string) (string, error) {

--- a/config/config_tmpl_test.go
+++ b/config/config_tmpl_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func testParse(config string, sysVars map[string]string) (*configpb.ProberConfig, error) {
-	textConfig, err := ParseTemplate(config, sysVars, nil)
+	textConfig, err := parseTemplate(config, sysVars, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ probe {
   }
 }
 `
-	textConfig, err := ParseTemplate(testConfig, map[string]string{}, func(key string) (string, error) {
+	textConfig, err := parseTemplate(testConfig, map[string]string{}, func(key string) (string, error) {
 		if key == "google-probe-name" {
 			return "google_dot_com_from", nil
 		}

--- a/config/configsource.go
+++ b/config/configsource.go
@@ -1,0 +1,119 @@
+// Copyright 2023 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"cloud.google.com/go/compute/metadata"
+	configpb "github.com/cloudprober/cloudprober/config/proto"
+	"github.com/cloudprober/cloudprober/internal/sysvars"
+	"github.com/cloudprober/cloudprober/logger"
+)
+
+const (
+	sysvarsModuleName = "sysvars"
+)
+
+type ConfigSource interface {
+	GetConfig() (*configpb.ProberConfig, error)
+	RawConfig() string
+	ParsedConfig() string
+}
+
+type DefaultConfigSource struct {
+	OverrideConfigFile   string
+	BaseVars             map[string]string
+	GetGCECustomMetadata func(string) (string, error)
+	l                    *logger.Logger
+
+	parsedConfig string
+	rawConfig    string
+	cfg          *configpb.ProberConfig
+}
+
+func getConfigContent(confFile string, l *logger.Logger) (content string, format string, err error) {
+	if confFile != "" {
+		return readConfigFile(confFile)
+	}
+
+	if *configFile != "" {
+		return readConfigFile(*configFile)
+	}
+
+	// On GCE first check if there is a config in custom metadata
+	// attributes.
+	if metadata.OnGCE() {
+		if config, err := readFromGCEMetadata(configMetadataKeyName); err != nil {
+			l.Infof("Error reading config from metadata. Err: %v", err)
+		} else {
+			return config, "", nil
+		}
+	}
+
+	// If config not found in metadata, check default config on disk
+	if _, err := os.Stat(defaultConfigFile); !os.IsNotExist(err) {
+		return readConfigFile(defaultConfigFile)
+	}
+
+	l.Warningf("Config file %s not found. Using default config.", defaultConfigFile)
+	return DefaultConfig(), "textpb", nil
+}
+
+func (dcs *DefaultConfigSource) parseConfig(configStr, configFormat string) (*configpb.ProberConfig, string, error) {
+	parsedConfig, err := ParseTemplate(configStr, dcs.BaseVars, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("error parsing config file as Go template. Err: %v", err)
+	}
+
+	cfg, err := configTextToProto(substEnvVars(parsedConfig, dcs.l), configFormat)
+	return cfg, parsedConfig, err
+}
+
+func (dcs *DefaultConfigSource) GetConfig() (*configpb.ProberConfig, error) {
+	if dcs.BaseVars == nil {
+		// Initialize sysvars module
+		if err := sysvars.Init(logger.NewWithAttrs(slog.String("component", sysvarsModuleName)), nil); err != nil {
+			return nil, err
+		}
+		dcs.BaseVars = sysvars.Vars()
+	}
+
+	configStr, configFormat, err := getConfigContent(dcs.OverrideConfigFile, dcs.l)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, parsedConfigStr, err := dcs.parseConfig(configStr, configFormat)
+	if err != nil {
+		return nil, err
+	}
+
+	dcs.parsedConfig = parsedConfigStr
+	dcs.rawConfig = configStr
+	dcs.cfg = cfg
+
+	return cfg, nil
+}
+
+func (dcs *DefaultConfigSource) RawConfig() string {
+	return dcs.rawConfig
+}
+
+func (dcs *DefaultConfigSource) ParsedConfig() string {
+	return dcs.parsedConfig
+}

--- a/config/configsource.go
+++ b/config/configsource.go
@@ -28,6 +28,8 @@ const (
 	sysvarsModuleName = "sysvars"
 )
 
+var defaultConfigFile = "/etc/cloudprober.cfg"
+
 type ConfigSource interface {
 	GetConfig() (*configpb.ProberConfig, error)
 	RawConfig() string

--- a/config/configsource.go
+++ b/config/configsource.go
@@ -46,9 +46,9 @@ type DefaultConfigSource struct {
 	cfg          *configpb.ProberConfig
 }
 
-func getConfigContent(confFile string, l *logger.Logger) (content string, format string, err error) {
-	if confFile != "" {
-		return readConfigFile(confFile)
+func (dcs *DefaultConfigSource) getConfigContent() (content string, format string, err error) {
+	if dcs.OverrideConfigFile != "" {
+		return readConfigFile(dcs.OverrideConfigFile)
 	}
 
 	if *configFile != "" {
@@ -59,7 +59,7 @@ func getConfigContent(confFile string, l *logger.Logger) (content string, format
 	// attributes.
 	if metadata.OnGCE() {
 		if config, err := readFromGCEMetadata(configMetadataKeyName); err != nil {
-			l.Infof("Error reading config from metadata. Err: %v", err)
+			dcs.l.Infof("Error reading config from metadata. Err: %v", err)
 		} else {
 			return config, "", nil
 		}
@@ -70,7 +70,7 @@ func getConfigContent(confFile string, l *logger.Logger) (content string, format
 		return readConfigFile(defaultConfigFile)
 	}
 
-	l.Warningf("Config file %s not found. Using default config.", defaultConfigFile)
+	dcs.l.Warningf("Config file %s not found. Using default config.", defaultConfigFile)
 	return DefaultConfig(), "textpb", nil
 }
 
@@ -93,7 +93,7 @@ func (dcs *DefaultConfigSource) GetConfig() (*configpb.ProberConfig, error) {
 		dcs.BaseVars = sysvars.Vars()
 	}
 
-	configStr, configFormat, err := getConfigContent(dcs.OverrideConfigFile, dcs.l)
+	configStr, configFormat, err := dcs.getConfigContent()
 	if err != nil {
 		return nil, err
 	}

--- a/config/configsource_test.go
+++ b/config/configsource_test.go
@@ -1,0 +1,121 @@
+// Copyright 2023 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	configpb "github.com/cloudprober/cloudprober/config/proto"
+	probespb "github.com/cloudprober/cloudprober/probes/proto"
+	surfacerspb "github.com/cloudprober/cloudprober/surfacers/proto"
+	targetspb "github.com/cloudprober/cloudprober/targets/proto"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestDefaultConfigSource(t *testing.T) {
+	wantCfg := &configpb.ProberConfig{
+		Probe: []*probespb.ProbeDef{
+			{
+				Name: proto.String("dns_k8s"),
+				Type: probespb.ProbeDef_DNS.Enum(),
+				Targets: &targetspb.TargetsDef{
+					Type: &targetspb.TargetsDef_HostNames{
+						HostNames: "10.0.0.1",
+					},
+				},
+			},
+		},
+		Surfacer: []*surfacerspb.SurfacerDef{
+			{
+				Type: surfacerspb.Type_STACKDRIVER.Enum(),
+			},
+		},
+	}
+	wantCfgStr := `probe {
+    name: "dns_k8s"
+    type: DNS
+    targets {
+        host_names: "10.0.0.1"
+    }
+}
+
+surfacer {
+    type: STACKDRIVER
+}`
+
+	tests := []struct {
+		name              string
+		filename          string
+		configFile        string
+		defaultConfigFile string
+		want              *configpb.ProberConfig
+		wantRawConfig     string
+		wantParsedConfig  string
+		wantErr           bool
+	}{
+		{
+			name:             "filename",
+			filename:         "testdata/cloudprober_base.cfg",
+			want:             wantCfg,
+			wantRawConfig:    wantCfgStr,
+			wantParsedConfig: wantCfgStr,
+		},
+		{
+			name:             "config_file_flag",
+			configFile:       "testdata/cloudprober_base.cfg",
+			want:             wantCfg,
+			wantRawConfig:    wantCfgStr,
+			wantParsedConfig: wantCfgStr,
+		},
+		{
+			name:              "default_config_file",
+			defaultConfigFile: "testdata/cloudprober_base.cfg",
+			want:              wantCfg,
+			wantRawConfig:     wantCfgStr,
+			wantParsedConfig:  wantCfgStr,
+		},
+		{
+			name:             "default_config",
+			want:             &configpb.ProberConfig{},
+			wantRawConfig:    "",
+			wantParsedConfig: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			*configFile = tt.configFile
+			dcs := &defaultConfigSource{
+				FileName: tt.filename,
+			}
+
+			if tt.defaultConfigFile != "" {
+				oldDefaultConfigFile := defaultConfigFile
+				defaultConfigFile = tt.defaultConfigFile
+				defer func() { defaultConfigFile = oldDefaultConfigFile }()
+			}
+
+			got, err := dcs.GetConfig()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConfigToProto() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.want.String(), got.String())
+			assert.Equal(t, tt.wantRawConfig, dcs.RawConfig())
+			assert.Equal(t, tt.wantParsedConfig, dcs.ParsedConfig())
+		})
+	}
+}

--- a/config/configsource_test.go
+++ b/config/configsource_test.go
@@ -15,6 +15,8 @@
 package config
 
 import (
+	"runtime"
+	"strings"
 	"testing"
 
 	configpb "github.com/cloudprober/cloudprober/config/proto"
@@ -55,6 +57,10 @@ func TestDefaultConfigSource(t *testing.T) {
 surfacer {
     type: STACKDRIVER
 }`
+
+	if runtime.GOOS == "windows" {
+		wantCfgStr = strings.ReplaceAll(wantCfgStr, "\n", "\r\n")
+	}
 
 	tests := []struct {
 		name              string

--- a/config/testdata/cloudprober_base.cfg
+++ b/config/testdata/cloudprober_base.cfg
@@ -1,6 +1,6 @@
 probe {
     name: "dns_k8s"
-    type: DNS 
+    type: DNS
     targets {
         host_names: "10.0.0.1"
     }

--- a/docs/content/docs/how-to/extensions.md
+++ b/docs/content/docs/how-to/extensions.md
@@ -179,10 +179,10 @@ func main() {
   flag.Parse()
 
   // Register our probe type
-  probes.RegisterProbeType(int(myprobe.E_RedisProbe.Field),
+  probes.RegisterProbeType(int(myprobe.E_RedisProbe.TypeDescriptor().Number()),
                            func() probes.Probe { return &myprobe.Probe{} })
 
-  err := cloudprober.InitFromConfig(getConfig()) // getConfig not shown here.
+  err := cloudprober.Init() // getConfig not shown here.
   if err != nil {
     glog.Exitf("Error initializing cloudprober. Err: %v", err)
   }
@@ -225,8 +225,7 @@ Full example in
 Let's compile our prober and run it with the above config:
 
 ```bash
-go build ./myprober.go
-./myprober --config_file=myprober.cfg
+go run ./myprober.go --config_file=myprober.cfg
 ```
 
 you should see an output like the following:

--- a/examples/extensions/myprober/myprober.go
+++ b/examples/extensions/myprober/myprober.go
@@ -17,10 +17,10 @@ func main() {
 	var log = logger.New()
 
 	// Register stubby probe type
-	probes.RegisterProbeType(int(myprobe.E_RedisProbe.Field),
+	probes.RegisterProbeType(int(myprobe.E_RedisProbe.TypeDescriptor().Number()),
 		func() probes.Probe { return &myprobe.Probe{} })
 
-	if err := cloudprober.InitFromConfig(""); err != nil {
+	if err := cloudprober.Init(); err != nil {
 		log.Criticalf("Error initializing cloudprober. Err: %v", err)
 	}
 


### PR DESCRIPTION
It kills a bunch of duplication. --configtest and --dumpconfig now use the same code for loading the file as rest of the regular functionality.