### PR TITLE
[config] Provide a way to access config file directory in configs.

### DIFF
--- a/config/configsource.go
+++ b/config/configsource.go
@@ -20,6 +20,7 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	configpb "github.com/cloudprober/cloudprober/config/proto"
+	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/internal/sysvars"
 	"github.com/cloudprober/cloudprober/logger"
 )
@@ -98,6 +99,10 @@ func (dcs *defaultConfigSource) GetConfig() (*configpb.ProberConfig, error) {
 			dcs.FileName = defaultConfigFile
 		}
 	}
+
+	// Set the config file path in runconfig. This can be used to find files
+	// relative to the config file.
+	runconfig.SetConfigFilePath(dcs.FileName)
 
 	if dcs.BaseVars == nil {
 		dcs.BaseVars = make(map[string]any, len(sysvars.Vars()))

--- a/config/runconfig/runconfig.go
+++ b/config/runconfig/runconfig.go
@@ -36,6 +36,7 @@ type runConfig struct {
 	buildTimestamp time.Time
 	rdsServer      *rdsserver.Server
 	httpServeMux   *http.ServeMux
+	configFilePath string
 }
 
 var rc runConfig
@@ -114,4 +115,16 @@ func DefaultHTTPServeMux() *http.ServeMux {
 	rc.RLock()
 	defer rc.RUnlock()
 	return rc.httpServeMux
+}
+
+func SetConfigFilePath(configFilePath string) {
+	rc.Lock()
+	defer rc.Unlock()
+	rc.configFilePath = configFilePath
+}
+
+func ConfigFilePath() string {
+	rc.RLock()
+	defer rc.RUnlock()
+	return rc.configFilePath
 }


### PR DESCRIPTION
- Add {{ configDir }} macro that expands to the config file directory.
- This will be useful to specify file paths relative to the config file
  directory, e.g. oauth json config, certificates, script, etc.