### PR TITLE
[probes.http] Stop using the default http transport

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -165,7 +165,8 @@ func (p *Probe) getTransport() (*http.Transport, error) {
 	if p.c.GetDisableHttp2() {
 		// HTTP/2 is enabled by default if server supports it. Setting
 		// TLSNextProto to an empty dict is the only way to disable it.
-		// This only works if transport hasn't been previously cloned. See https://github.com/cloudprober/cloudprober/issues/872
+		// This only works if transport hasn't been previously cloned.
+		// See https://github.com/cloudprober/cloudprober/issues/872
 		transport.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
 		transport.ForceAttemptHTTP2 = false
 	}

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -104,7 +104,10 @@ type probeResult struct {
 }
 
 func (p *Probe) getTransport() (*http.Transport, error) {
-	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport := &http.Transport{
+		Proxy:             http.ProxyFromEnvironment,
+		ForceAttemptHTTP2: true,
+	}
 	dialer := &net.Dialer{
 		Timeout:   p.opts.Timeout,
 		KeepAlive: 30 * time.Second, // TCP keep-alive

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -106,7 +106,6 @@ type probeResult struct {
 func (p *Probe) getTransport() (*http.Transport, error) {
 	transport := &http.Transport{
 		Proxy:             http.ProxyFromEnvironment,
-		TLSClientConfig:   &tls.Config{},
 		ForceAttemptHTTP2: true,
 	}
 	dialer := &net.Dialer{
@@ -166,6 +165,7 @@ func (p *Probe) getTransport() (*http.Transport, error) {
 	if p.c.GetDisableHttp2() {
 		// HTTP/2 is enabled by default if server supports it. Setting
 		// TLSNextProto to an empty dict is the only way to disable it.
+		// This only works if transport hasn't been previously cloned. See https://github.com/cloudprober/cloudprober/issues/872
 		transport.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
 		transport.ForceAttemptHTTP2 = false
 	}

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -106,6 +106,7 @@ type probeResult struct {
 func (p *Probe) getTransport() (*http.Transport, error) {
 	transport := &http.Transport{
 		Proxy:             http.ProxyFromEnvironment,
+		TLSClientConfig:   &tls.Config{},
 		ForceAttemptHTTP2: true,
 	}
 	dialer := &net.Dialer{

--- a/probes/http/http_test.go
+++ b/probes/http/http_test.go
@@ -698,6 +698,9 @@ func TestGetTransport(t *testing.T) {
 			assert.Equal(t, !test.disableHTTP2, transport.ForceAttemptHTTP2)
 
 			if test.disableHTTP2 {
+				if transport.TLSClientConfig != nil {
+					assert.Empty(t, transport.TLSClientConfig.NextProtos)
+				}
 				assert.NotNil(t, transport.TLSNextProto)
 				assert.Empty(t, transport.TLSNextProto)
 			} else {

--- a/probes/http/http_test.go
+++ b/probes/http/http_test.go
@@ -698,9 +698,6 @@ func TestGetTransport(t *testing.T) {
 			assert.Equal(t, !test.disableHTTP2, transport.ForceAttemptHTTP2)
 
 			if test.disableHTTP2 {
-				if transport.TLSClientConfig != nil {
-					assert.Empty(t, transport.TLSClientConfig.NextProtos)
-				}
 				assert.NotNil(t, transport.TLSNextProto)
 				assert.Empty(t, transport.TLSNextProto)
 			} else {


### PR DESCRIPTION
To address https://github.com/cloudprober/cloudprober/issues/872

Currently if the `disable_http2` option is set to true, http probes would fail with malformed response. 

This is due to `transport.ForceAttemptHTTP2` being set to false and `transport.TLSNextProto` being set to an empty map, BUT `transport.TLSClientConfig.NextProtos` being populated with `"h2", "http/1.1"`. In other words, we wanted to disable http2, but the TLS ALPN protocols contain `h2`. This is not a valid configuration.

To prevent ALPN protocols from being populated, we shouldn't use the default http transport.


## Testing
Probes with the following config are succeeding without getting malformed response.
```
probe {
  name: "google"
  type: HTTP
  targets {
    host_names: "google.com"
  }
  interval_msec: 5000  # 5s
  timeout_msec: 5000   # 5s

  http_probe {
    protocol: HTTPS
    disable_http2: true
  }
}

probe {
  name: "cloudprober"
  type: HTTP
  targets {
    host_names: "cloudprober.org"
  }
  interval_msec: 5000  # 5s
  timeout_msec: 5000   # 5s

  http_probe {
    protocol: HTTPS
    disable_http2: true
  }
}
```
