### PR TITLE
Use context in ServeContext.

### DIFF
--- a/probes/external/serverutils/serverutils.go
+++ b/probes/external/serverutils/serverutils.go
@@ -168,8 +168,8 @@ func serve(ctx context.Context, probeFunc func(*serverpb.ProbeRequest, *serverpb
 //				reply.ErrorMessage = proto.String(errMsg)
 //			}
 //		})
-func ServeContext(probeFunc func(*serverpb.ProbeRequest, *serverpb.ProbeReply)) {
-	serve(context.Background(), probeFunc, bufio.NewReader(os.Stdin), os.Stdout, os.Stderr)
+func ServeContext(ctx context.Context, probeFunc func(*serverpb.ProbeRequest, *serverpb.ProbeReply)) {
+	serve(ctx, probeFunc, bufio.NewReader(os.Stdin), os.Stdout, os.Stderr)
 }
 
 // Serve is similar to ServeContext but uses the background context.


### PR DESCRIPTION
I noticed that https://pkg.go.dev/github.com/cloudprober/cloudprober/probes/external/serverutils#ServeContext doesn't take a context. This has been true since it was added in https://github.com/cloudprober/cloudprober/pull/695, so it looks like an oversight. This change updates the function to properly take a context (and to work with its example code.