### PR TITLE
Fix client cert handling when cert reloading is enabled

### DIFF
--- a/internal/tlsconfig/tlsconfig.go
+++ b/internal/tlsconfig/tlsconfig.go
@@ -85,7 +85,7 @@ func UpdateTLSConfig(tlsConfig *tls.Config, c *configpb.TLSConfig) error {
 		if c.GetReloadIntervalSec() > 0 {
 			key := [2]string{certF, keyF}
 
-			tlsConfig.GetCertificate = func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			tlsConfig.GetClientCertificate = func(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 				global.mu.RLock()
 				entry, ok := global.cache[key]
 				global.mu.RUnlock()


### PR DESCRIPTION
Since cloudprober is the client, the dynamic cert loading needs to be implemented in GetClientCertificate rather than GetCertificate.