### PR TITLE
update go directive to include minor version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudprober/cloudprober
 
-go 1.23
+go 1.23.3
 
 require (
 	cloud.google.com/go/bigquery v1.59.1


### PR DESCRIPTION
With the patch number, I got a weird "toolchain not available" error (where my workspace has go 1.22.x installed; and this project is asking to upgrade to 1.23, but apparently it doesn't know how...)

More discussion here:  https://github.com/golang/go/issues/62278