### PR TITLE
[probes.external] Make substitution labels consistent with additional labels

### DIFF
--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -185,20 +185,17 @@ type command interface {
 func (p *Probe) labels(ep endpoint.Endpoint) map[string]string {
 	labels := make(map[string]string)
 
-	for k, v := range map[string]string{
-		"target":      ep.Name,
-		"target.name": ep.Name,
-		"port":        strconv.Itoa(ep.Port),
-		"target.port": strconv.Itoa(ep.Port),
-		"target.ip":   ep.IP.String(),
-	} {
-		if p.labelKeys[k] {
+	for k := range p.labelKeys {
+		if v, ok := map[string]string{
+			"target":      ep.Name,
+			"target.name": ep.Name,
+			"port":        strconv.Itoa(ep.Port),
+			"target.port": strconv.Itoa(ep.Port),
+			"target.ip":   ep.IP.String(),
+			"probe":       p.name,
+		}[k]; ok {
 			labels[k] = v
 		}
-	}
-
-	if p.labelKeys["probe"] {
-		labels["probe"] = p.name
 	}
 
 	if p.labelKeys["address"] {

--- a/probes/external/external_test.go
+++ b/probes/external/external_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"os/exec"
 	"reflect"
@@ -264,8 +265,20 @@ func TestUpdateLabelKeys(t *testing.T) {
 				Value: proto.String("@target@"),
 			},
 			{
+				Name:  proto.String("target_name"),
+				Value: proto.String("@target.name@"),
+			},
+			{
 				Name:  proto.String("probe"),
 				Value: proto.String("@probe@"),
+			},
+			{
+				Name:  proto.String("target_ip"),
+				Value: proto.String("@target.ip@"),
+			},
+			{
+				Name:  proto.String("target_port"),
+				Value: proto.String("@target.port@"),
 			},
 		},
 	}
@@ -279,6 +292,9 @@ func TestUpdateLabelKeys(t *testing.T) {
 
 	expected := map[string]bool{
 		"target":            true,
+		"target.name":       true,
+		"target.ip":         true,
+		"target.port":       true,
 		"port":              true,
 		"probe":             true,
 		"target.label.fqdn": true,
@@ -291,6 +307,7 @@ func TestUpdateLabelKeys(t *testing.T) {
 	gotLabels := p.labels(endpoint.Endpoint{
 		Name: "targetA",
 		Port: 8080,
+		IP:   net.ParseIP("127.0.0.1"),
 		Labels: map[string]string{
 			"fqdn": "targetA.svc.local",
 		},
@@ -300,10 +317,11 @@ func TestUpdateLabelKeys(t *testing.T) {
 		"port":              "8080",
 		"probe":             "probeP",
 		"target":            "targetA",
+		"target.name":       "targetA",
+		"target.ip":         "127.0.0.1",
+		"target.port":       "8080",
 	}
-	if !reflect.DeepEqual(gotLabels, wantLabels) {
-		t.Errorf("p.labels got: %v, want: %v", gotLabels, wantLabels)
-	}
+	assert.Equal(t, wantLabels, gotLabels, "p.labels")
 }
 
 // TestSendRequest verifies that sendRequest sends appropriately populated

--- a/probes/external/proto/config.pb.go
+++ b/probes/external/proto/config.pb.go
@@ -88,9 +88,15 @@ type ProbeConf struct {
 	Mode *ProbeConf_Mode `protobuf:"varint,1,opt,name=mode,enum=cloudprober.probes.external.ProbeConf_Mode,def=0" json:"mode,omitempty"`
 	// Command.  For ONCE probes, arguments are processed for the following field
 	// substitutions:
-	// @probe@    Name of the probe
-	// @target@   Hostname of the target
-	// @address@  IP address of the target
+	// @probe@                    Name of the probe
+	// @target.name@ or @target@  Hostname of the target
+	// @target.port@ or @port@    Port of the target
+	// @target.ip@                IP address associated with target
+	// @address@                  Resolved IP address of the target, in case of
+	//
+	//	discovered targets, same as @target.ip@.
+	//
+	// @target.label.<x>@         Label x of the target
 	//
 	// For example, for target ig-us-central1-a, /tools/recreate_vm -vm @target@
 	// will get converted to: /tools/recreate_vm -vm ig-us-central1-a
@@ -204,7 +210,7 @@ func (x *ProbeConf) GetDisableStreamingOutputMetrics() bool {
 
 // Options for the SERVER mode probe requests. These options are passed on to
 // the external probe server as part of the ProbeRequest. Values are
-// substituted similar to command arguments for the ONCE mode probes.
+// substituted similar to command arguments for the ONCE mode probes above.
 type ProbeConf_Option struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/probes/external/proto/config.proto
+++ b/probes/external/proto/config.proto
@@ -18,9 +18,13 @@ message ProbeConf {
 
   // Command.  For ONCE probes, arguments are processed for the following field
   // substitutions:
-  // @probe@    Name of the probe
-  // @target@   Hostname of the target
-  // @address@  IP address of the target
+  // @probe@                    Name of the probe
+  // @target.name@ or @target@  Hostname of the target
+  // @target.port@ or @port@    Port of the target
+  // @target.ip@                IP address associated with target
+  // @address@                  Resolved IP address of the target, in case of
+  //                            discovered targets, same as @target.ip@.
+  // @target.label.<x>@         Label x of the target
   //
   // For example, for target ig-us-central1-a, /tools/recreate_vm -vm @target@
   // will get converted to: /tools/recreate_vm -vm ig-us-central1-a
@@ -32,7 +36,7 @@ message ProbeConf {
 
   // Options for the SERVER mode probe requests. These options are passed on to
   // the external probe server as part of the ProbeRequest. Values are
-  // substituted similar to command arguments for the ONCE mode probes.
+  // substituted similar to command arguments for the ONCE mode probes above.
   message Option {
     optional string name = 1;
     optional string value = 2;


### PR DESCRIPTION
- External probe substitution labels are applied to probe command line or probe options. These labels were added before additional labels were introduced. This PR makes them consistent.

- Add more tests and documentation.