### PR TITLE
[probes.dns] Add ptype="dns" label to all DNS probe metrics by default

### DIFF
--- a/probes/dns/dns.go
+++ b/probes/dns/dns.go
@@ -132,7 +132,8 @@ func (prr probeRunResult) Metrics(ts time.Time, _ int64, opts *options.Options) 
 		AddMetric("total", &prr.total).
 		AddMetric("success", &prr.success).
 		AddMetric(opts.LatencyMetricName, prr.latency.Clone()).
-		AddMetric("timeouts", &prr.timeouts)
+		AddMetric("timeouts", &prr.timeouts).
+		AddLabel("ptype", "dns")
 
 	if prr.validationFailure != nil {
 		em.AddMetric("validation_failure", prr.validationFailure)


### PR DESCRIPTION
This appears to be set on other probes. Obviously the workaround is `additional_label`, so I'm not sure whether it's actually worth doing this.