### PR TITLE
[surfacers.otel] Change resource attributes.

### DIFF
--- a/surfacers/internal/otel/otel.go
+++ b/surfacers/internal/otel/otel.go
@@ -170,7 +170,7 @@ func New(ctx context.Context, config *configpb.SurfacerConf, opts *options.Optio
 	exportInterval := time.Second * time.Duration(config.GetExportIntervalSec())
 	r := metric.NewPeriodicReader(exp, metric.WithProducer(os), metric.WithInterval(exportInterval))
 
-	res, err := resource.New(ctx, resource.WithHost(), resource.WithContainer(), resource.WithFromEnv())
+	res, err := resource.New(ctx, resource.WithHost(), resource.WithFromEnv())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create resource: %v", err)
 	}


### PR DESCRIPTION
- Container ID is a super long string and is not very useful.
- Pod info is available as host name on k8s.