### PR TITLE
[targets.resolver] On failure, attempt refresh on each resolve call.

### DIFF
--- a/targets/resolver/resolver.go
+++ b/targets/resolver/resolver.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Cloudprober Authors.
+// Copyright 2017-2024 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/targets/resolver/resolver.go
+++ b/targets/resolver/resolver.go
@@ -173,7 +173,7 @@ func (cr *cacheRecord) refresh(name string, resolve func(string) ([]net.IP, erro
 	}
 }
 
-func (cr *cacheRecord) updateNow(maxAge time.Duration) bool {
+func (cr *cacheRecord) shouldUpdateNow(maxAge time.Duration) bool {
 	cr.mu.RLock()
 	defer cr.mu.RUnlock()
 	return !cr.updateInProgress && time.Since(cr.lastUpdatedAt) >= maxAge
@@ -190,7 +190,7 @@ func (cr *cacheRecord) refreshIfRequired(name string, resolve func(string) ([]ne
 	cr.callInit.Do(func() { cr.refresh(name, resolve, refreshed) })
 
 	// Cache record is old and no update in progress, issue a request to update.
-	if cr.updateNow(maxAge) {
+	if cr.shouldUpdateNow(maxAge) {
 		cr.mu.Lock()
 		cr.updateInProgress = true
 		cr.mu.Unlock()

--- a/targets/resolver/resolver.go
+++ b/targets/resolver/resolver.go
@@ -155,8 +155,8 @@ func (cr *cacheRecord) refresh(name string, resolve func(string) ([]net.IP, erro
 	}
 	cr.err = err
 	cr.updateInProgress = false
-	// If we have an error, we don't update the cache record or set
-	// lastUpdatedAt. This allows us to retry resolve on the next request.
+	// If we have an error, we don't update the cache record so that callers
+	// can use cached IP addresses if they want.
 	if err != nil {
 		return
 	}

--- a/targets/resolver/resolver.go
+++ b/targets/resolver/resolver.go
@@ -176,7 +176,7 @@ func (cr *cacheRecord) refresh(name string, resolve func(string) ([]net.IP, erro
 func (cr *cacheRecord) shouldUpdateNow(maxAge time.Duration) bool {
 	cr.mu.RLock()
 	defer cr.mu.RUnlock()
-	return !cr.updateInProgress && time.Since(cr.lastUpdatedAt) >= maxAge
+	return !cr.updateInProgress && (time.Since(cr.lastUpdatedAt) >= maxAge || cr.err != nil)
 }
 
 // refreshIfRequired does most of the work. Overall goal is to minimize the

--- a/targets/resolver/resolver_test.go
+++ b/targets/resolver/resolver_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Cloudprober Authors.
+// Copyright 2017-2024 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ func TestResolveWithMaxAge(t *testing.T) {
 	waitForRefreshAndVerify(t, refreshed, time.Second, false)
 }
 
-// TestResolveErr tests the behavior of the resolver when the backend returns an
+// TestResolveErr tests the behavior of the resolver when backend returns an
 // error. This test uses the refreshed channel and waits on it to make the
 // resolver behavior deterministic.
 func TestResolveErr(t *testing.T) {
@@ -148,10 +148,7 @@ func TestResolveErr(t *testing.T) {
 	waitForRefreshAndVerify(t, refreshedCh, time.Second, true)
 	waitForRefreshAndVerify(t, refreshedCh, time.Second, false)
 
-	// cnt=1, returning 0.0.0.0, but updating the cache record asynchronously
-	// to contain the error returned for cnt=2.
-	// Note that refresh has happned by now since we waited on the refreshed
-	// channel above.
+	// cnt=1, returning 0.0.0.0, but will trigger another refresh due to maxAge
 	time.Sleep(10 * time.Millisecond)
 	ip, err = r.resolveWithMaxAge("testHost", 4, 10*time.Millisecond, refreshedCh)
 	if err != nil {


### PR DESCRIPTION
If refresh from backend fails, we should attempt to refresh on each resolve call.

Also, use read-write mutex instead of default mutex wherever possible. It won't have much impact on performance as we never lock for long, but it is still a good practice.