### PR TITLE
Avoid emitting probe metrics after context cancellation

### DIFF
--- a/probes/common/sched/sched.go
+++ b/probes/common/sched/sched.go
@@ -112,6 +112,12 @@ func (s *Scheduler) startForTarget(ctx context.Context, target endpoint.Endpoint
 			continue
 		}
 		s.RunProbeForTarget(ctx, target, result)
+		if ctxDone(ctx) {
+			// Probe or target context was canceled during the probe run.
+			// The probe was interrupted mid-run before the timeout happened,
+			// so we should discard any metrics collected during this run.
+			return
+		}
 
 		// Export stats if it's the time to do so.
 		runCnt++

--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -430,7 +430,7 @@ func (p *Probe) runProbe(startCtx context.Context) {
 	if p.mode == "server" {
 		p.runServerProbe(probeCtx, startCtx)
 	} else {
-		p.runOnceProbe(probeCtx)
+		p.runOnceProbe(probeCtx, startCtx)
 	}
 }
 

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -584,6 +584,13 @@ func (p *Probe) startForTarget(ctx context.Context, target endpoint.Endpoint, da
 			result.total += int64(p.c.GetRequestsPerProbe())
 		}
 
+		if ctxDone(ctx) {
+			// Probe or target context was canceled during the probe run.
+			// The probe was interrupted mid-run before the timeout happened,
+			// so we should discard any metrics collected during this run.
+			return
+		}
+
 		// Export stats if it's the time to do so.
 		runCnt++
 		if (runCnt % p.statsExportFrequency) == 0 {

--- a/probes/ping/ping.go
+++ b/probes/ping/ping.go
@@ -533,6 +533,14 @@ func (p *Probe) Start(ctx context.Context, dataChan chan *metrics.EventMetrics) 
 		p.l.Debugf("Probe started, runcount %d", p.runCnt)
 		p.runProbe()
 		p.l.Debugf("Probe finished, runcount %d", p.runCnt)
+
+		// exit without exporting stats if the probe run was interrupted.
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
 		if (p.runCnt % uint64(p.statsExportFreq)) != 0 {
 			continue
 		}


### PR DESCRIPTION
When a probe is stopped, i.e. via the probe removal process, sometimes the cancellation of the probe context happens while a probe run is in progress. This can cause that probe run to be interrupted mid-execution and return with a failure, which then gets reported through the metrics channel and out to the surfacer as a failed probe, even though the failure was due to probe cancellation rather than an external cause.

This PR adds a check to make sure the context is still live after the probe run is completed but before metrics are emitted. If the context is done, the probe stops without emitting the metrics.

Probe types and their susceptibilities for this issue:
- dns
  - dns does not have the issue because the probe run is not interrupted by context closure
- external (non-server)
  - this does have the issue if the context closes during the process execution as that will forcefully kill the process and result in a failure
- external (server)
  - this does not have the issue because the metrics reporting is bounded by the context, and because process failures are not emitted as event metrics
- grpc
  - this does not have the issue as metrics are emitted on the next loop after running probes, which involves checking the context again. Individual target cancellations are also handled because all target removals delete the probe result before the next metrics emission cycle runs.
- http
  - has this issue, is fixed in the PR. Canceled context can lead to failures.
- ping
  - ping does not have this issue as the inner probe runner does not respect context closure
- tcp
  - tcp uses the `sched` utility to run probes, which is susceptible to this failure. `sched` has been updated in the same way as `http`
- udp
  - udp doesn't have the issue because context cancellation will immediately stop the function that does metrics exporting
- udp listener
  - udp listener doesn't have the issue because context cancellation will immediately stop the function that does metrics exporting