### PR TITLE
gitignore: unignore checked-in files without extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@
 # Unignore all dirs
 !*/
 
+# Unignore files without extensions
+!Dockerfile
+!AUTHORS
+!Makefile
+!LICENSE
+
 docs/node_modules
 docs/public
 docs/resources


### PR DESCRIPTION
Currently, gitignore is ignoring some root files that don't have extensions. This causes weird behavior since there are ignored files currently in the repo state.