### PR TITLE
[surfacers] Cleanup surfacers options.

### DIFF
--- a/docs/content/docs/surfacers/overview.md
+++ b/docs/content/docs/surfacers/overview.md
@@ -23,6 +23,8 @@ Cloudprober currently supports following surfacer types:
 
 - Prometheus
   ([config](https://cloudprober.org/docs/config/surfacer/#cloudprober_surfacer_prometheus_SurfacerConf))
+- OpenTelemetry (OTEL)
+  ([config](https://cloudprober.org/docs/config/surfacer/#cloudprober_surfacer_otel_SurfacerConf))
 - [Stackdriver (Google Cloud Monitoring)](../stackdriver)
 - Google Pub/Sub
   ([config](https://cloudprober.org/docs/config/surfacer/#cloudprober_surfacer_pubsub_SurfacerConf))

--- a/surfacers/internal/bigquery/bigquery.go
+++ b/surfacers/internal/bigquery/bigquery.go
@@ -146,8 +146,8 @@ func distToBqMetrics(d *metrics.DistributionData, metricName string, labels map[
 	countMetric := updateMetricValues(labels, metricName+"_count", d.Count, timestamp, conf)
 
 	bqMetrics := []*bqrow{
-		&bqrow{value: sumMetric},
-		&bqrow{value: countMetric},
+		{value: sumMetric},
+		{value: countMetric},
 	}
 
 	// Create and format all metrics for each bucket in this distribution. Each

--- a/surfacers/internal/common/options/options.go
+++ b/surfacers/internal/common/options/options.go
@@ -169,11 +169,11 @@ func buildOptions(sdef *surfacerpb.SurfacerDef, ignoreInit bool, l *logger.Logge
 	}
 
 	opts.AddFailureMetric = opts.Config.GetAddFailureMetric()
-	defaultFailureMetric := map[surfacerpb.Type]bool{
-		surfacerpb.Type_STACKDRIVER: true,
-		surfacerpb.Type_CLOUDWATCH:  true,
+	defaultDisableFailureMetric := map[surfacerpb.Type]bool{
+		surfacerpb.Type_FILE:   true,
+		surfacerpb.Type_PUBSUB: true,
 	}
-	if opts.Config.AddFailureMetric == nil && defaultFailureMetric[opts.Config.GetType()] {
+	if opts.Config.AddFailureMetric == nil && !defaultDisableFailureMetric[opts.Config.GetType()] {
 		opts.AddFailureMetric = true
 	}
 

--- a/surfacers/internal/datadog/datadog.go
+++ b/surfacers/internal/datadog/datadog.go
@@ -46,6 +46,7 @@ var datadogKind = map[metrics.Kind]string{
 // DDSurfacer implements a datadog surfacer for datadog metrics.
 type DDSurfacer struct {
 	c         *configpb.SurfacerConf
+	opts      *options.Options
 	writeChan chan *metrics.EventMetrics
 	client    *ddClient
 	l         *logger.Logger
@@ -124,6 +125,10 @@ func recordMapValue[T int64 | float64](dd *DDSurfacer, m *metrics.Map[T], baseTa
 
 func (dd *DDSurfacer) recordEventMetrics(ctx context.Context, publishTimer *time.Ticker, em *metrics.EventMetrics) {
 	for _, metricKey := range em.MetricsKeys() {
+		if !dd.opts.AllowMetric(metricKey) {
+			continue
+		}
+
 		var series []ddSeries
 		switch value := em.Metric(metricKey).(type) {
 		case metrics.NumValue:

--- a/surfacers/internal/otel/otel.go
+++ b/surfacers/internal/otel/otel.go
@@ -343,6 +343,10 @@ func (os *OtelSurfacer) Write(_ context.Context, em *metrics.EventMetrics) {
 	}
 
 	for _, metricName := range em.MetricsKeys() {
+		if !os.opts.AllowMetric(metricName) {
+			continue
+		}
+
 		otelmetrics, err := os.convertMetric(em, metricName)
 		if err != nil {
 			os.l.Errorf("Error converting metric: %s, err: %v", metricName, err)

--- a/surfacers/internal/postgres/postgres_test.go
+++ b/surfacers/internal/postgres/postgres_test.go
@@ -21,7 +21,8 @@ func TestEMToPGMetricsNoDistribution(t *testing.T) {
 		AddMetric("resp_code", respCodesVal).
 		AddLabel("ptype", "http")
 
-	rows := emToPGMetrics(em)
+	s := &Surfacer{}
+	rows := s.emToPGMetrics(em)
 
 	if len(rows) != 4 {
 		t.Errorf("Expected %d rows, received: %d\n", 4, len(rows))
@@ -55,7 +56,8 @@ func TestEMToPGMetricsWithDistribution(t *testing.T) {
 		AddMetric("latency", latencyVal).
 		AddLabel("ptype", "http")
 
-	rows := emToPGMetrics(em)
+	s := &Surfacer{}
+	rows := s.emToPGMetrics(em)
 
 	if len(rows) != 5 {
 		t.Errorf("Expected %d rows, received: %d\n", 5, len(rows))

--- a/surfacers/proto/config.pb.go
+++ b/surfacers/proto/config.pb.go
@@ -216,13 +216,12 @@ type SurfacerDef struct {
 	//
 	// For efficiency reasons, filtering by metric name has to be implemented by
 	// individual surfacers (while going through metrics within an EventMetrics).
-	// Currently following surfacers implement it:
-	//
-	//	CLOUDWATCH, PROMETHEUS, STACKDRIVER
+	// As FILE and PUBSUB surfacers export eventmetrics as is, they don't support
+	// this option.
 	AllowMetricsWithName  *string `protobuf:"bytes,6,opt,name=allow_metrics_with_name,json=allowMetricsWithName" json:"allow_metrics_with_name,omitempty"`
 	IgnoreMetricsWithName *string `protobuf:"bytes,7,opt,name=ignore_metrics_with_name,json=ignoreMetricsWithName" json:"ignore_metrics_with_name,omitempty"`
-	// Whether to add failure metric or not. For stackdriver surfacer, we add
-	// failure metric by default.
+	// Whether to add failure metric or not. This option is enabled by default
+	// for all surfacers except FILE and PUBSUB.
 	AddFailureMetric *bool `protobuf:"varint,8,opt,name=add_failure_metric,json=addFailureMetric" json:"add_failure_metric,omitempty"`
 	// If set to true, cloudprober will export all metrics as gauge metrics. Note
 	// that cloudprober inherently generates only cumulative metrics. To create

--- a/surfacers/proto/config.proto
+++ b/surfacers/proto/config.proto
@@ -78,13 +78,13 @@ message SurfacerDef {
   //
   // For efficiency reasons, filtering by metric name has to be implemented by
   // individual surfacers (while going through metrics within an EventMetrics).
-  // Currently following surfacers implement it:
-  //     CLOUDWATCH, PROMETHEUS, STACKDRIVER
+  // As FILE and PUBSUB surfacers export eventmetrics as is, they don't support
+  // this option.
   optional string allow_metrics_with_name = 6;
   optional string ignore_metrics_with_name = 7;
 
-  // Whether to add failure metric or not. For stackdriver surfacer, we add
-  // failure metric by default.
+  // Whether to add failure metric or not. This option is enabled by default
+  // for all surfacers except FILE and PUBSUB.
   optional bool add_failure_metric = 8;
 
   // If set to true, cloudprober will export all metrics as gauge metrics. Note

--- a/surfacers/proto/config_proto_gen.cue
+++ b/surfacers/proto/config_proto_gen.cue
@@ -92,13 +92,13 @@ import (
 	//
 	// For efficiency reasons, filtering by metric name has to be implemented by
 	// individual surfacers (while going through metrics within an EventMetrics).
-	// Currently following surfacers implement it:
-	//     CLOUDWATCH, PROMETHEUS, STACKDRIVER
+	// As FILE and PUBSUB surfacers export eventmetrics as is, they don't support
+	// this option.
 	allowMetricsWithName?:  string @protobuf(6,string,name=allow_metrics_with_name)
 	ignoreMetricsWithName?: string @protobuf(7,string,name=ignore_metrics_with_name)
 
-	// Whether to add failure metric or not. For stackdriver surfacer, we add
-	// failure metric by default.
+	// Whether to add failure metric or not. This option is enabled by default
+	// for all surfacers except FILE and PUBSUB.
 	addFailureMetric?: bool @protobuf(8,bool,name=add_failure_metric)
 
 	// If set to true, cloudprober will export all metrics as gauge metrics. Note


### PR DESCRIPTION
- Enable add_failure_metric for all surfacers except FILE and PUBSUB.
- Add enable/disable metrics by name functionality to all surfacers
  except FILE and PUBSUB.
- Update documentation to include the OpenTelemetry option.