### PR TITLE
Postgres surfacer metric filter bugfix

### DIFF
--- a/surfacers/internal/postgres/postgres.go
+++ b/surfacers/internal/postgres/postgres.go
@@ -185,10 +185,11 @@ type Surfacer struct {
 
 // New initializes a Postgres surfacer. Postgres surfacer inserts probe results
 // into a postgres database.
-func New(ctx context.Context, config *configpb.SurfacerConf, l *logger.Logger) (*Surfacer, error) {
+func New(ctx context.Context, config *configpb.SurfacerConf, opts *options.Options, l *logger.Logger) (*Surfacer, error) {
 	s := &Surfacer{
-		c: config,
-		l: l,
+		c:    config,
+		opts: opts,
+		l:    l,
 		openDB: func(cs string) (*sql.DB, error) {
 			return sql.Open("postgres", cs)
 		},

--- a/surfacers/surfacers.go
+++ b/surfacers/surfacers.go
@@ -196,7 +196,7 @@ func initSurfacer(ctx context.Context, s *surfacerpb.SurfacerDef, sType surfacer
 	case surfacerpb.Type_FILE:
 		surfacer, err = file.New(ctx, s.GetFileSurfacer(), opts, l)
 	case surfacerpb.Type_POSTGRES:
-		surfacer, err = postgres.New(ctx, s.GetPostgresSurfacer(), l)
+		surfacer, err = postgres.New(ctx, s.GetPostgresSurfacer(), opts, l)
 	case surfacerpb.Type_PUBSUB:
 		surfacer, err = pubsub.New(ctx, s.GetPubsubSurfacer(), opts, l)
 	case surfacerpb.Type_CLOUDWATCH:


### PR DESCRIPTION
Hello,
during the initialisation of postgres surfacer options are never set but are later on used to check if metrics should be sent to Postgres database.
I added the options as a parameter of creating postgres surfacer.