### PR TITLE
[surfacers] Ignore sysvars metrics for file surfacer added by default

### DIFF
--- a/surfacers/surfacers.go
+++ b/surfacers/surfacers.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cloudprober/cloudprober/surfacers/internal/pubsub"
 	"github.com/cloudprober/cloudprober/surfacers/internal/stackdriver"
 	"github.com/cloudprober/cloudprober/web/formatutils"
+	"google.golang.org/protobuf/proto"
 
 	surfacerpb "github.com/cloudprober/cloudprober/surfacers/proto"
 )
@@ -88,6 +89,12 @@ var defaultSurfacers = []*surfacerpb.SurfacerDef{
 	},
 	{
 		Type: surfacerpb.Type_FILE.Enum(),
+		IgnoreMetricsWithLabel: []*surfacerpb.LabelFilter{
+			{
+				Key:   proto.String("probe"),
+				Value: proto.String("sysvars"),
+			},
+		},
 	},
 }
 


### PR DESCRIPTION
- Most folks don't add surfacers, relying on default configuration which adds `FILE` and `PROMETHEUS` surfacers. `FILE` surfacer metrics go to stdout by default, intermixing with the logs.
- Sysvars metrics are generated every 30s, producing 4 lines (for 4 eventmetrics) every 30s. This can get pretty noisy.
- This change disables sysvars metrics only for the config added by default. It will have no impact if you add `FILE` surfacer explicitly.