### PR TITLE
[tagets.resolver] Use explicit DNS client when DNS server is overridden

### DIFF
--- a/targets/resolver/resolver.go
+++ b/targets/resolver/resolver.go
@@ -304,11 +304,15 @@ func WithDNSServer(serverNetworkOverride, serverAddressOverride string) Option {
 					return nil, err
 				}
 				for _, ans := range resp.Answer {
-					switch a := ans.(type) {
-					case *dns.A:
-						ips = append(ips, a.A)
-					case *dns.AAAA:
-						ips = append(ips, a.AAAA)
+					switch qType {
+					case dns.TypeA:
+						if a, ok := ans.(*dns.A); ok {
+							ips = append(ips, a.A)
+						}
+					case dns.TypeAAAA:
+						if aaaa, ok := ans.(*dns.AAAA); ok {
+							ips = append(ips, aaaa.AAAA)
+						}
 					}
 				}
 			}

--- a/targets/resolver/resolver.go
+++ b/targets/resolver/resolver.go
@@ -297,6 +297,9 @@ func WithDNSServer(serverNetworkOverride, serverAddressOverride string) Option {
 			var ips []net.IP
 			dnsClient := &dns.Client{Net: r.backendNetwork}
 
+			// TODO: We should probably limit cache record to a specify IP
+			// version, but that will be a bigger change as cache records are
+			// currently indexed by the hostname only.
 			for _, qType := range []uint16{dns.TypeA, dns.TypeAAAA} {
 				msg := new(dns.Msg).SetQuestion(fqdn, qType)
 				resp, _, err := dnsClient.ExchangeContext(ctx, msg, r.backendServer)

--- a/targets/resolver/resolver.go
+++ b/targets/resolver/resolver.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/cloudprober/cloudprober/logger"
 	targetspb "github.com/cloudprober/cloudprober/targets/proto"
+	"github.com/miekg/dns"
 )
 
 // The max age and the timeout for resolving a target.
@@ -287,23 +288,31 @@ func WithMaxTTL(ttl time.Duration) Option {
 }
 
 func WithDNSServer(serverNetworkOverride, serverAddressOverride string) Option {
-	netResolver := &net.Resolver{
-		PreferGo: true,
-		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-			d := net.Dialer{}
-			if serverNetworkOverride != "" {
-				network = serverNetworkOverride
-			}
-			// Note: we ignore the address in the argument
-			return d.DialContext(ctx, network, serverAddressOverride)
-		},
-	}
-
 	return func(r *resolverImpl) {
 		r.backendServer = serverAddressOverride
 		r.backendNetwork = serverNetworkOverride
+
 		r.resolve = func(ctx context.Context, host string) ([]net.IP, error) {
-			return netResolver.LookupIP(ctx, "ip", host)
+			fqdn := dns.Fqdn(host)
+			var ips []net.IP
+			dnsClient := &dns.Client{Net: r.backendNetwork}
+
+			for _, qType := range []uint16{dns.TypeA, dns.TypeAAAA} {
+				msg := new(dns.Msg).SetQuestion(fqdn, qType)
+				resp, _, err := dnsClient.ExchangeContext(ctx, msg, r.backendServer)
+				if err != nil {
+					return nil, err
+				}
+				for _, ans := range resp.Answer {
+					switch a := ans.(type) {
+					case *dns.A:
+						ips = append(ips, a.A)
+					case *dns.AAAA:
+						ips = append(ips, a.AAAA)
+					}
+				}
+			}
+			return ips, nil
 		}
 	}
 }


### PR DESCRIPTION
- Go's LookupIP implementation is complex (to make it efficient) and not worth it when DNS server is overridden.
- LookupIP may be buggy or less deterministic when not using system's local resolvers. I am not sure if that's the case, but I think it's okay to skip it to use a simple DNS client to do DNS queries when not using local resolvers.

Go's implementation is here:
https://github.com/golang/go/blob/ab5c22e7ed6bda79f07410c0041e020e52dc9b35/src/net/dnsclient_unix.go#L609
https://github.com/golang/go/blob/ab5c22e7ed6bda79f07410c0041e020e52dc9b35/src/net/dnsclient_unix.go#L297
