### PR TITLE
[metrics] Remove redundant cloning of some metrics

### DIFF
--- a/probes/dns/dns.go
+++ b/probes/dns/dns.go
@@ -130,7 +130,7 @@ func (prr probeRunResult) Metrics(ts time.Time, opts *options.Options) *metrics.
 	em := metrics.NewEventMetrics(ts).
 		AddMetric("total", &prr.total).
 		AddMetric("success", &prr.success).
-		AddMetric(opts.LatencyMetricName, prr.latency.Clone()).
+		AddMetric(opts.LatencyMetricName, prr.latency).
 		AddMetric("timeouts", &prr.timeouts)
 
 	if prr.validationFailure != nil {

--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -243,7 +243,7 @@ func (p *Probe) processProbeResult(ps *probeStatus, result *result) {
 	defaultEM := metrics.NewEventMetrics(time.Now()).
 		AddMetric("success", metrics.NewInt(result.success)).
 		AddMetric("total", metrics.NewInt(result.total)).
-		AddMetric(p.opts.LatencyMetricName, result.latency.Clone()).
+		AddMetric(p.opts.LatencyMetricName, result.latency).
 		AddLabel("ptype", "external").
 		AddLabel("probe", p.name).
 		AddLabel("dst", ps.target.Name)

--- a/probes/grpc/grpc.go
+++ b/probes/grpc/grpc.go
@@ -507,20 +507,18 @@ func (p *Probe) Start(ctx context.Context, dataChan chan *metrics.EventMetrics) 
 
 			result.Lock()
 			em := metrics.NewEventMetrics(ts).
-				AddMetric("total", result.total.Clone()).
-				AddMetric("success", result.success.Clone()).
-				AddMetric(p.opts.LatencyMetricName, result.latency.Clone()).
-				AddMetric("connecterrors", result.connectErrors.Clone()).
+				AddMetric("total", &result.total).
+				AddMetric("success", &result.success).
+				AddMetric(p.opts.LatencyMetricName, result.latency).
+				AddMetric("connecterrors", &result.connectErrors).
 				AddLabel("ptype", "grpc").
 				AddLabel("probe", p.name).
 				AddLabel("dst", target.Dst())
-			result.Unlock()
-
 			if result.validationFailure != nil {
 				em.AddMetric("validation_failure", result.validationFailure)
 			}
-
 			p.opts.RecordMetrics(target, em, dataChan)
+			result.Unlock()
 		}
 
 		// Finally, update targets and start new probe loops if necessary.

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -468,12 +468,12 @@ func (p *Probe) exportMetrics(ts time.Time, result *probeResult, target endpoint
 	em := metrics.NewEventMetrics(ts).
 		AddMetric("total", metrics.NewInt(result.total)).
 		AddMetric("success", metrics.NewInt(result.success)).
-		AddMetric(p.opts.LatencyMetricName, result.latency.Clone()).
+		AddMetric(p.opts.LatencyMetricName, result.latency).
 		AddMetric("timeouts", metrics.NewInt(result.timeouts)).
-		AddMetric("resp-code", result.respCodes.Clone())
+		AddMetric("resp-code", result.respCodes)
 
 	if result.respBodies != nil {
-		em.AddMetric("resp-body", result.respBodies.Clone())
+		em.AddMetric("resp-body", result.respBodies)
 	}
 
 	if p.c.GetKeepAlive() {
@@ -486,19 +486,19 @@ func (p *Probe) exportMetrics(ts time.Time, result *probeResult, target endpoint
 
 	if result.latencyBreakdown != nil {
 		if dl := result.latencyBreakdown.dnsLatency; dl != nil {
-			em.AddMetric("dns_latency", dl.Clone())
+			em.AddMetric("dns_latency", dl)
 		}
 		if cl := result.latencyBreakdown.connectLatency; cl != nil {
-			em.AddMetric("connect_latency", cl.Clone())
+			em.AddMetric("connect_latency", cl)
 		}
 		if tl := result.latencyBreakdown.tlsLatency; tl != nil {
-			em.AddMetric("tls_handshake_latency", tl.Clone())
+			em.AddMetric("tls_handshake_latency", tl)
 		}
 		if rwl := result.latencyBreakdown.reqWriteLatency; rwl != nil {
-			em.AddMetric("req_write_latency", rwl.Clone())
+			em.AddMetric("req_write_latency", rwl)
 		}
 		if fbl := result.latencyBreakdown.firstByteLatency; fbl != nil {
-			em.AddMetric("first_byte_latency", fbl.Clone())
+			em.AddMetric("first_byte_latency", fbl)
 		}
 	}
 

--- a/probes/ping/ping.go
+++ b/probes/ping/ping.go
@@ -545,7 +545,7 @@ func (p *Probe) Start(ctx context.Context, dataChan chan *metrics.EventMetrics) 
 			em := metrics.NewEventMetrics(ts).
 				AddMetric("total", metrics.NewInt(result.sent)).
 				AddMetric("success", metrics.NewInt(success)).
-				AddMetric(p.opts.LatencyMetricName, result.latency.Clone()).
+				AddMetric(p.opts.LatencyMetricName, result.latency).
 				AddLabel("ptype", "ping").
 				AddLabel("probe", p.name).
 				AddLabel("dst", target.Name)

--- a/probes/tcp/tcp.go
+++ b/probes/tcp/tcp.go
@@ -69,7 +69,7 @@ func (result *probeResult) Metrics(ts time.Time, opts *options.Options) *metrics
 	em := metrics.NewEventMetrics(ts).
 		AddMetric("total", metrics.NewInt(result.total)).
 		AddMetric("success", metrics.NewInt(result.success)).
-		AddMetric(opts.LatencyMetricName, result.latency.Clone()).
+		AddMetric(opts.LatencyMetricName, result.latency).
 		AddLabel("ptype", "tcp")
 
 	if result.validationFailure != nil {

--- a/probes/udp/udp.go
+++ b/probes/udp/udp.go
@@ -99,7 +99,7 @@ func (prr probeResult) eventMetrics(probeName string, opts *options.Options, f f
 	m := metrics.NewEventMetrics(time.Now()).
 		AddMetric("total"+suffix, metrics.NewInt(prr.total)).
 		AddMetric("success"+suffix, metrics.NewInt(prr.success)).
-		AddMetric(opts.LatencyMetricName+suffix, prr.latency.Clone()).
+		AddMetric(opts.LatencyMetricName+suffix, prr.latency).
 		AddMetric("delayed"+suffix, metrics.NewInt(prr.delayed)).
 		AddLabel("ptype", "udp").
 		AddLabel("probe", probeName).


### PR DESCRIPTION
Cloning of complex values like latency and response codes is unnecessary now as EventMetrics are cloned right after they are composed[1].

[1] Cloning right after creation sounds bad, but cloning of EventMetrics is handled in a central function (providing more safety and better handling), while creation of EventMetrics happens in many places.
https://github.com/cloudprober/cloudprober/blob/8eabdeba7c2f94135b12cfc48c3117e034eac5fc/probes/options/options.go#L292