### PR TITLE
[targets.dns] Use contexts for backend resolve function

### DIFF
--- a/internal/rds/client/client_test.go
+++ b/internal/rds/client/client_test.go
@@ -234,7 +234,7 @@ func TestListAndResolve(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Got error initializing RDS client: %v", err)
 	}
-	client.resolver = dnsRes.New(dnsRes.WithResolveFunc(func(name string) ([]net.IP, error) {
+	client.resolver = dnsRes.New(dnsRes.WithResolveFunc(func(_ context.Context, name string) ([]net.IP, error) {
 		return testNameToIP[name], nil
 	}))
 
@@ -292,7 +292,7 @@ func TestCacheBehaviorWithServerSupport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Got error initializing RDS client: %v", err)
 	}
-	client.resolver = dnsRes.New(dnsRes.WithResolveFunc(func(name string) ([]net.IP, error) {
+	client.resolver = dnsRes.New(dnsRes.WithResolveFunc(func(_ context.Context, name string) ([]net.IP, error) {
 		return testNameToIP[name], nil
 	}))
 
@@ -351,7 +351,7 @@ func TestCacheBehaviorWithoutServerSupport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Got error initializing RDS client: %v", err)
 	}
-	client.resolver = dnsRes.New(dnsRes.WithResolveFunc(func(name string) ([]net.IP, error) {
+	client.resolver = dnsRes.New(dnsRes.WithResolveFunc(func(_ context.Context, name string) ([]net.IP, error) {
 		return testNameToIP[name], nil
 	}))
 
@@ -391,7 +391,7 @@ func TestOnDemandRefresh(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Got error initializing RDS client: %v", err)
 	}
-	client.resolver = dnsRes.New(dnsRes.WithResolveFunc(func(name string) ([]net.IP, error) {
+	client.resolver = dnsRes.New(dnsRes.WithResolveFunc(func(_ context.Context, name string) ([]net.IP, error) {
 		return testNameToIP[name], nil
 	}))
 


### PR DESCRIPTION
- Make the backend resolve function take a context, and call it with a context with timeout.
- Earlier we were handling timeouts ourselves through a goroutine because when resolver was implemented there was no LookupIP with context. New method is much better.
- Also, create a custom resolver only once, no need to create a new one on each resolve call.
