### PR TITLE
[probes.external] Factor out command execution.

### DIFF
--- a/probes/common/command/command.go
+++ b/probes/common/command/command.go
@@ -1,0 +1,145 @@
+// Copyright 2017-2024 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package command implements functionality to run a command for probes.
+
+This package is used by the external and browser probe types.
+*/
+package command
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/cloudprober/cloudprober/logger"
+)
+
+const (
+	maxScannerTokenSize = 256 * 1024
+)
+
+func isPipeOrFileClosedError(err error) bool {
+	if err == io.ErrClosedPipe {
+		return true
+	}
+	if pe, ok := err.(*os.PathError); ok {
+		if pe.Err == os.ErrClosed {
+			return true
+		}
+	}
+	return false
+}
+
+type Command struct {
+	CmdLine                []string
+	EnvVars                []string
+	WorkDir                string
+	ProcessStreamingOutput func([]byte)
+}
+
+func (c *Command) setupStreaming(cmd *exec.Cmd, l *logger.Logger) error {
+	stdout := make(chan []byte)
+	stdoutR, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	go func() {
+		defer close(stdout)
+		defer stdoutR.Close()
+		scanner := bufio.NewScanner(stdoutR)
+
+		buf := make([]byte, 0, bufio.MaxScanTokenSize)
+		scanner.Buffer(buf, maxScannerTokenSize)
+
+		for scanner.Scan() {
+			stdout <- scanner.Bytes()
+		}
+		if err := scanner.Err(); err != nil && !isPipeOrFileClosedError(err) {
+			l.Errorf("Error reading from stdout: %v", err)
+		}
+	}()
+
+	// Capture stderr
+	stderrR, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	go func() {
+		defer stderrR.Close()
+		scanner := bufio.NewScanner(stderrR)
+
+		buf := make([]byte, 0, bufio.MaxScanTokenSize)
+		scanner.Buffer(buf, maxScannerTokenSize)
+
+		for scanner.Scan() {
+			l.Warningf("Stderr: %s", scanner.Text())
+		}
+		if err := scanner.Err(); err != nil && !isPipeOrFileClosedError(err) {
+			l.Errorf("Error reading from stderr: %v", err)
+		}
+	}()
+
+	go func() {
+		for line := range stdout {
+			c.ProcessStreamingOutput(line)
+		}
+	}()
+
+	return nil
+}
+
+func (c *Command) Execute(ctx context.Context, l *logger.Logger) (string, error) {
+	cmd := exec.CommandContext(ctx, c.CmdLine[0], c.CmdLine[1:]...)
+	if c.EnvVars != nil {
+		cmd.Env = append(append(cmd.Env, os.Environ()...), c.EnvVars...)
+	}
+
+	if c.WorkDir != "" {
+		cmd.Dir = c.WorkDir
+	}
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+
+	if c.ProcessStreamingOutput != nil {
+		if err := c.setupStreaming(cmd, l); err != nil {
+			return "", fmt.Errorf("error setting up stdout/stderr streaming: %v", err)
+		}
+	} else {
+		cmd.Stdout, cmd.Stderr = &stdoutBuf, &stderrBuf
+	}
+
+	l.Debugf("Running command: %v", cmd)
+	err := runCommand(ctx, cmd)
+
+	if err != nil {
+		stdout, stderr := stdoutBuf.String(), stderrBuf.String()
+		stderrout := ""
+		if stdout != "" || stderr != "" {
+			stderrout = fmt.Sprintf(" Stdout: %s, Stderr: %s", stdout, stderr)
+		}
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("external probe process died with the status (%s). Stderr: %s", exitErr.Error(), stderrout)
+		} else {
+			return "", fmt.Errorf("error executing the external program. Err: %v. Stderr: %s", err, stderrout)
+		}
+	}
+
+	return stdoutBuf.String(), nil
+}

--- a/probes/common/command/command_test.go
+++ b/probes/common/command/command_test.go
@@ -1,0 +1,152 @@
+// Copyright 2017-2024 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package command
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestShellProcessSuccess is just a helper function that we use to test the
+// actual command execution (from startCmdIfNotRunning, e.g.).
+func TestShellProcessSuccess(t *testing.T) {
+	// Ignore this test if it's not being run as a subprocess for another test.
+	if os.Getenv("GO_CP_TEST_PROCESS") != "1" {
+		return
+	}
+
+	exportEnvList := []string{}
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, "GO_CP_TEST") {
+			exportEnvList = append(exportEnvList, env)
+		}
+	}
+	fmt.Fprintf(os.Stderr, "Running test command. Env: %s\n", strings.Join(exportEnvList, ","))
+
+	pauseTime := 10 * time.Millisecond
+	pauseSec, _ := strconv.Atoi(os.Getenv("GO_CP_TEST_PAUSE"))
+	if pauseSec != 0 {
+		pauseTime = time.Duration(pauseSec) * time.Second
+	}
+
+	if len(os.Args) > 4 {
+		fmt.Printf("cmd \"%s\"\n", os.Args[3])
+		time.Sleep(pauseTime)
+		fmt.Printf("args \"%s\"\n", strings.Join(os.Args[4:], ","))
+		fmt.Printf("env \"%s\"\n", strings.Join(exportEnvList, ","))
+	}
+
+	if os.Getenv("GO_CP_TEST_PROCESS_FAIL") != "" {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func testCommandExecute(t *testing.T, disableStreaming bool) {
+	t.Helper()
+
+	// This is the base command, it gets appended to the test command.
+	cmd := []string{"/test/cmd", "--address=a.com", "--arg2"}
+
+	p := &Command{
+		CmdLine: append([]string{os.Args[0], "-test.run=TestShellProcessSuccess", "--", cmd[0]}, cmd[1:]...), // prepend os.Args[0],
+		EnvVars: []string{
+			"GO_CP_TEST_PROCESS=1",
+			"GO_CP_TEST_PIDS_FILE=pidsFile",
+		},
+	}
+
+	// Output by TestShellProcessSuccess from the first run
+	wantOutput := []string{
+		"cmd \"/test/cmd\"",
+		"args \"--address=a.com,--arg2\"",
+		"env \"GO_CP_TEST_PROCESS=1,GO_CP_TEST_PIDS_FILE=pidsFile\"",
+	}
+
+	var output []string
+	var outputTS []int64
+	var outputMu sync.RWMutex
+	if !disableStreaming {
+		p.ProcessStreamingOutput = func(line []byte) {
+			outputMu.Lock()
+			defer outputMu.Unlock()
+			output = append(output, string(line))
+			outputTS = append(outputTS, time.Now().UnixMilli())
+		}
+	}
+
+	t.Run("first-run", func(t *testing.T) {
+		payload, err := p.Execute(context.Background(), nil)
+		assert.NoError(t, err)
+
+		if !disableStreaming {
+			assert.Equal(t, "", payload)
+		} else {
+			assert.Equal(t, strings.Join(wantOutput, "\n")+"\n", payload)
+		}
+	})
+
+	wantOutput = append(wantOutput, wantOutput...)
+	wantOutput[len(wantOutput)-1] = "env \"GO_CP_TEST_PROCESS_FAIL=1,GO_CP_TEST_PROCESS=1,GO_CP_TEST_PIDS_FILE=pidsFile\""
+	t.Run("second-run", func(t *testing.T) {
+		os.Setenv("GO_CP_TEST_PROCESS_FAIL", "1")
+		defer os.Unsetenv("GO_CP_TEST_PROCESS_FAIL")
+
+		payload, err := p.Execute(context.Background(), nil)
+		assert.Error(t, err)
+		assert.Equal(t, "", payload)
+	})
+
+	// Make process timeout between "cmd" and "args" output
+	wantOutput = append(wantOutput, wantOutput[0])
+	t.Run("third-run-with-timeout", func(t *testing.T) {
+		os.Setenv("GO_CP_TEST_PAUSE", "1")
+		defer os.Unsetenv("GO_CP_TEST_PAUSE")
+
+		// Give process enough time to get the first line
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		payload, err := p.Execute(ctx, nil)
+		assert.Error(t, err)
+		assert.Equal(t, "", payload)
+	})
+
+	if !disableStreaming {
+		outputMu.RLock()
+		defer outputMu.RUnlock()
+		assert.Equal(t, wantOutput, output)
+
+		// Verify that difference between first two timestamps is at least 10ms
+		assert.True(t, outputTS[1] >= outputTS[0]+10, "gap between cmd and arg not more than 10ms")
+		// Verify that difference between second two timestamps is less than 10ms
+		assert.True(t, outputTS[2] < outputTS[1]+10, "gap between arg and env not less than 10ms")
+	}
+}
+
+func TestCommand(t *testing.T) {
+	for _, disableStreaming := range []bool{false, true} {
+		t.Run(fmt.Sprintf("disable-streaming:%v", disableStreaming), func(t *testing.T) {
+			testCommandExecute(t, disableStreaming)
+		})
+	}
+}

--- a/probes/common/command/runcmd_nonlinux.go
+++ b/probes/common/command/runcmd_nonlinux.go
@@ -14,13 +14,13 @@
 
 //go:build !linux
 
-package external
+package command
 
 import (
 	"context"
 	"os/exec"
 )
 
-func (p *Probe) runCommand(_ context.Context, c *exec.Cmd) error {
-	return c.Run()
+func runCommand(_ context.Context, cmd *exec.Cmd) error {
+	return cmd.Run()
 }

--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -24,14 +24,10 @@ over stdin/stdout for each probe cycle.
 package external
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"os/exec"
 	"regexp"
 	"sort"
 	"strconv"
@@ -45,6 +41,7 @@ import (
 	"github.com/cloudprober/cloudprober/metrics"
 	"github.com/cloudprober/cloudprober/metrics/payload"
 	payloadpb "github.com/cloudprober/cloudprober/metrics/payload/proto"
+	"github.com/cloudprober/cloudprober/probes/common/command"
 	configpb "github.com/cloudprober/cloudprober/probes/external/proto"
 	serverpb "github.com/cloudprober/cloudprober/probes/external/proto"
 	"github.com/cloudprober/cloudprober/probes/options"
@@ -178,7 +175,7 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 	return nil
 }
 
-type command interface {
+type commandIntf interface {
 	Wait() error
 }
 
@@ -215,22 +212,23 @@ func (p *Probe) labels(ep endpoint.Endpoint) map[string]string {
 	return labels
 }
 
-// probeStatus captures the single probe status. It's only used by runProbe
-// functions to pass a probe's status to processProbeResult method.
+func (p *Probe) withStdLabels(em *metrics.EventMetrics, target endpoint.Endpoint) *metrics.EventMetrics {
+	return em.AddLabel("ptype", "external").AddLabel("probe", p.name).AddLabel("dst", target.Dst())
+}
+
 type probeStatus struct {
-	target  endpoint.Endpoint
 	success bool
 	latency time.Duration
 	payload string
 }
 
-func (p *Probe) processProbeResult(ps *probeStatus, result *result) {
+func (p *Probe) processProbeResult(ps *probeStatus, target endpoint.Endpoint, result *result) {
 	if ps.success && p.opts.Validators != nil {
 		failedValidations := validators.RunValidators(p.opts.Validators, &validators.Input{ResponseBody: []byte(ps.payload)}, result.validationFailure, p.l)
 
 		// If any validation failed, log and set success to false.
 		if len(failedValidations) > 0 {
-			p.l.Debug("Target:", ps.target.Name, " failed validations: ", strings.Join(failedValidations, ","), ".")
+			p.l.Debug("Target:", target.Name, " failed validations: ", strings.Join(failedValidations, ","), ".")
 			ps.success = false
 		}
 	}
@@ -243,88 +241,21 @@ func (p *Probe) processProbeResult(ps *probeStatus, result *result) {
 	defaultEM := metrics.NewEventMetrics(time.Now()).
 		AddMetric("success", metrics.NewInt(result.success)).
 		AddMetric("total", metrics.NewInt(result.total)).
-		AddMetric(p.opts.LatencyMetricName, result.latency.Clone()).
-		AddLabel("ptype", "external").
-		AddLabel("probe", p.name).
-		AddLabel("dst", ps.target.Name)
+		AddMetric(p.opts.LatencyMetricName, result.latency.Clone())
 
 	if p.opts.Validators != nil {
 		defaultEM.AddMetric("validation_failure", result.validationFailure)
 	}
-	p.opts.RecordMetrics(ps.target, defaultEM, p.dataChan)
+
+	p.opts.RecordMetrics(target, p.withStdLabels(defaultEM, target), p.dataChan)
 
 	// If probe is configured to use the external process output (or reply payload
 	// in case of server probe) as metrics.
 	if p.c.GetOutputAsMetrics() {
-		for _, em := range p.payloadParser.PayloadMetrics(&payload.Input{Text: []byte(ps.payload)}, ps.target.Dst()) {
-			em.AddLabel("ptype", "external").AddLabel("probe", p.name).AddLabel("dst", ps.target.Dst())
-			p.opts.RecordMetrics(ps.target, em, p.dataChan, options.WithNoAlert())
+		for _, em := range p.payloadParser.PayloadMetrics(&payload.Input{Text: []byte(ps.payload)}, target.Dst()) {
+			p.opts.RecordMetrics(target, p.withStdLabels(em, target), p.dataChan, options.WithNoAlert())
 		}
 	}
-}
-
-func isPipeOrFileClosedError(err error) bool {
-	if err == io.ErrClosedPipe {
-		return true
-	}
-	if pe, ok := err.(*os.PathError); ok {
-		if pe.Err == os.ErrClosed {
-			return true
-		}
-	}
-	return false
-}
-
-func (p *Probe) setupStreaming(c *exec.Cmd, target endpoint.Endpoint) error {
-	stdout := make(chan string)
-	stdoutR, err := c.StdoutPipe()
-	if err != nil {
-		return err
-	}
-	stderrR, err := c.StderrPipe()
-	if err != nil {
-		return err
-	}
-	go func() {
-		defer close(stdout)
-		defer stdoutR.Close()
-		scanner := bufio.NewScanner(stdoutR)
-
-		buf := make([]byte, 0, bufio.MaxScanTokenSize)
-		scanner.Buffer(buf, maxScannerTokenSize)
-
-		for scanner.Scan() {
-			stdout <- scanner.Text()
-		}
-		if err := scanner.Err(); err != nil && !isPipeOrFileClosedError(err) {
-			p.l.Errorf("Error reading from stdout: %v", err)
-		}
-	}()
-	go func() {
-		defer stderrR.Close()
-		scanner := bufio.NewScanner(stderrR)
-
-		buf := make([]byte, 0, bufio.MaxScanTokenSize)
-		scanner.Buffer(buf, maxScannerTokenSize)
-
-		for scanner.Scan() {
-			p.l.Warningf("Stderr: %s", scanner.Text())
-		}
-		if err := scanner.Err(); err != nil && !isPipeOrFileClosedError(err) {
-			p.l.Errorf("Error reading from stderr: %v", err)
-		}
-	}()
-
-	go func() {
-		for line := range stdout {
-			for _, em := range p.payloadParser.PayloadMetrics(&payload.Input{Text: []byte(line)}, target.Dst()) {
-				em.AddLabel("ptype", "external").AddLabel("probe", p.name).AddLabel("dst", target.Dst())
-				p.opts.RecordMetrics(target, em, p.dataChan, options.WithNoAlert())
-			}
-		}
-	}()
-
-	return nil
 }
 
 func (p *Probe) runOnceProbe(ctx context.Context) {
@@ -348,47 +279,26 @@ func (p *Probe) runOnceProbe(ctx context.Context) {
 
 			p.l.Infof("Running external command: %s %s", p.cmdName, strings.Join(args, " "))
 			result.total++
-			startTime := time.Now()
 
-			c := exec.CommandContext(ctx, p.cmdName, args...)
-			if p.envVars != nil {
-				c.Env = append(append(c.Env, os.Environ()...), p.envVars...)
+			cmd := &command.Command{
+				CmdLine: append([]string{p.cmdName}, args...),
+				EnvVars: p.envVars,
 			}
-
-			var stdoutBuf, stderrBuf bytes.Buffer
-
 			if p.c.GetOutputAsMetrics() && !p.c.GetDisableStreamingOutputMetrics() {
-				if err := p.setupStreaming(c, target); err != nil {
-					p.l.Errorf("Error setting up stdout/stderr pipe: %v", err)
-					return
+				cmd.ProcessStreamingOutput = func(line []byte) {
+					for _, em := range p.payloadParser.PayloadMetrics(&payload.Input{Text: line}, target.Dst()) {
+						p.opts.RecordMetrics(target, p.withStdLabels(em, target), p.dataChan, options.WithNoAlert())
+					}
 				}
-			} else {
-				c.Stdout, c.Stderr = &stdoutBuf, &stderrBuf
 			}
 
-			err := p.runCommand(ctx, c)
-
-			success := true
+			startTime := time.Now()
+			status, err := cmd.Execute(ctx, p.l)
+			latency := time.Since(startTime)
 			if err != nil {
-				success = false
-				stdout, stderr := stdoutBuf.String(), stderrBuf.String()
-				stderrout := ""
-				if stdout != "" || stderr != "" {
-					stderrout = fmt.Sprintf(" Stdout: %s, Stderr: %s", stdout, stderr)
-				}
-				if exitErr, ok := err.(*exec.ExitError); ok {
-					p.l.Errorf("external probe process died with the status: %s.%s", exitErr.Error(), stderrout)
-				} else {
-					p.l.Errorf("Error executing the external program. Err: %v.%s", err, stderrout)
-				}
+				p.l.Errorf("Error running external probe: %v", err)
 			}
-
-			p.processProbeResult(&probeStatus{
-				target:  target,
-				success: success,
-				payload: stdoutBuf.String(),
-				latency: time.Since(startTime),
-			}, result)
+			p.processProbeResult(&probeStatus{success: err == nil, latency: latency, payload: status}, target, result)
 		}(target, p.results[target.Key()])
 	}
 	wg.Wait()

--- a/probes/external/external_server.go
+++ b/probes/external/external_server.go
@@ -58,7 +58,7 @@ var (
 
 // monitorCommand waits for the process to terminate and sets cmdRunning to
 // false when that happens.
-func (p *Probe) monitorCommand(startCtx context.Context, cmd command) error {
+func (p *Probe) monitorCommand(startCtx context.Context, cmd commandIntf) error {
 	err := cmd.Wait()
 
 	// Dont'log error message if killed explicitly.
@@ -236,12 +236,11 @@ func (p *Probe) runServerProbe(ctx, startCtx context.Context) {
 					success = false
 				}
 				ps := &probeStatus{
-					target:  reqInfo.target,
 					success: success,
 					latency: time.Since(reqInfo.timestamp),
 					payload: rep.GetPayload(),
 				}
-				p.processProbeResult(ps, p.results[reqInfo.target.Key()])
+				p.processProbeResult(ps, reqInfo.target, p.results[reqInfo.target.Key()])
 			}
 
 			// We send a total if len(p.targets) requests. We can exit if we've
@@ -274,6 +273,6 @@ func (p *Probe) runServerProbe(ctx, startCtx context.Context) {
 	outstandingReqsMu.Lock()
 	defer outstandingReqsMu.Unlock()
 	for _, req := range outstandingReqs {
-		p.processProbeResult(&probeStatus{target: req.target, success: false}, p.results[req.target.Key()])
+		p.processProbeResult(&probeStatus{success: false}, req.target, p.results[req.target.Key()])
 	}
 }

--- a/probes/external/external_test.go
+++ b/probes/external/external_test.go
@@ -525,22 +525,20 @@ func TestProcessProbeResult(t *testing.T) {
 
 			// First run
 			p.processProbeResult(&probeStatus{
-				target:  endpoint.Endpoint{Name: "test-target"},
 				success: true,
 				latency: time.Millisecond,
 				payload: test.payloads[0],
-			}, r)
+			}, endpoint.Endpoint{Name: "test-target"}, r)
 
 			wantSuccess := int64(1)
 			verifyProcessedResult(t, p, r, wantSuccess, "p-failures", test.wantValues[0], test.wantExtraLabels)
 
 			// Second run
 			p.processProbeResult(&probeStatus{
-				target:  endpoint.Endpoint{Name: "test-target"},
 				success: true,
 				latency: time.Millisecond,
 				payload: test.payloads[1],
-			}, r)
+			}, endpoint.Endpoint{Name: "test-target"}, r)
 			wantSuccess++
 
 			verifyProcessedResult(t, p, r, wantSuccess, "p-failures", test.wantValues[1], test.wantExtraLabels)


### PR DESCRIPTION
- Factor out command execution fuctionality into a common package in
preparation for adding the browser probe. (See #848).
- I want to factor it out sooner so that we can test external prober
changes sooner.