### PR TITLE
[probes.external] Refactor the external probe code

### DIFF
--- a/probes/external/external_server.go
+++ b/probes/external/external_server.go
@@ -61,11 +61,9 @@ var (
 func (p *Probe) monitorCommand(startCtx context.Context, cmd command) error {
 	err := cmd.Wait()
 
-	// Spare logging error message if killed explicitly.
-	select {
-	case <-startCtx.Done():
+	// Dont'log error message if killed explicitly.
+	if startCtx.Err() != nil {
 		return nil
-	default:
 	}
 
 	if exitErr, ok := err.(*exec.ExitError); ok {

--- a/probes/external/external_server.go
+++ b/probes/external/external_server.go
@@ -1,0 +1,287 @@
+// Copyright 2017-2023 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package external implements an external probe type for cloudprober.
+
+External probe type executes an external process for actual probing. These probes
+can have two modes: "once" and "server". In "once" mode, the external process is
+started for each probe run cycle, while in "server" mode, external process is
+started only if it's not running already and Cloudprober communicates with it
+over stdin/stdout for each probe cycle.
+*/
+package external
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cloudprober/cloudprober/common/strtemplate"
+	serverpb "github.com/cloudprober/cloudprober/probes/external/proto"
+	"github.com/cloudprober/cloudprober/probes/external/serverutils"
+	"github.com/cloudprober/cloudprober/targets/endpoint"
+	"google.golang.org/protobuf/proto"
+)
+
+var (
+	// TimeBetweenRequests is the time interval between probe requests for
+	// multiple targets. In server mode, probe requests for multiple targets are
+	// sent to the same external probe process. Sleeping between requests provides
+	// some time buffer for the probe process to dequeue the incoming requests and
+	// avoids filling up the communication pipe.
+	//
+	// Note that this value impacts the effective timeout for a target as timeout
+	// is applied for all the targets in aggregate. For example, 100th target in
+	// the targets list will have the effective timeout of (timeout - 1ms).
+	// TODO(manugarg): Make sure that the last target in the list has an impact of
+	// less than 1% on its timeout.
+	TimeBetweenRequests = 10 * time.Microsecond
+)
+
+// monitorCommand waits for the process to terminate and sets cmdRunning to
+// false when that happens.
+func (p *Probe) monitorCommand(startCtx context.Context, cmd command) error {
+	err := cmd.Wait()
+
+	// Spare logging error message if killed explicitly.
+	select {
+	case <-startCtx.Done():
+		return nil
+	default:
+	}
+
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return fmt.Errorf("external probe process died with the status: %s. Stderr: %s", exitErr.Error(), string(exitErr.Stderr))
+	}
+	return err
+}
+
+func (p *Probe) startCmdIfNotRunning(startCtx context.Context) error {
+	// Start external probe command if it's not running already. Note that here we
+	// are trusting the cmdRunning to be set correctly. It can be false for 4
+	// reasons:
+	// Correct reasons:
+	// 1) This is the first call and process has actually never been started.
+	// 2) Process died for some reason and monitor set cmdRunning to false.
+	// Incorrect reasons:
+	// 3) cmd.Start() started the process but still returned an error.
+	// 4) cmd.Wait() returned incorrectly, while the process was still running.
+	//
+	// 3 or 4 should never really happen, but managing processes can be tricky.
+	// Documenting here to help with debugging if we run into an issue.
+	p.cmdRunningMu.Lock()
+	defer p.cmdRunningMu.Unlock()
+	if p.cmdRunning {
+		return nil
+	}
+	p.l.Infof("Starting external command: %s %s", p.cmdName, strings.Join(p.cmdArgs, " "))
+	cmd := exec.CommandContext(startCtx, p.cmdName, p.cmdArgs...)
+	var err error
+	if p.cmdStdin, err = cmd.StdinPipe(); err != nil {
+		return err
+	}
+	if p.cmdStdout, err = cmd.StdoutPipe(); err != nil {
+		return err
+	}
+	if p.cmdStderr, err = cmd.StderrPipe(); err != nil {
+		return err
+	}
+	if len(p.envVars) > 0 {
+		cmd.Env = append(cmd.Env, p.envVars...)
+	}
+
+	go func() {
+		scanner := bufio.NewScanner(p.cmdStderr)
+		for scanner.Scan() {
+			p.l.Warningf("Stderr of %s: %s", cmd.Path, scanner.Text())
+		}
+	}()
+
+	if err = cmd.Start(); err != nil {
+		p.l.Errorf("error while starting the cmd: %s %s. Err: %v", cmd.Path, cmd.Args, err)
+		return fmt.Errorf("error while starting the cmd: %s %s. Err: %v", cmd.Path, cmd.Args, err)
+	}
+
+	ctx, cancelReadProbeReplies := context.WithCancel(startCtx)
+	// This goroutine waits for the process to terminate and sets cmdRunning to
+	// false when that happens.
+	go func() {
+		if err := p.monitorCommand(startCtx, cmd); err != nil {
+			p.l.Error(err.Error())
+		}
+		cancelReadProbeReplies()
+		p.cmdRunningMu.Lock()
+		p.cmdRunning = false
+		p.cmdRunningMu.Unlock()
+	}()
+	go p.readProbeReplies(ctx)
+	p.cmdRunning = true
+	return nil
+}
+
+func (p *Probe) readProbeReplies(ctx context.Context) error {
+	bufReader := bufio.NewReader(p.cmdStdout)
+	// Start a background goroutine to read probe replies from the probe server
+	// process's stdout and put them on the probe's replyChan. Note that replyChan
+	// is a one element channel. Idea is that we won't need buffering other than
+	// the one provided by Unix pipes.
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+		rep := new(serverpb.ProbeReply)
+		if err := serverutils.ReadMessage(ctx, rep, bufReader); err != nil {
+			// Return if external probe process pipe has closed. We get:
+			//  io.EOF: when other process has closed the pipe.
+			//  os.ErrClosed: when we have closed the pipe (through cmd.Wait()).
+			// *os.PathError: deferred close of the pipe.
+			_, isPathError := err.(*os.PathError)
+			if err == os.ErrClosed || err == io.EOF || isPathError {
+				p.l.Errorf("External probe process pipe is closed. Err: %s", err.Error())
+				return err
+			}
+			p.l.Errorf("Error reading probe reply: %s", err.Error())
+			continue
+		}
+		p.replyChan <- rep
+	}
+
+}
+
+func (p *Probe) sendRequest(requestID int32, ep endpoint.Endpoint) error {
+	req := &serverpb.ProbeRequest{
+		RequestId: proto.Int32(requestID),
+		TimeLimit: proto.Int32(int32(p.opts.Timeout / time.Millisecond)),
+		Options:   []*serverpb.ProbeRequest_Option{},
+	}
+	for _, opt := range p.c.GetOptions() {
+		value := opt.GetValue()
+		if len(p.labelKeys) != 0 { // If we're looking for substitions.
+			res, found := strtemplate.SubstituteLabels(value, p.labels(ep))
+			if !found {
+				p.l.Warningf("Missing substitution in option %q", value)
+			} else {
+				value = res
+			}
+		}
+		req.Options = append(req.Options, &serverpb.ProbeRequest_Option{
+			Name:  opt.Name,
+			Value: proto.String(value),
+		})
+	}
+
+	p.l.Debugf("Sending a probe request %v to the external probe server for target %v", requestID, ep.Name)
+	return serverutils.WriteMessage(req, p.cmdStdin)
+}
+
+func (p *Probe) runServerProbe(ctx, startCtx context.Context) {
+	type requestInfo struct {
+		target    endpoint.Endpoint
+		timestamp time.Time
+	}
+
+	outstandingReqs := make(map[int32]requestInfo)
+	var outstandingReqsMu sync.RWMutex
+	sendDoneCh := make(chan struct{})
+
+	if err := p.startCmdIfNotRunning(startCtx); err != nil {
+		p.l.Error(err.Error())
+		return
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		// Read probe replies until we have no outstanding requests or context has
+		// run out.
+		for {
+			select {
+			case <-ctx.Done():
+				p.l.Error(ctx.Err().Error())
+				return
+			case rep := <-p.replyChan:
+				outstandingReqsMu.Lock()
+				reqInfo, ok := outstandingReqs[rep.GetRequestId()]
+				if ok {
+					delete(outstandingReqs, rep.GetRequestId())
+				}
+				outstandingReqsMu.Unlock()
+				if !ok {
+					// Not our reply, could be from the last timed out probe.
+					p.l.Warningf("Got a reply that doesn't match any outstading request: Request id from reply: %v. Ignoring.", rep.GetRequestId())
+					continue
+				}
+				success := true
+				if rep.GetErrorMessage() != "" {
+					p.l.Errorf("Probe for target %v failed with error message: %s", reqInfo.target, rep.GetErrorMessage())
+					success = false
+				}
+				ps := &probeStatus{
+					target:  reqInfo.target,
+					success: success,
+					latency: time.Since(reqInfo.timestamp),
+					payload: rep.GetPayload(),
+				}
+				p.processProbeResult(ps, p.results[reqInfo.target.Key()])
+			}
+
+			// If we are done sending requests, we can exit if we have no
+			// outstanding requests.
+			select {
+			case <-sendDoneCh:
+				if len(outstandingReqs) == 0 {
+					return
+				}
+			default:
+			}
+		}
+	}()
+
+	// Send probe requests
+	for _, target := range p.targets {
+		p.requestID++
+		p.results[target.Key()].total++
+		outstandingReqsMu.Lock()
+		outstandingReqs[p.requestID] = requestInfo{
+			target:    target,
+			timestamp: time.Now(),
+		}
+		outstandingReqsMu.Unlock()
+		p.sendRequest(p.requestID, target)
+		time.Sleep(TimeBetweenRequests)
+	}
+
+	// Send signal to receiver loop that we are done sending requests.
+	close(sendDoneCh)
+
+	// Wait for receiver goroutine to exit.
+	wg.Wait()
+
+	// Handle requests that we have not yet received replies for: "requests" will
+	// contain only outstanding requests by this point.
+	outstandingReqsMu.Lock()
+	defer outstandingReqsMu.Unlock()
+	for _, req := range outstandingReqs {
+		p.processProbeResult(&probeStatus{target: req.target, success: false}, p.results[req.target.Key()])
+	}
+}

--- a/probes/external/external_server_test.go
+++ b/probes/external/external_server_test.go
@@ -1,0 +1,243 @@
+// Copyright 2017-2024 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package external
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cloudprober/cloudprober/metrics/testutils"
+	serverpb "github.com/cloudprober/cloudprober/probes/external/proto"
+	"github.com/cloudprober/cloudprober/probes/external/serverutils"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+// startProbeServer starts a test probe server to work with the TestProbeServer
+// test below.
+func startProbeServer(t *testing.T, ctx context.Context, testPayload string, r io.Reader, w io.WriteCloser) {
+	rd := bufio.NewReader(r)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		req := &serverpb.ProbeRequest{}
+		if err := serverutils.ReadMessage(context.Background(), req, rd); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			t.Errorf("Error reading probe request. Err: %v", err)
+			return
+		}
+		var action, target string
+		opts := req.GetOptions()
+		for _, opt := range opts {
+			if opt.GetName() == "action" {
+				action = opt.GetValue()
+				continue
+			}
+			if opt.GetName() == "target" {
+				target = opt.GetValue()
+				continue
+			}
+		}
+		id := req.GetRequestId()
+
+		actionToResponse := map[string]*serverpb.ProbeReply{
+			"nopayload": {RequestId: proto.Int32(id)},
+			"payload": {
+				RequestId: proto.Int32(id),
+				Payload:   proto.String(testPayload),
+			},
+			"payload_with_error": {
+				RequestId:    proto.Int32(id),
+				Payload:      proto.String(testPayload),
+				ErrorMessage: proto.String("error"),
+			},
+		}
+		t.Logf("Request id: %d, action: %s, target: %s", id, action, target)
+		if action == "pipe_server_close" {
+			w.Close()
+			return
+		}
+		if res, ok := actionToResponse[action]; ok {
+			serverutils.WriteMessage(res, w)
+		}
+	}
+}
+
+// runAndVerifyServerProbe executes a server probe and verifies the replies
+// received.
+func runAndVerifyServerProbe(t *testing.T, p *Probe, action string, tgts []string, total, success map[string]int64, numEventMetrics int) {
+	setProbeOptions(p, "action", action)
+
+	runAndVerifyProbe(t, p, tgts, total, success)
+
+	// Verify that we got all the expected EventMetrics
+	ems, err := testutils.MetricsFromChannel(p.dataChan, numEventMetrics, 1*time.Second)
+	if err != nil {
+		t.Error(err)
+	}
+	mmap := testutils.MetricsMapByTarget(ems)
+
+	for _, tgt := range tgts {
+		assert.Equal(t, total[tgt], mmap.LastValueInt64(tgt, "total"))
+		assert.Equal(t, success[tgt], mmap.LastValueInt64(tgt, "success"))
+	}
+}
+
+func testProbeServerSetup(t *testing.T, ctx context.Context, readErrorCh chan error) (*Probe, string) {
+	// We create two pairs of pipes to establish communication between this prober
+	// and the test probe server (defined above).
+	// Test probe server input pipe. We writes on w1 and external command reads
+	// from r1.
+	r1, w1, err := os.Pipe()
+	if err != nil {
+		t.Errorf("Error creating OS pipe. Err: %v", err)
+	}
+	// Test probe server output pipe. External command writes on w2 and we read
+	// from r2.
+	r2, w2, err := os.Pipe()
+	if err != nil {
+		t.Errorf("Error creating OS pipe. Err: %v", err)
+	}
+
+	testPayload := "p90 45\n"
+	// Start probe server in a goroutine
+	go startProbeServer(t, ctx, testPayload, r1, w2)
+
+	p := createTestProbe("./testCommand", nil)
+	p.cmdRunning = true // don't try to start the probe server
+	p.cmdStdin = w1
+	p.cmdStdout = r2
+	p.mode = "server"
+
+	// Start the goroutine that reads probe replies.
+	go func() {
+		err := p.readProbeReplies(ctx)
+		if readErrorCh != nil {
+			readErrorCh <- err
+			close(readErrorCh)
+		}
+	}()
+
+	return p, testPayload
+}
+
+func TestProbeServerMode(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	p, _ := testProbeServerSetup(t, ctx, nil)
+	defer cancel()
+
+	total, success := make(map[string]int64), make(map[string]int64)
+
+	// No payload
+	tgts := []string{"target1", "target2"}
+	for _, tgt := range tgts {
+		total[tgt]++
+		success[tgt]++
+	}
+	t.Run("nopayload", func(t *testing.T) {
+		runAndVerifyServerProbe(t, p, "nopayload", tgts, total, success, 2)
+	})
+
+	// Payload
+	tgts = []string{"target3"}
+	for _, tgt := range tgts {
+		total[tgt]++
+		success[tgt]++
+	}
+	t.Run("payload", func(t *testing.T) {
+		// 2 metrics per target
+		runAndVerifyServerProbe(t, p, "payload", tgts, total, success, 1*2)
+	})
+
+	// Payload with error
+	tgts = []string{"target2", "target3"}
+	for _, tgt := range tgts {
+		total[tgt]++
+	}
+	t.Run("payload_with_error", func(t *testing.T) {
+		// 2 targets, 2 EMs per target
+		runAndVerifyServerProbe(t, p, "payload_with_error", tgts, total, success, 2*2)
+	})
+
+	// Timeout
+	tgts = []string{"target1", "target2", "target3"}
+	for _, tgt := range tgts {
+		total[tgt]++
+	}
+
+	// Reduce probe timeout to make this test pass quicker.
+	p.opts.Timeout = time.Second
+	t.Run("timeout", func(t *testing.T) {
+		// 3 targets, 1 EM per target
+		runAndVerifyServerProbe(t, p, "timeout", tgts, total, success, 3*1)
+	})
+}
+
+func TestProbeServerRemotePipeClose(t *testing.T) {
+	readErrorCh := make(chan error)
+	ctx, cancel := context.WithCancel(context.Background())
+	p, _ := testProbeServerSetup(t, ctx, readErrorCh)
+	defer cancel()
+
+	total, success := make(map[string]int64), make(map[string]int64)
+	// Remote pipe close
+	tgts := []string{"target"}
+	for _, tgt := range tgts {
+		total[tgt]++
+	}
+	// Reduce probe timeout to make this test pass quicker.
+	p.opts.Timeout = time.Second
+	runAndVerifyServerProbe(t, p, "pipe_server_close", tgts, total, success, 1)
+	readError := <-readErrorCh
+	if readError == nil {
+		t.Error("Didn't get error in reading pipe")
+	}
+	if readError != io.EOF {
+		t.Errorf("Didn't get correct error in reading pipe. Got: %v, wanted: %v", readError, io.EOF)
+	}
+}
+
+func TestProbeServerLocalPipeClose(t *testing.T) {
+	readErrorCh := make(chan error)
+	ctx, cancel := context.WithCancel(context.Background())
+	p, _ := testProbeServerSetup(t, ctx, readErrorCh)
+	defer cancel()
+
+	total, success := make(map[string]int64), make(map[string]int64)
+	// Local pipe close
+	tgts := []string{"target"}
+	for _, tgt := range tgts {
+		total[tgt]++
+	}
+	// Reduce probe timeout to make this test pass quicker.
+	p.opts.Timeout = time.Second
+	p.cmdStdout.(*os.File).Close()
+	runAndVerifyServerProbe(t, p, "pipe_local_close", tgts, total, success, 1)
+	readError := <-readErrorCh
+	if readError == nil {
+		t.Error("Didn't get error in reading pipe")
+	}
+	if _, ok := readError.(*os.PathError); !ok {
+		t.Errorf("Didn't get correct error in reading pipe. Got: %T, wanted: *os.PathError", readError)
+	}
+}

--- a/probes/external/serverutils/serverutils_test.go
+++ b/probes/external/serverutils/serverutils_test.go
@@ -1,0 +1,118 @@
+// Copyright 2017 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serverutils
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	serverpb "github.com/cloudprober/cloudprober/probes/external/proto"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestReadProbeReply(t *testing.T) {
+	reply := &serverpb.ProbeReply{
+		RequestId: proto.Int32(123),
+		Payload:   proto.String("test payload"),
+	}
+
+	buf := new(bytes.Buffer)
+	err := WriteMessage(reply, buf)
+	assert.NoError(t, err)
+
+	r := bufio.NewReader(buf)
+	gotReply := &serverpb.ProbeReply{}
+	assert.NoError(t, ReadMessage(context.Background(), gotReply, r))
+	assert.True(t, proto.Equal(reply, gotReply), "proto equal check")
+}
+
+func TestReadProbeRequest(t *testing.T) {
+	request := &serverpb.ProbeRequest{
+		RequestId: proto.Int32(123),
+		TimeLimit: proto.Int32(5000),
+		Options:   []*serverpb.ProbeRequest_Option{{Name: proto.String("opt1"), Value: proto.String("val1")}},
+	}
+
+	buf := new(bytes.Buffer)
+	err := WriteMessage(request, buf)
+	assert.NoError(t, err)
+
+	r := bufio.NewReader(buf)
+	gotRequest := &serverpb.ProbeRequest{}
+	assert.NoError(t, ReadMessage(context.Background(), gotRequest, r))
+	assert.True(t, proto.Equal(request, gotRequest))
+}
+
+func TestWriteMessage(t *testing.T) {
+	// Create a mock proto message
+	message := &serverpb.ProbeReply{
+		RequestId: proto.Int32(123),
+		Payload:   proto.String("test payload"),
+	}
+
+	// Create a buffer to write the message to
+	buf := new(bytes.Buffer)
+
+	// Call the WriteMessage function
+	err := WriteMessage(message, buf)
+	assert.NoError(t, err)
+
+	// Verify the output
+	fmt.Printf("buf: %x\n", buf.String())
+	expectedOutput := "\nContent-Length: 16\n\n\b{\x1a\ftest payload"
+	assert.Equal(t, expectedOutput, buf.String())
+}
+
+func TestServe(t *testing.T) {
+	// Create a mock probe function
+	mockProbeFunc := func(request *serverpb.ProbeRequest, reply *serverpb.ProbeReply) {
+		reply.RequestId = request.RequestId
+		reply.Payload = proto.String("test payload")
+	}
+
+	stdinR, stdinW := io.Pipe()
+	stdoutR, stdoutW := io.Pipe()
+
+	// Call the Serve function
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go serve(ctx, mockProbeFunc, stdinR, stdoutW, stdoutW)
+
+	// Create a mock probe request
+	mockRequest := &serverpb.ProbeRequest{
+		RequestId: proto.Int32(123),
+		TimeLimit: proto.Int32(5000),
+		Options:   []*serverpb.ProbeRequest_Option{{Name: proto.String("opt1"), Value: proto.String("val1")}},
+	}
+
+	// Write the mock probe request to the mock stdin
+	WriteMessage(mockRequest, stdinW)
+
+	// Wait for the reply to be written to the mock stdout
+	reply := &serverpb.ProbeReply{}
+	assert.NoError(t, ReadMessage(context.Background(), reply, bufio.NewReader(stdoutR)))
+
+	// Verify the reply
+	expectedReply := &serverpb.ProbeReply{
+		RequestId: proto.Int32(123),
+		Payload:   proto.String("test payload"),
+	}
+	assert.True(t, proto.Equal(expectedReply, reply))
+}


### PR DESCRIPTION
Changes:
* Split out server handling code into a different file
* Write tests for serverutils
* Use context to cancel various loops, but we'll still not be able to cancel the pending `read`.