### PR TITLE
[build] Upgrade to Go 1.23.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudprober/cloudprober
 
-go 1.23.0
+go 1.23.3
 
 require (
 	cloud.google.com/go/bigquery v1.59.1


### PR DESCRIPTION
- Go build cache is broken in 1.23.0 as explained [here](https://github.com/actions/setup-go/issues/498).