### PR TITLE
Update go directive to include the patch number

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudprober/cloudprober
 
-go 1.23
+go 1.23.0
 
 require (
 	cloud.google.com/go/bigquery v1.59.1


### PR DESCRIPTION
Without the patch number, I hit a "toolchain not available" error from an env where go 1.22 was installed, and this project requires 1.23, and apparently it cannot locate the toolchain.

Similar discussion in: https://github.com/golang/go/issues/62278