### PR TITLE
[metrics] Set type to GAUGE when exporting metrics as GAUGE

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -16,7 +16,7 @@
 package metrics
 
 import (
-	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -81,5 +81,5 @@ func ParseValueFromString(val string) (Value, error) {
 		return distVal, nil
 	}
 
-	return nil, errors.New("unknown value type")
+	return nil, fmt.Errorf("unknown value type: %s", val)
 }

--- a/surfacers/internal/common/transform/transform.go
+++ b/surfacers/internal/common/transform/transform.go
@@ -57,6 +57,7 @@ func CumulativeToGauge(em *metrics.EventMetrics, lvCache map[string]*metrics.Eve
 
 	// If it is the first time for this EventMetrics, return it as it is.
 	if !ok {
+		em.Kind = metrics.GAUGE
 		return em, nil
 	}
 
@@ -65,5 +66,6 @@ func CumulativeToGauge(em *metrics.EventMetrics, lvCache map[string]*metrics.Eve
 		return nil, fmt.Errorf("error subtracting cached metrics from current metrics: %v", err)
 	}
 
+	gaugeEM.Kind = metrics.GAUGE
 	return gaugeEM, nil
 }


### PR DESCRIPTION
- Also, in metrics, print the input if we can't parse it.