### PR TITLE
[metrics] Don't clone eventmetrics unnecessarily

### DIFF
--- a/probes/common/sched/sched.go
+++ b/probes/common/sched/sched.go
@@ -43,6 +43,9 @@ func ctxDone(ctx context.Context) bool {
 // ProbeResult represents results of a probe run.
 type ProbeResult interface {
 	// Metrics returns ProbeResult metrics as a metrics.EventMetrics object.
+	// This EventMetrics object should not be reused for further accounting
+	// because it's modified by the scheduler and later on when it's pushed
+	// to the data channel.
 	Metrics(time.Time, *options.Options) *metrics.EventMetrics
 }
 

--- a/probes/options/options.go
+++ b/probes/options/options.go
@@ -278,8 +278,7 @@ func (opts *Options) IsScheduled() bool {
 }
 
 type recordOptions struct {
-	NoAlert         bool
-	CloneBeforePush bool
+	NoAlert bool
 }
 
 type RecordOptions func(*recordOptions)
@@ -290,20 +289,10 @@ func WithNoAlert() RecordOptions {
 	}
 }
 
-func WithCloneBeforePush() RecordOptions {
-	return func(ro *recordOptions) {
-		ro.CloneBeforePush = true
-	}
-}
-
 func (opts *Options) RecordMetrics(ep endpoint.Endpoint, em *metrics.EventMetrics, dataChan chan<- *metrics.EventMetrics, ropts ...RecordOptions) {
 	ro := &recordOptions{}
 	for _, ropt := range ropts {
 		ropt(ro)
-	}
-
-	if ro.CloneBeforePush {
-		em = em.Clone()
 	}
 
 	em.LatencyUnit = opts.LatencyUnit

--- a/probes/options/options.go
+++ b/probes/options/options.go
@@ -289,6 +289,11 @@ func WithNoAlert() RecordOptions {
 	}
 }
 
+// RecordMetrics updates EventMetrics with additional labels and pushes it to
+// the data channel and alert handlers. It also logs EventMetrics if configured
+// to do so in the options.
+// Note: RecordMetrics doesn't clone the provided EventMetrics. It expects the
+// caller to not modify it after calling this function.
 func (opts *Options) RecordMetrics(ep endpoint.Endpoint, em *metrics.EventMetrics, dataChan chan<- *metrics.EventMetrics, ropts ...RecordOptions) {
 	ro := &recordOptions{}
 	for _, ropt := range ropts {

--- a/probes/options/options.go
+++ b/probes/options/options.go
@@ -302,18 +302,17 @@ func (opts *Options) RecordMetrics(ep endpoint.Endpoint, em *metrics.EventMetric
 		ropt(ro)
 	}
 
+	if ro.CloneBeforePush {
+		em = em.Clone()
+	}
+
 	em.LatencyUnit = opts.LatencyUnit
 	for _, al := range opts.AdditionalLabels {
 		em.AddLabel(al.KeyValueForTarget(ep))
 	}
 
 	opts.LogMetrics(em)
-
-	if ro.CloneBeforePush {
-		dataChan <- em.Clone()
-	} else {
-		dataChan <- em
-	}
+	dataChan <- em
 
 	if !ro.NoAlert {
 		for _, ah := range opts.AlertHandlers {


### PR DESCRIPTION
This cloning got added in https://github.com/cloudprober/cloudprober/pull/533, when we tried to standardize handling of eventmetrics through options.RecordMetrics. It doesn't really serve any purpose as probes calling this function already provide a clean, disconnected EventMetrics.