### PR TITLE
[probes.external] Test: Kill all started processes before exiting.

### DIFF
--- a/probes/external/external_test.go
+++ b/probes/external/external_test.go
@@ -715,13 +715,12 @@ func TestMain(m *testing.M) {
 		pidsFile = tempFile.Name()
 		tempFile.Close()
 	} else {
-		pidsF := os.Getenv("GO_CP_TEST_PIDS_FILE")
-		pidsFile, err := os.OpenFile(pidsF, os.O_RDWR, 0644)
+		pidsF, err := os.OpenFile(os.Getenv("GO_CP_TEST_PIDS_FILE"), os.O_APPEND|os.O_WRONLY, 0644)
 		if err != nil {
 			log.Fatalf("Failed to open temp file for pids: %v", err)
 		}
-		pidsFile.WriteString(fmt.Sprintf("%d\n", os.Getpid()))
-		pidsFile.Close()
+		pidsF.WriteString(fmt.Sprintf("%d\n", os.Getpid()))
+		pidsF.Close()
 	}
 
 	status := m.Run()

--- a/probes/external/external_test.go
+++ b/probes/external/external_test.go
@@ -733,10 +733,9 @@ func TestMain(m *testing.M) {
 	for _, pid := range strings.Fields(strings.TrimSpace(string(pidsBytes))) {
 		pid, err := strconv.Atoi(pid)
 		if err != nil {
-			fmt.Printf("Failed to convert pid (%v) to int, err: %v\n", pid, err)
-			os.Exit(1)
+			log.Fatalf("Failed to convert pid (%v) to int, err: %v", pid, err)
 		}
-		fmt.Println("Killing pid", pid)
+		log.Println("Killing pid", pid)
 		p, err := os.FindProcess(pid)
 		if err != nil {
 			continue


### PR DESCRIPTION
- This is important for Windows tests where deleting the test binary fails if it's still executing (for testing external probe process).