### PR TITLE
[docs] Update github homepage image

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ systems. This kind of monitoring makes it possible to monitor your systems'
 interfaces regardless of the implementation and helps you quickly pin down
 what's broken in your system (see [why probers](https://blog.manugarg.com/posts/why-you-need-probers/)).
 
-![Cloudprober Use Case](http://cloudprober.org/diagrams/cloudprober_use_case.svg)
+<img width="460" src="https://cloudprober.org/homepage.svg"/>
 
 ## Features
 


### PR DESCRIPTION
- Make it consistent with cloudprober.org homepage.
- Also, old image is a bit confusing now.