### PR TITLE
[probes.external] Fix sporadic pipe read error logs.

### DIFF
--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -257,6 +257,18 @@ func (p *Probe) processProbeResult(ps *probeStatus, result *result) {
 	}
 }
 
+func isPipeOrFileClosedError(err error) bool {
+	if err == io.ErrClosedPipe {
+		return true
+	}
+	if pe, ok := err.(*os.PathError); ok {
+		if pe.Err == os.ErrClosed {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *Probe) setupStreaming(c *exec.Cmd, target endpoint.Endpoint) error {
 	stdout := make(chan string)
 	stdoutR, err := c.StdoutPipe()
@@ -278,8 +290,8 @@ func (p *Probe) setupStreaming(c *exec.Cmd, target endpoint.Endpoint) error {
 		for scanner.Scan() {
 			stdout <- scanner.Text()
 		}
-		if err := scanner.Err(); err != nil && err != io.ErrClosedPipe {
-			p.l.Errorf("Error reading from stdout: %v", err)
+		if err := scanner.Err(); err != nil && !isPipeOrFileClosedError(err) {
+			p.l.Errorf("Error reading from stdout: %v %T", err, err)
 		}
 	}()
 	go func() {
@@ -292,7 +304,7 @@ func (p *Probe) setupStreaming(c *exec.Cmd, target endpoint.Endpoint) error {
 		for scanner.Scan() {
 			p.l.Warningf("Stderr: %s", scanner.Text())
 		}
-		if err := scanner.Err(); err != nil && err != io.ErrClosedPipe {
+		if err := scanner.Err(); err != nil && !isPipeOrFileClosedError(err) {
 			p.l.Errorf("Error reading from stderr: %v", err)
 		}
 	}()

--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -291,7 +291,7 @@ func (p *Probe) setupStreaming(c *exec.Cmd, target endpoint.Endpoint) error {
 			stdout <- scanner.Text()
 		}
 		if err := scanner.Err(); err != nil && !isPipeOrFileClosedError(err) {
-			p.l.Errorf("Error reading from stdout: %v %T", err, err)
+			p.l.Errorf("Error reading from stdout: %v", err)
 		}
 	}()
 	go func() {


### PR DESCRIPTION
= While reading external process's stdout and stderr, don't log the error if it's caused by pipe closing.