### PR TITLE
Add cloudprober support for TPC universe domain

### DIFF
--- a/internal/rds/gcp/forwarding_rules.go
+++ b/internal/rds/gcp/forwarding_rules.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cloudprober/cloudprober/logger"
 	"golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -186,7 +187,13 @@ func defaultComputeService(apiVersion string, baseAPIPath string) (*compute.Serv
 	if err != nil {
 		return nil, err
 	}
-	cs, err := compute.New(client)
+
+	opts := []option.ClientOption{option.WithHTTPClient(client)}
+	if *logger.GCPUniverseDomain != "" {
+		opts = append(opts, option.WithUniverseDomain(*logger.GCPUniverseDomain))
+	}
+	var cs *compute.Service
+	cs, err = compute.NewService(context.Background(), opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rds/gcp/pubsub.go
+++ b/internal/rds/gcp/pubsub.go
@@ -121,7 +121,7 @@ func (lister *pubsubMsgsLister) initSubscriber(ctx context.Context, sub *configp
 	if ok {
 		err := s.SeekToTime(ctx, time.Now().Add(-seekBackDuration))
 		if err != nil {
-			return nil, fmt.Errorf("pubsub: error seeking back time for the subscription: %s", sub.GetName())
+			return nil, fmt.Errorf("pubsub: error seeking back time for the subscription: %s, %v", sub.GetName(), err)
 		}
 		return s, nil
 	}
@@ -163,6 +163,9 @@ func newPubSubMsgsLister(project string, c *configpb.PubSubMessages, l *logger.L
 	var opts []option.ClientOption
 	if c.GetApiEndpoint() != "" {
 		opts = append(opts, option.WithEndpoint(c.GetApiEndpoint()))
+		if *logger.GCPUniverseDomain != "" {
+			opts = append(opts, option.WithUniverseDomain(*logger.GCPUniverseDomain))
+		}
 	}
 
 	client, err := pubsub.NewClient(ctx, project, opts...)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -53,6 +53,9 @@ var (
 	// Override the GCP cloud logging endpoint.
 	gcpLoggingEndpoint = flag.String("gcp_logging_endpoint", "", "GCP logging endpoint")
 
+	// GCPUniverseDomain overrides the GCP universe domain.
+	GCPUniverseDomain = flag.String("gcp_universe_domain", "", "GCP universe domain")
+
 	// LogPrefixEnvVar environment variable is used to determine the stackdriver
 	// log name prefix. Default prefix is "cloudprober".
 	LogPrefixEnvVar = "CLOUDPROBER_LOG_PREFIX"
@@ -61,11 +64,12 @@ var (
 // EnvVars defines environment variables that can be used to modify the logging
 // behavior.
 var EnvVars = struct {
-	DisableCloudLogging, DebugLog, GCPLoggingEndpoint string
+	DisableCloudLogging, DebugLog, GCPLoggingEndpoint, GCPUniverseDomain string
 }{
 	"CLOUDPROBER_DISABLE_CLOUD_LOGGING",
 	"CLOUDPROBER_DEBUG_LOG",
 	"CLOUDPROBER_GCP_LOGGING_ENDPOINT",
+	"CLOUDPROBER_GCP_UNIVERSE_DOMAIN",
 }
 
 const (
@@ -309,6 +313,9 @@ func (l *Logger) EnableStackdriverLogging() {
 	if l.gcpLoggingEndpoint != "" {
 		l.Infof("Setting logging endpoint to %s", l.gcpLoggingEndpoint)
 		o = append(o, option.WithEndpoint(l.gcpLoggingEndpoint))
+		if *GCPUniverseDomain != "" {
+			o = append(o, option.WithUniverseDomain(*GCPUniverseDomain))
+		}
 	}
 
 	l.gcpLogc, err = logging.NewClient(context.Background(), projectID, o...)
@@ -518,6 +525,10 @@ func init() {
 
 	if envVarSet(EnvVars.GCPLoggingEndpoint) {
 		*gcpLoggingEndpoint = os.Getenv(EnvVars.GCPLoggingEndpoint)
+	}
+
+	if envVarSet(EnvVars.GCPUniverseDomain) {
+		*GCPUniverseDomain = os.Getenv(EnvVars.GCPUniverseDomain)
 	}
 
 	// Determine the base path for the cloudprober source code.


### PR DESCRIPTION
Adding support for the [WithUniverseDomain](https://pkg.go.dev/google.golang.org/api/option#WithUniverseDomain) option in GCP API.

The capability to override the universe domain is needed to support all GCP APIs, including: cloud logging, Pubsub and GCE.

Suggested implementation:

Since the logger.go module already supports few flags ([for example](https://github.com/cloudprober/cloudprober/blob/1a3db5251f1402545f22d8a9f589d904c7817bb5/logger/logger.go#L53)) and is imported by multiple other modules, the most straightforward implementation would be to add an additional startup flag to the logger.go and export this flag as a public property.