### PR TITLE
[servers.http] Fix /healthcheck when lameduck lister is not initialized.

### DIFF
--- a/internal/servers/http/http.go
+++ b/internal/servers/http/http.go
@@ -70,7 +70,7 @@ func (s *Server) lameduckStatus() bool {
 
 func (s *Server) lameduckHandler(w http.ResponseWriter) {
 	if s.ldLister == nil {
-		w.Write([]byte("unknown"))
+		w.Write([]byte("unknown - lameduck lister not initialized"))
 		return
 	}
 	w.Write([]byte(strconv.FormatBool(s.lameduckStatus())))
@@ -78,7 +78,7 @@ func (s *Server) lameduckHandler(w http.ResponseWriter) {
 
 func (s *Server) healthcheckHandler(w http.ResponseWriter) {
 	if s.ldLister == nil {
-		w.Write([]byte("unknown"))
+		w.Write([]byte("unknown - lameduck lister not initialized. Note: Healthcheck at this port is NOT a good proxy for Cloudprober health."))
 		return
 	}
 	if s.lameduckStatus() {

--- a/internal/servers/http/http.go
+++ b/internal/servers/http/http.go
@@ -78,7 +78,7 @@ func (s *Server) lameduckHandler(w http.ResponseWriter) {
 
 func (s *Server) healthcheckHandler(w http.ResponseWriter) {
 	if s.ldLister == nil {
-		w.Write([]byte("unknown - lameduck lister not initialized. Note: Healthcheck at this port is NOT a good proxy for Cloudprober health."))
+		w.Write([]byte("unknown - lameduck lister not initialized. Note: Healthcheck at this port is NOT a good proxy for Cloudprober health. Use /health at the default port for that.\n"))
 		return
 	}
 	if s.lameduckStatus() {

--- a/internal/servers/http/http_test.go
+++ b/internal/servers/http/http_test.go
@@ -163,16 +163,15 @@ func TestLameduckingTestInstance(t *testing.T) {
 }
 
 func TestLameduckListerNil(t *testing.T) {
-	expectedErrMsg := "not initialized"
-
+	unknown := "unknown"
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	s, _ := testServer(ctx, t, "testInstance", nil)
 	defer cancelFunc()
 
-	if resp, status := get(t, s.ln, "lameduck"); !strings.Contains(resp, expectedErrMsg) || status != "200 OK" {
-		t.Errorf("Didn't get the expected response for the URL '/lameduck'. got: %q, %q. want it to contain: %q, %q", resp, status, expectedErrMsg, "200 OK")
+	if resp, status := get(t, s.ln, "lameduck"); !strings.Contains(resp, unknown) || status != "200 OK" {
+		t.Errorf("Didn't get the expected response for the URL '/lameduck'. got: %q, %q. want it to contain: %q, %q", resp, status, unknown, "200 OK")
 	}
-	if resp, status := get(t, s.ln, "healthcheck"); resp != OK || status != "200 OK" {
-		t.Errorf("Didn't get the expected response for the URL '/healthcheck'. got: %q, %q , want: %q, %q", resp, status, OK, "200 OK")
+	if resp, status := get(t, s.ln, "healthcheck"); resp != unknown || status != "200 OK" {
+		t.Errorf("Didn't get the expected response for the URL '/healthcheck'. got: %q, %q , want: %q, %q", resp, status, unknown, "200 OK")
 	}
 }

--- a/internal/servers/http/http_test.go
+++ b/internal/servers/http/http_test.go
@@ -171,7 +171,7 @@ func TestLameduckListerNil(t *testing.T) {
 	if resp, status := get(t, s.ln, "lameduck"); !strings.Contains(resp, unknown) || status != "200 OK" {
 		t.Errorf("Didn't get the expected response for the URL '/lameduck'. got: %q, %q. want it to contain: %q, %q", resp, status, unknown, "200 OK")
 	}
-	if resp, status := get(t, s.ln, "healthcheck"); resp != unknown || status != "200 OK" {
+	if resp, status := get(t, s.ln, "healthcheck"); !strings.Contains(resp, unknown) || status != "200 OK" {
 		t.Errorf("Didn't get the expected response for the URL '/healthcheck'. got: %q, %q , want: %q, %q", resp, status, unknown, "200 OK")
 	}
 }


### PR DESCRIPTION
- For /lameduck and /healthcheck return "unknown" if lameduck lister is not initialized. 
- We don't want to generate log every time as that will be very noisy. One can still debug why they are getting "unknown".