### PR TITLE
[probes.dns] Don't reset latency on each run

### DIFF
--- a/probes/dns/dns.go
+++ b/probes/dns/dns.go
@@ -264,12 +264,6 @@ func (p *Probe) runProbe(ctx context.Context, target endpoint.Endpoint, res sche
 	// Convert interface to struct type
 	result := res.(*probeRunResult)
 
-	if p.opts.LatencyDist != nil {
-		result.latency = p.opts.LatencyDist.CloneDist()
-	} else {
-		result.latency = metrics.NewFloat(0)
-	}
-
 	port := defaultPort
 	if target.Port != 0 {
 		port = target.Port


### PR DESCRIPTION
Setting result's latency on each run is a leftover of  the`statskeeper` usage -- `statskeeper` did metrics aggregation on its [own](https://github.com/cloudprober/cloudprober/blob/be96965267409c4a9d87e0291ebb1160944d321f/probes/common/statskeeper/statskeeper.go#L74), so each probe run produced a new result object. We moved away from the `statskeeper` package in #800.

Fixes #835. 