### PR TITLE
[web] Move web initialization to cloudprober init.

### DIFF
--- a/cloudprober.go
+++ b/cloudprober.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cloudprober/cloudprober/prober"
 	"github.com/cloudprober/cloudprober/probes"
 	"github.com/cloudprober/cloudprober/surfacers"
+	"github.com/cloudprober/cloudprober/web"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/channelz/service"
 	"google.golang.org/grpc/credentials"
@@ -139,6 +140,14 @@ func setDebugHandlers(srvMux *http.ServeMux) {
 	srvMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 }
 
+func initWeb() error {
+	return web.Init(web.DataFuncs{
+		GetRawConfig:    GetRawConfig,
+		GetParsedConfig: GetParsedConfig,
+		GetInfo:         GetInfo,
+	})
+}
+
 // InitFromConfig initializes Cloudprober using the provided config.
 // Deprecated: This function is kept only for compatibility reasons. It's
 // recommended to use Init() or InitWithConfigSource() instead.
@@ -152,6 +161,13 @@ func Init() error {
 }
 
 func InitWithConfigSource(configSrc config.ConfigSource) error {
+	if err := initWithConfigSource(config.DefaultConfigSource()); err != nil {
+		return err
+	}
+	return initWeb()
+}
+
+func initWithConfigSource(configSrc config.ConfigSource) error {
 	// Return immediately if prober is already initialized.
 	cloudProber.Lock()
 	defer cloudProber.Unlock()

--- a/cloudprober.go
+++ b/cloudprober.go
@@ -156,7 +156,7 @@ func InitWithConfigSource(configSrc config.ConfigSource) error {
 	if err := initWithConfigSource(config.DefaultConfigSource()); err != nil {
 		return err
 	}
-	return web.Init(web.DataFuncs{
+	return web.InitWithDataFuncs(web.DataFuncs{
 		GetRawConfig:    GetRawConfig,
 		GetParsedConfig: GetParsedConfig,
 		GetInfo:         GetInfo,

--- a/cloudprober.go
+++ b/cloudprober.go
@@ -140,14 +140,6 @@ func setDebugHandlers(srvMux *http.ServeMux) {
 	srvMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 }
 
-func initWeb() error {
-	return web.Init(web.DataFuncs{
-		GetRawConfig:    GetRawConfig,
-		GetParsedConfig: GetParsedConfig,
-		GetInfo:         GetInfo,
-	})
-}
-
 // InitFromConfig initializes Cloudprober using the provided config.
 // Deprecated: This function is kept only for compatibility reasons. It's
 // recommended to use Init() or InitWithConfigSource() instead.
@@ -164,7 +156,11 @@ func InitWithConfigSource(configSrc config.ConfigSource) error {
 	if err := initWithConfigSource(config.DefaultConfigSource()); err != nil {
 		return err
 	}
-	return initWeb()
+	return web.Init(web.DataFuncs{
+		GetRawConfig:    GetRawConfig,
+		GetParsedConfig: GetParsedConfig,
+		GetInfo:         GetInfo,
+	})
 }
 
 func initWithConfigSource(configSrc config.ConfigSource) error {

--- a/cloudprober.go
+++ b/cloudprober.go
@@ -153,7 +153,7 @@ func Init() error {
 }
 
 func InitWithConfigSource(configSrc config.ConfigSource) error {
-	if err := initWithConfigSource(config.DefaultConfigSource()); err != nil {
+	if err := initWithConfigSource(configSrc); err != nil {
 		return err
 	}
 	return web.InitWithDataFuncs(web.DataFuncs{

--- a/cmd/cloudprober/main.go
+++ b/cmd/cloudprober/main.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cloudprober/cloudprober/config"
 	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/logger"
-	"github.com/cloudprober/cloudprober/web"
 )
 
 var (
@@ -150,11 +149,6 @@ func main() {
 
 	if err := cloudprober.Init(); err != nil {
 		l.Criticalf("Error initializing cloudprober. Err: %v", err)
-	}
-
-	// web.Init sets up web UI for cloudprober.
-	if err := web.Init(); err != nil {
-		l.Criticalf("Error initializing web interface. Err: %v", err)
 	}
 
 	startCtx := context.Background()

--- a/examples/extensions/myprober/myprober.go
+++ b/examples/extensions/myprober/myprober.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cloudprober/cloudprober/examples/extensions/myprober/myprobe"
 	"github.com/cloudprober/cloudprober/examples/extensions/myprober/mytargets"
 	"github.com/cloudprober/cloudprober/logger"
-	"github.com/cloudprober/cloudprober/web"
 )
 
 func main() {
@@ -21,11 +20,6 @@ func main() {
 
 	if err := cloudprober.Init(); err != nil {
 		log.Criticalf("Error initializing cloudprober. Err: %v", err)
-	}
-
-	// web.Init sets up web UI for cloudprober.
-	if err := web.Init(); err != nil {
-		log.Criticalf("Error initializing web interface. Err: %v", err)
 	}
 
 	cloudprober.Start(context.Background())

--- a/web/web.go
+++ b/web/web.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Cloudprober Authors.
+// Copyright 2018-2024 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -111,6 +111,11 @@ func Init() error {
 	return nil
 }
 
+var secretConfigRunningMsg = `
+	<p>Config contains secrets. /config-running is not available.<br>
+	Visit <a href=/config-parsed>/config-parsed</a> to see the config.<p>
+	`
+
 // InitWithDataFuncs initializes cloudprober web interface handler.
 func InitWithDataFuncs(fn DataFuncs) error {
 	srvMux := runconfig.DefaultHTTPServeMux()
@@ -134,10 +139,7 @@ func InitWithDataFuncs(fn DataFuncs) error {
 		if !config.EnvRegex.MatchString(parsedConfig) {
 			configRunning = runningConfig(fn)
 		} else {
-			configRunning = `
-			<p>Config contains secrets. /config-running is not available.<br>
-			Visit <a href=/config-parsed>/config-parsed</a> to see the config.<p>
-			`
+			configRunning = secretConfigRunningMsg
 		}
 
 		fmt.Fprint(w, configRunning)

--- a/web/web.go
+++ b/web/web.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/internal/alerting"
 	"github.com/cloudprober/cloudprober/internal/servers"
+	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/probes"
 	"github.com/cloudprober/cloudprober/surfacers"
 	"github.com/cloudprober/cloudprober/web/resources"
@@ -104,8 +105,13 @@ type DataFuncs struct {
 	GetInfo         func() (map[string]*probes.ProbeInfo, []*surfacers.SurfacerInfo, []*servers.ServerInfo)
 }
 
-// Init initializes cloudprober web interface handler.
-func Init(fn DataFuncs) error {
+func Init() {
+	l := logger.Logger{}
+	l.Warningf("web.Init is a no-op now. Web interface is now initialized by cloudprober.Init(), you don't need to initialize it explicitly.")
+}
+
+// InitWithDataFuncs initializes cloudprober web interface handler.
+func InitWithDataFuncs(fn DataFuncs) error {
 	srvMux := runconfig.DefaultHTTPServeMux()
 	for _, url := range []string{"/config", "/config-running", "/static/"} {
 		if webutils.IsHandled(srvMux, url) {

--- a/web/web.go
+++ b/web/web.go
@@ -128,17 +128,18 @@ func InitWithDataFuncs(fn DataFuncs) error {
 		fmt.Fprint(w, fn.GetParsedConfig())
 	})
 
-	parsedConfig := fn.GetParsedConfig()
-	var configRunning string
-	if !config.EnvRegex.MatchString(parsedConfig) {
-		configRunning = runningConfig(fn)
-	} else {
-		configRunning = `
-		<p>Config contains secrets. /config-running is not available.<br>
-		Visit <a href=/config-parsed>/config-parsed</a> to see the config.<p>
-		`
-	}
 	srvMux.HandleFunc("/config-running", func(w http.ResponseWriter, r *http.Request) {
+		parsedConfig := fn.GetParsedConfig()
+		var configRunning string
+		if !config.EnvRegex.MatchString(parsedConfig) {
+			configRunning = runningConfig(fn)
+		} else {
+			configRunning = `
+			<p>Config contains secrets. /config-running is not available.<br>
+			Visit <a href=/config-parsed>/config-parsed</a> to see the config.<p>
+			`
+		}
+
 		fmt.Fprint(w, configRunning)
 	})
 

--- a/web/web.go
+++ b/web/web.go
@@ -105,9 +105,10 @@ type DataFuncs struct {
 	GetInfo         func() (map[string]*probes.ProbeInfo, []*surfacers.SurfacerInfo, []*servers.ServerInfo)
 }
 
-func Init() {
+func Init() error {
 	l := logger.Logger{}
 	l.Warningf("web.Init is a no-op now. Web interface is now initialized by cloudprober.Init(), you don't need to initialize it explicitly.")
+	return nil
 }
 
 // InitWithDataFuncs initializes cloudprober web interface handler.

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -1,0 +1,112 @@
+// Copyright 2018-2024 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package web provides web interface for cloudprober.
+package web
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cloudprober/cloudprober/config/runconfig"
+	"github.com/cloudprober/cloudprober/internal/servers"
+	"github.com/cloudprober/cloudprober/probes"
+	"github.com/cloudprober/cloudprober/surfacers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitWithDataFuncs(t *testing.T) {
+	getInfo := func() (map[string]*probes.ProbeInfo, []*surfacers.SurfacerInfo, []*servers.ServerInfo) {
+
+		return nil, nil, nil
+	}
+
+	tests := []struct {
+		name              string
+		dataFuncs         DataFuncs
+		wantResp          map[string]string
+		wantConfigRunning string
+		wantErr           bool
+	}{
+		{
+			name: "base",
+			dataFuncs: DataFuncs{
+				GetRawConfig:    func() string { return "raw-config" },
+				GetParsedConfig: func() string { return "parsed-config" },
+				GetInfo:         getInfo,
+			},
+			wantResp: map[string]string{
+				"/config":        "raw-config",
+				"/config-parsed": "parsed-config",
+			},
+		},
+		{
+			name: "with-secret",
+			dataFuncs: DataFuncs{
+				GetRawConfig:    func() string { return "raw-config" },
+				GetParsedConfig: func() string { return "parsed-config **$password**" },
+				GetInfo:         getInfo,
+			},
+			wantResp: map[string]string{
+				"/config":        "raw-config",
+				"/config-parsed": "parsed-config **$password**",
+			},
+			wantConfigRunning: secretConfigRunningMsg,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldSrvMux := runconfig.DefaultHTTPServeMux()
+			defer runconfig.SetDefaultHTTPServeMux(oldSrvMux)
+			srvMux := http.NewServeMux()
+			runconfig.SetDefaultHTTPServeMux(srvMux)
+
+			httpSrv := httptest.NewServer(srvMux)
+			defer httpSrv.Close()
+
+			if err := InitWithDataFuncs(tt.dataFuncs); (err != nil) != tt.wantErr {
+				t.Errorf("InitWithDataFuncs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			client := httpSrv.Client()
+			if tt.wantConfigRunning == "" {
+				tt.wantConfigRunning = runningConfig(tt.dataFuncs)
+			}
+			tt.wantResp["/config-running"] = tt.wantConfigRunning
+			for path, wantResp := range tt.wantResp {
+				resp, err := client.Get(httpSrv.URL + path)
+				if err != nil {
+					t.Errorf("Error getting %s: %v", path, err)
+					continue
+				}
+				if resp.StatusCode != http.StatusOK {
+					t.Errorf("Got status code: %d, want: %d", resp.StatusCode, http.StatusOK)
+				}
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Errorf("Error reading response body: %v", err)
+				}
+				assert.Equal(t, wantResp, string(body), "response body")
+			}
+
+			httpSrv.Close()
+		})
+	}
+}
+
+func TestInit(t *testing.T) {
+	assert.Nil(t, Init(), "Init() should return nil")
+}


### PR DESCRIPTION
This will minimize the binary code even further, making creating extensions simpler. 