### PR TITLE
[website.homepage] Add a diagram to Cloudprober homepage.

### DIFF
--- a/docs/assets/scss/common/_custom.scss
+++ b/docs/assets/scss/common/_custom.scss
@@ -76,7 +76,7 @@ a.docs-link {
 }
 
 .doks-navbar {
-  background-color: #f0f0f0;
+  background-color: #f8f8f8;
 }
 
 .nav .nav-item {

--- a/docs/config/_default/params.toml
+++ b/docs/config/_default/params.toml
@@ -3,7 +3,7 @@
 ## Homepage
 title = "Cloudprober"
 titleSeparator = "-"
-titleAddition = "Monitoring software to detect failures before your customers do."
+titleAddition = "Detect failures before your customers do."
 description = "An active/synthetic monitoring software to reliably detect outages before your customers do."
 googleAnalytics = 'G-MEASUREMENT_ID'
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -3,7 +3,7 @@ title: "Cloudprober"
 description:
   "An active/synthetic monitoring software to reliably detect outages before
   your customers do."
-lead: "Monitoring software to detect failures before your customers do."
+lead: "Detect failures before your customers do."
 date: 2020-10-06T08:47:36+00:00
 lastmod: 2020-10-06T08:47:36+00:00
 draft: false

--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -1,20 +1,18 @@
 {{ define "main" }}
-<section class="section container-fluid mt-n3 pb-3">
+<section class="section container-fluid mt-n3 pb-3" style="padding: 40px 50px;">
   <div class="row justify-content-center">
-    <div class="col-lg-12 text-center">
-      <h1 class="mt-0">{{ .Title }}</h1>
-    </div>
-    <div class="col-lg-11 col-xl-10 text-center">
-      <p class="lead">{{ .Params.lead | safeHTML }}</p>
+    <div class="col-lg-8 text-center">
+      <h1 class="mt-5 mb-5">{{ .Title }}</h1>
+      <h3 class="mb-5">{{ .Params.lead | safeHTML }}</h3>
       <a
-        class="btn btn-primary btn-lg px-4 mb-2"
+        class="btn btn-primary mb-2"
         href="/docs/{{ if .Site.Params.options.docsVersioning }}{{ .Site.Params.docsVersion }}/{{ end }}overview/cloudprober"
         role="button"
         >Get Started</a
       >
-      <p class="meta" style="font-weight:500">
-        <a href="https://github.com/cloudprober/cloudprober">Open-source</a>
-      </p>
+    </div>
+    <div class="col-lg-8">
+      <img width=480 style="float:right;margin:30px" src="/homepage.drawio.svg">
     </div>
   </div>
 </section>


### PR DESCRIPTION
- Diagram gives an idea of Cloudprober functionality visually.
- Also shorten the lead line by removing "Monitoring software to"