### PR TITLE
[probes.external] Fix serverutils.

### DIFF
--- a/probes/external/serverutils/serverutils.go
+++ b/probes/external/serverutils/serverutils.go
@@ -169,10 +169,10 @@ func serve(ctx context.Context, probeFunc func(*serverpb.ProbeRequest, *serverpb
 //			}
 //		})
 func ServeContext(probeFunc func(*serverpb.ProbeRequest, *serverpb.ProbeReply)) {
-	serve(context.Background(), probeFunc, bufio.NewReader(os.Stdin), bufio.NewWriter(os.Stdout), bufio.NewWriter(os.Stderr))
+	serve(context.Background(), probeFunc, bufio.NewReader(os.Stdin), os.Stdout, os.Stderr)
 }
 
 // Serve is similar to ServeContext but uses the background context.
 func Serve(probeFunc func(*serverpb.ProbeRequest, *serverpb.ProbeReply)) {
-	serve(context.Background(), probeFunc, bufio.NewReader(os.Stdin), bufio.NewWriter(os.Stdout), bufio.NewWriter(os.Stderr))
+	serve(context.Background(), probeFunc, bufio.NewReader(os.Stdin), os.Stdout, os.Stderr)
 }


### PR DESCRIPTION
We should not be writing to buffered stdout and stderr. This change was introduced recently in v0.13.4:
  github.com/cloudprober/cloudprober/pull/695