### PR TITLE
Use network buffer less aggressive in ping probe

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,7 @@
 # Dockerfile for quick development and testing
 # To build:
 #    docker build -t cloudprober:test . -f Dockerfile.dev
-FROM golang:1.18-alpine as build
+FROM golang:1.21.1-alpine as build
 
 WORKDIR /app
 COPY . /
@@ -9,5 +9,5 @@ RUN if [[ ! -f /cloudprober ]]; then go build -o /cloudprober /cmd/cloudprober.g
 
 FROM alpine
 COPY --from=build /cloudprober /cloudprober
-COPY cloudprober_test.cfg /etc/cloudprober.cfg
+COPY cmd/cloudprober_test.cfg /etc/cloudprober.cfg
 ENTRYPOINT ["/cloudprober"]

--- a/probes/ping/ping.go
+++ b/probes/ping/ping.go
@@ -301,6 +301,9 @@ func (p *Probe) sendPackets(runID uint16, tracker chan bool) {
 			}
 
 			tracker <- true
+			// When have high number targets (does not matter in one probe or in different probes),
+			// do not send packets to aggressive to avoid buffer overflow.
+			time.Sleep(1 * time.Microsecond)
 		}
 
 		packetsSent++
@@ -358,6 +361,7 @@ func (p *Probe) recvPackets(runID uint16, tracker chan bool) {
 			}
 			// if it's a timeout, return immediately.
 			if neterr, ok := err.(*net.OpError); ok && neterr.Timeout() {
+                                p.l.Debugf("Network timed out %d", p.runCnt)
 				return
 			}
 			continue
@@ -426,7 +430,7 @@ func (p *Probe) recvPackets(runID uint16, tracker chan bool) {
 
 		// check if this packet belongs to this run
 		if !matchPacket(runID, pkt.id, pkt.seq, p.useDatagramSocket) {
-			p.l.Info("Reply ", pkt.String(rtt), " Unmatched packet, probably from the last probe run.")
+			p.l.Info("Reply ", pkt.String(rtt), " Unmatched packet, probably received after probe timeout is reached.")
 			continue
 		}
 
@@ -522,8 +526,9 @@ func (p *Probe) Start(ctx context.Context, dataChan chan *metrics.EventMetrics) 
 		default:
 		}
 
+		p.l.Debugf("Probe started, runcount %d", p.runCnt)
 		p.runProbe()
-		p.l.Debugf("%s: Probe finished.", p.name)
+		p.l.Debugf("Probe finished, runcount %d", p.runCnt)
 		if (p.runCnt % uint64(p.statsExportFreq)) != 0 {
 			continue
 		}


### PR DESCRIPTION
When have higher number of targets (seen on 600+), no matter in single
probe or in different probes, we may cause network buffer overflow as
we add packets to the buffer much faster than NIC can handle them.
To avoid this we may increase net.core.wmem sysctl, or add 1 milisecond
dalay between buffer writes (which is done by this patch). This allows
to have stable results for even 2k targets in single probe.

Also patch improves logging
   - Added debug log when probe is started.
   - Do not print duplicate p.name as it is always added by logger,
      add p.runCnt instead
   - Improve debug message for a case when packet does not match runId
      this is usually happening when we received packet after probe timeout.