### PR TITLE
[probes.grpc] Fix connection retry interval

### DIFF
--- a/probes/grpc/grpc_test.go
+++ b/probes/grpc/grpc_test.go
@@ -266,7 +266,6 @@ func TestConnectFailures(t *testing.T) {
 	}
 	p := &Probe{}
 	p.Init("grpc-connectfail", probeOpts)
-	p.dialOpts = append(p.dialOpts, grpc.WithBlock())
 	dataChan := make(chan *metrics.EventMetrics, 5)
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup


### PR DESCRIPTION
Use a ticker to retry connection setup.

See #814 for more details.