### PR TITLE
[docs] Show Cloudprober users more prominently

### DIFF
--- a/docs/assets/scss/common/_custom.scss
+++ b/docs/assets/scss/common/_custom.scss
@@ -32,6 +32,7 @@
     "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
     "Segoe UI Symbol", "Noto Color Emoji";
   font-size: 125%;
+  line-height: 1.5;
 }
 
 .alert {

--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -29,12 +29,16 @@
 <section class="section section-sm">
   <div class="container">
     <div class="row justify-content-center py-3">
-      <div class="col-lg-12 text-center">
-        <p style="font-weight: 400; font-size: 17px">
-          <i>
-            An open-source active monitoring tool trusted by large and small
-            organizations alike.
-          </i>
+      <div class="col-lg-12 text-center" style="border:1px solid #176bab !important; margin-bottom: 1rem">
+        <h3 class="h3" style="font-weight: 700; margin-top: 1rem" id="trusted-by">
+          Trusted by Leading Organizations
+        </h3>
+        <p style="font-weight: 400">
+          <span class="emphasize">
+            Google, Tesla, Snowflake, Apple, DoorDash, Uber, Cloudflare, Walmart, Robinhood,
+            Okta, Goldman Sachs, JPMorganChase, Hostinger, Digital Ocean, Disney+,
+            Yahoo Japan</span
+          >, and more.
         </p>
       </div>
     </div>
@@ -44,18 +48,18 @@
         <p style="font-weight: 400">
           Cloudprober comes with efficient, highly scalable, built-in
           <a href="https://cloudprober.org/docs/overview/probe/">probes</a> for
-          common types of checks: HTTP (REST APIs), PING, DNS, gRPC, TCP, UDP.
+          common types of checks: HTTP/S, gRPC, DNS, PING, TCP, UDP.
         </p>
       </div>
       <div class="col-lg-5">
         <h2 class="h3" style="font-weight: 700">
-          Trusted by multiple large organizations
+          Flexible custom probes and extensibility
         </h2>
-        <p style="font-weight: 400">
-          <span class="emphasize">
-            Google, Tesla, Apple, DoorDash, Uber, Cloudflare, Yahoo Japan,
-            Goldman Sachs, Robinhood, Hostinger, Disney+</span
-          >, and more.
+        <p>
+          Run any binary or script as a probe (see
+          <a href="docs/how-to/external-probe">external probe</a>). You can also
+          <a href="/docs/how-to/extensions/">add</a> your own probe types and
+          target types based on your organization's needs.
         </p>
       </div>
       <div class="col-lg-5">
@@ -69,17 +73,6 @@
     </div>
     <div class="row justify-content-center text-center">
       <div class="col-lg-5">
-        <h2 class="h3" style="font-weight: 700">
-          Flexible custom probes and extensibility
-        </h2>
-        <p>
-          Run any binary or script as a probe (see
-          <a href="docs/how-to/external-probe">external probe</a>). You can also
-          <a href="/docs/how-to/extensions/">add</a> your own probe types and
-          target types based on your organization's needs.
-        </p>
-      </div>
-      <div class="col-lg-5">
         <h2 class="h3" style="font-weight: 700">Automated targets discovery</h2>
         <p>
           Reliable, automated
@@ -91,11 +84,19 @@
         </p>
       </div>
       <div class="col-lg-5">
+        <h2 class="h3" style="font-weight: 700">Open Source</h2>
+        <p>
+          Cloudprober is <a href="https://github.com/cloudprober/cloudprober">
+          open-source</a> and free to use. It is actively maintained, and has
+          a growing community of users and contributors.
+        </p>
+      </div>
+      <div class="col-lg-5">
         <h2 class="h3" style="font-weight: 700">Deployment friendly</h2>
         <p>
-          Written entirely in Go. Available as a standalone static binary or
-          through a docker image. Multiple ways to configure, including
-          environment variables.
+          Written entirely in Go. Available as a standalone static binary,
+          through a container image, or Helm charts. Multiple ways
+          to configure, including environment variables.
         </p>
       </div>
     </div>


### PR DESCRIPTION
- And, add more organizations to the list.