### PR TITLE
Fixing getting the cert files form Google Storage

### DIFF
--- a/internal/file/gcs.go
+++ b/internal/file/gcs.go
@@ -33,7 +33,11 @@ func gcsRequest(ctx context.Context, method, objectPath string) (*http.Response,
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, path.Join(gcsHTTPBaseURL, objectPath), nil)
+	u, _ := url.Parse(gcsHTTPBaseURL)
+	u.Path = path.Join(u.Path, objectPath)
+
+
+	req, err := http.NewRequestWithContext(ctx, method, u, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/file/gcs.go
+++ b/internal/file/gcs.go
@@ -33,7 +33,11 @@ func gcsRequest(ctx context.Context, method, objectPath string) (*http.Response,
 		return nil, err
 	}
 
-	u, _ := url.Parse(gcsHTTPBaseURL)
+	u, err := url.Parse(gcsHTTPBaseURL)
+	if err != nil {
+	  // This should never happen as base URL is defined by us.
+	  panic("invalid GCS base URL: " + err.Error())
+	}  
 	u.Path = path.Join(u.Path, objectPath)
 
 

--- a/internal/file/gcs.go
+++ b/internal/file/gcs.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"path"
 	"time"
 

--- a/internal/file/gcs.go
+++ b/internal/file/gcs.go
@@ -42,7 +42,7 @@ func gcsRequest(ctx context.Context, method, objectPath string) (*http.Response,
 	u.Path = path.Join(u.Path, objectPath)
 
 
-	req, err := http.NewRequestWithContext(ctx, method, u, nil)
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This cl https://github.com/cloudprober/cloudprober/pull/396 breaks accessing Google Storage as path.join converts double slash into single slash

Below code returns https:/storage.googleapis.com/bbmc-cloudradar-internal-ip-only/rds/ssl/cloudprober.crt
package main

```
import (
	"fmt"
	"path"
)

const gcsHTTPBaseURL = "https://storage.googleapis.com"

func main() {
	fmt.Printf(path.Join(gcsHTTPBaseURL, "bbmc-cloudradar-internal-ip-only/rds/ssl/cloudprober.crt"))
}
```