### PR TITLE
[probes.external] Fix a bug in initialization of server mode

### DIFF
--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -53,8 +53,6 @@ var (
 	validLabelRe = regexp.MustCompile(`@(target|address|port|probe|target.(name|ip|port)|target\.label\.[^@]+)@`)
 )
 
-const maxScannerTokenSize = 256 * 1024
-
 type result struct {
 	total, success    int64
 	latency           metrics.LatencyValue

--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -64,7 +64,6 @@ type result struct {
 // Probe holds aggregate information about all probe runs, per-target.
 type Probe struct {
 	name    string
-	mode    string
 	cmdName string
 	cmdArgs []string
 	envVars []string
@@ -148,15 +147,6 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 	// Figure out labels we are interested in
 	p.updateLabelKeys()
 
-	switch p.c.GetMode() {
-	case configpb.ProbeConf_ONCE:
-		p.mode = "once"
-	case configpb.ProbeConf_SERVER:
-		p.mode = "server"
-	default:
-		return fmt.Errorf("invalid mode: %s", p.c.GetMode())
-	}
-
 	p.results = make(map[string]*result)
 
 	if !p.c.GetOutputAsMetrics() {
@@ -165,6 +155,9 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 
 	omo := p.c.GetOutputMetricsOptions()
 	if omo.GetMetricsKind() == payloadpb.OutputMetricsOptions_UNDEFINED && p.c.GetMode() == configpb.ProbeConf_SERVER {
+		if omo == nil {
+			omo = &payloadpb.OutputMetricsOptions{}
+		}
 		omo.MetricsKind = payloadpb.OutputMetricsOptions_CUMULATIVE.Enum()
 	}
 	p.payloadParser, err = payload.NewParser(omo, p.l)
@@ -336,7 +329,7 @@ func (p *Probe) runProbe(startCtx context.Context) {
 
 	p.updateTargets()
 
-	if p.mode == "server" {
+	if p.c.GetMode() == configpb.ProbeConf_SERVER {
 		p.runServerProbe(probeCtx, startCtx)
 	} else {
 		p.runOnceProbe(probeCtx)

--- a/probes/external/external_server_test.go
+++ b/probes/external/external_server_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cloudprober/cloudprober/metrics/testutils"
+	configpb "github.com/cloudprober/cloudprober/probes/external/proto"
 	serverpb "github.com/cloudprober/cloudprober/probes/external/proto"
 	"github.com/cloudprober/cloudprober/probes/external/serverutils"
 	"github.com/stretchr/testify/assert"
@@ -127,7 +128,7 @@ func testProbeServerSetup(t *testing.T, ctx context.Context, readErrorCh chan er
 	p.cmdRunning = true // don't try to start the probe server
 	p.cmdStdin = w1
 	p.cmdStdout = r2
-	p.mode = "server"
+	p.c.Mode = configpb.ProbeConf_SERVER.Enum()
 
 	// Start the goroutine that reads probe replies.
 	go func() {

--- a/probes/external/external_server_test.go
+++ b/probes/external/external_server_test.go
@@ -124,11 +124,10 @@ func testProbeServerSetup(t *testing.T, ctx context.Context, readErrorCh chan er
 	// Start probe server in a goroutine
 	go startProbeServer(t, ctx, testPayload, r1, w2)
 
-	p := createTestProbe("./testCommand", nil)
+	p := createTestProbe("./testCommand", nil, configpb.ProbeConf_SERVER)
 	p.cmdRunning = true // don't try to start the probe server
 	p.cmdStdin = w1
 	p.cmdStdout = r2
-	p.c.Mode = configpb.ProbeConf_SERVER.Enum()
 
 	// Start the goroutine that reads probe replies.
 	go func() {

--- a/probes/external/external_test.go
+++ b/probes/external/external_test.go
@@ -67,8 +67,9 @@ func runAndVerifyProbe(t *testing.T, p *Probe, tgts []string, total, success map
 	}
 }
 
-func createTestProbe(cmd string, envVar map[string]string) *Probe {
+func createTestProbe(cmd string, envVar map[string]string, mode configpb.ProbeConf_Mode) *Probe {
 	probeConf := &configpb.ProbeConf{
+		Mode: mode.Enum(),
 		Options: []*configpb.ProbeConf_Option{
 			{
 				Name:  proto.String("action"),
@@ -136,7 +137,7 @@ func testProbeOnceMode(t *testing.T, cmd string, tgts []string, runTwice, disabl
 	p := createTestProbe(cmd, map[string]string{
 		"GO_CP_TEST_PROCESS":   "1",
 		"GO_CP_TEST_PIDS_FILE": pidsFile,
-	})
+	}, configpb.ProbeConf_ONCE)
 
 	p.cmdArgs = append([]string{"-test.run=TestShellProcessSuccess", "--", p.cmdName}, p.cmdArgs...)
 	p.cmdName = os.Args[0]
@@ -547,7 +548,7 @@ func TestProcessProbeResult(t *testing.T) {
 }
 
 func TestCommandParsing(t *testing.T) {
-	p := createTestProbe("./test-command --flag1 one --flag23 \"two three\"", nil)
+	p := createTestProbe("./test-command --flag1 one --flag23 \"two three\"", nil, configpb.ProbeConf_ONCE)
 
 	wantCmdName := "./test-command"
 	if p.cmdName != wantCmdName {
@@ -690,7 +691,7 @@ func TestProbeStartCmdIfNotRunning(t *testing.T) {
 			p := createTestProbe("/testCommand", map[string]string{
 				"GO_CP_TEST_PROCESS": "1",
 				"GO_CP_TEST_PAUSE":   strconv.Itoa(test.pauseSec),
-			})
+			}, configpb.ProbeConf_ONCE)
 
 			p.cmdName = os.Args[0]
 			p.cmdArgs = []string{"-test.run=TestShellProcessSuccess"}


### PR DESCRIPTION
If OutputMetricOptions was unset, we were trying to set field of a nil object.

Add initialization specific tests.