### PR TITLE
[probes.external] Improve on how we export external probe process's logs

### DIFF
--- a/probes/external/external_server.go
+++ b/probes/external/external_server.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
@@ -109,7 +110,7 @@ func (p *Probe) startCmdIfNotRunning(startCtx context.Context) error {
 	go func() {
 		scanner := bufio.NewScanner(p.cmdStderr)
 		for scanner.Scan() {
-			p.l.Warningf("Stderr of %s: %s", cmd.Path, scanner.Text())
+			p.l.WarningAttrs("process stderr", slog.String("process_stderr", scanner.Text()), slog.String("process_path", cmd.Path))
 		}
 	}()
 


### PR DESCRIPTION
- Export external process's logs in a dedicated field: `process_stderr`
- This allow users to further parse external process's logs.

I asked ChatGPT if Datadog can do it. It seems it can:
https://chatgpt.com/share/671304a1-9944-8005-9568-cdd058c1547c

See https://github.com/cloudprober/cloudprober/issues/893 for some background.