### PR TITLE
Support file glob when including config files

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -106,11 +106,23 @@ func handleIncludes(baseDir string, content []byte) (string, error) {
 			final = append(final, line)
 			continue
 		}
-		includedCfg, err := readConfigFile(filepath.Join(baseDir, m[1]))
+
+		includePath := filepath.Join(baseDir, m[1])
+		files, err := filepath.Glob(includePath)
 		if err != nil {
 			return "", err
 		}
-		final = append(final, includedCfg)
+		if len(files) == 0 {
+			return "", fmt.Errorf("config include error: %s didn't match any files", includePath)
+		}
+
+		for _, file := range files {
+			includedCfg, err := readConfigFile(file)
+			if err != nil {
+				return "", err
+			}
+			final = append(final, includedCfg)
+		}
 	}
 
 	newline := "\n"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -327,6 +327,9 @@ func TestReadConfigFile(t *testing.T) {
 			fileName: "testdata/include_test/cloudprober_include.nested.txtar",
 		},
 		{
+			fileName: "testdata/include_test/cloudprober_include.glob.txtar",
+		},
+		{
 			fileName: "testdata/include_test/cloudprober_include.error.txtar",
 			wantErr:  true,
 		},

--- a/config/testdata/include_test/cloudprober_include.glob.txtar
+++ b/config/testdata/include_test/cloudprober_include.glob.txtar
@@ -1,0 +1,46 @@
+Files to test include feature
+
+-- cloudprober.cfg --
+include "cloudprober.d/*.cfg"
+
+surfacer {
+    type: PROMETHEUS
+}
+
+-- cloudprober.d/team1.cfg --
+probe {
+    name: "probe_web1"
+    type: HTTP
+    targets {
+        host_names: "web1.example.com"
+    }
+}
+
+-- cloudprober.d/team2.cfg --
+probe {
+    name: "probe_web2"
+    type: HTTP
+    targets {
+        host_names: "web2.example.com"
+    }
+}
+
+-- output --
+probe {
+    name: "probe_web1"
+    type: HTTP
+    targets {
+        host_names: "web1.example.com"
+    }
+}
+probe {
+    name: "probe_web2"
+    type: HTTP
+    targets {
+        host_names: "web2.example.com"
+    }
+}
+
+surfacer {
+    type: PROMETHEUS
+}


### PR DESCRIPTION
This is a potential solution for #826 to enable providing a file path glob in the `include` config to pick up all files in a directory.
I also toyed with the idea of allowing absolute paths in the include config as well but left it out to keep PR in sync with the issue/summary. Something along the lines of:
```
               var absPath string
               if filepath.IsAbs(m[1]) {
                       absPath = m[1]
               } else {
                       absPath = filepath.Join(baseDir, m[1])
               }

               files, err := filepath.Glob(absPath)
```