### PR TITLE
[probes.http] Scheduler should consider user provided gap between targets

### DIFF
--- a/probes/common/sched/sched.go
+++ b/probes/common/sched/sched.go
@@ -69,9 +69,6 @@ type Scheduler struct {
 	// RunProbeForTarget is called per probe cycle for each target.
 	RunProbeForTarget func(context.Context, endpoint.Endpoint, ProbeResult)
 
-	// IntervalBetweenTargets defines the time between target updates.
-	IntervalBetweenTargets time.Duration
-
 	statsExportFrequency  int64
 	targetsUpdateInterval time.Duration
 	targets               []endpoint.Endpoint
@@ -98,16 +95,26 @@ func (s *Scheduler) init() {
 }
 
 func (s *Scheduler) gapBetweenTargets() time.Duration {
-	interTargetGap := s.IntervalBetweenTargets
-
-	// If not configured by user, determine based on probe interval and number of
-	// targets.
-	if interTargetGap == 0 && len(s.targets) != 0 {
-		// Use 1/10th of the probe interval to spread out target groroutines.
-		interTargetGap = s.Opts.Interval / time.Duration(10*len(s.targets))
+	type confTargetGap interface {
+		GetIntervalBetweenTargetsMsec() int32
 	}
 
-	return interTargetGap
+	var interTargetGap time.Duration
+
+	if s.Opts.ProbeConf != nil {
+		if c, ok := s.Opts.ProbeConf.(confTargetGap); ok {
+			interTargetGap = time.Duration(c.GetIntervalBetweenTargetsMsec()) * time.Millisecond
+		}
+	}
+
+	if interTargetGap != 0 || len(s.targets) == 0 {
+		return interTargetGap
+	}
+
+	// If not configured by user, determine based on probe interval and number
+	// of targets. Use 1/10th of the probe interval to spread out target
+	// goroutines.
+	return s.Opts.Interval / time.Duration(10*len(s.targets))
 }
 
 func (s *Scheduler) startForTarget(ctx context.Context, target endpoint.Endpoint) {

--- a/probes/common/sched/sched.go
+++ b/probes/common/sched/sched.go
@@ -95,13 +95,13 @@ func (s *Scheduler) init() {
 }
 
 func (s *Scheduler) gapBetweenTargets() time.Duration {
-	type confTargetGap interface {
-		GetIntervalBetweenTargetsMsec() int32
-	}
-
 	var interTargetGap time.Duration
 
 	if s.Opts.ProbeConf != nil {
+		type confTargetGap interface {
+			GetIntervalBetweenTargetsMsec() int32
+		}
+
 		if c, ok := s.Opts.ProbeConf.(confTargetGap); ok {
 			interTargetGap = time.Duration(c.GetIntervalBetweenTargetsMsec()) * time.Millisecond
 		}

--- a/probes/tcp/tcp.go
+++ b/probes/tcp/tcp.go
@@ -182,12 +182,11 @@ func (p *Probe) runProbe(ctx context.Context, target endpoint.Endpoint, res sche
 // Start starts and runs the probe indefinitely.
 func (p *Probe) Start(ctx context.Context, dataChan chan *metrics.EventMetrics) {
 	s := &sched.Scheduler{
-		ProbeName:              p.name,
-		DataChan:               dataChan,
-		Opts:                   p.opts,
-		NewResult:              func(_ *endpoint.Endpoint) sched.ProbeResult { return p.newResult() },
-		RunProbeForTarget:      p.runProbe,
-		IntervalBetweenTargets: time.Duration(p.c.GetIntervalBetweenTargetsMsec()) * time.Millisecond,
+		ProbeName:         p.name,
+		DataChan:          dataChan,
+		Opts:              p.opts,
+		NewResult:         func(_ *endpoint.Endpoint) sched.ProbeResult { return p.newResult() },
+		RunProbeForTarget: p.runProbe,
 	}
 	s.UpdateTargetsAndStartProbes(ctx)
 }


### PR DESCRIPTION
Moving of HTTP probe to common scheduler in https://github.com/cloudprober/cloudprober/pull/840 introduced a bug, where we stopped honoring user provided inter-target-gap. Only HTTP and TCP probes have this config field (it was initially only in HTTP, but was copied to TCP probe).