### PR TITLE
[probes.external] Cleanup after config and server proto merge

### DIFF
--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -43,7 +43,6 @@ import (
 	payloadpb "github.com/cloudprober/cloudprober/metrics/payload/proto"
 	"github.com/cloudprober/cloudprober/probes/common/command"
 	configpb "github.com/cloudprober/cloudprober/probes/external/proto"
-	serverpb "github.com/cloudprober/cloudprober/probes/external/proto"
 	"github.com/cloudprober/cloudprober/probes/options"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
 	"github.com/google/shlex"
@@ -77,7 +76,7 @@ type Probe struct {
 	cmdStdin     io.Writer
 	cmdStdout    io.ReadCloser
 	cmdStderr    io.ReadCloser
-	replyChan    chan *serverpb.ProbeReply
+	replyChan    chan *configpb.ProbeReply
 	targets      []endpoint.Endpoint
 	results      map[string]*result // probe results keyed by targets
 	dataChan     chan *metrics.EventMetrics
@@ -120,7 +119,7 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 		p.l = &logger.Logger{}
 	}
 	p.c = c
-	p.replyChan = make(chan *serverpb.ProbeReply)
+	p.replyChan = make(chan *configpb.ProbeReply)
 
 	cmdParts, err := shlex.Split(p.c.GetCommand())
 	if err != nil {

--- a/probes/external/external_server.go
+++ b/probes/external/external_server.go
@@ -36,7 +36,7 @@ import (
 	"time"
 
 	"github.com/cloudprober/cloudprober/common/strtemplate"
-	serverpb "github.com/cloudprober/cloudprober/probes/external/proto"
+	configpb "github.com/cloudprober/cloudprober/probes/external/proto"
 	"github.com/cloudprober/cloudprober/probes/external/serverutils"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
 	"google.golang.org/protobuf/proto"
@@ -146,7 +146,7 @@ func (p *Probe) readProbeReplies(ctx context.Context) error {
 		if ctx.Err() != nil {
 			return nil
 		}
-		rep := new(serverpb.ProbeReply)
+		rep := new(configpb.ProbeReply)
 		if err := serverutils.ReadMessage(ctx, rep, bufReader); err != nil {
 			// Return if external probe process pipe has closed. We get:
 			//  io.EOF: when other process has closed the pipe.
@@ -166,10 +166,10 @@ func (p *Probe) readProbeReplies(ctx context.Context) error {
 }
 
 func (p *Probe) sendRequest(requestID int32, ep endpoint.Endpoint) error {
-	req := &serverpb.ProbeRequest{
+	req := &configpb.ProbeRequest{
 		RequestId: proto.Int32(requestID),
 		TimeLimit: proto.Int32(int32(p.opts.Timeout / time.Millisecond)),
-		Options:   []*serverpb.ProbeRequest_Option{},
+		Options:   []*configpb.ProbeRequest_Option{},
 	}
 	for _, opt := range p.c.GetOptions() {
 		value := opt.GetValue()
@@ -181,7 +181,7 @@ func (p *Probe) sendRequest(requestID int32, ep endpoint.Endpoint) error {
 				value = res
 			}
 		}
-		req.Options = append(req.Options, &serverpb.ProbeRequest_Option{
+		req.Options = append(req.Options, &configpb.ProbeRequest_Option{
 			Name:  opt.Name,
 			Value: proto.String(value),
 		})

--- a/probes/external/external_server_test.go
+++ b/probes/external/external_server_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/cloudprober/cloudprober/metrics/testutils"
 	configpb "github.com/cloudprober/cloudprober/probes/external/proto"
-	serverpb "github.com/cloudprober/cloudprober/probes/external/proto"
 	"github.com/cloudprober/cloudprober/probes/external/serverutils"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
@@ -39,7 +38,7 @@ func startProbeServer(t *testing.T, ctx context.Context, testPayload string, r i
 			return
 		}
 
-		req := &serverpb.ProbeRequest{}
+		req := &configpb.ProbeRequest{}
 		if err := serverutils.ReadMessage(context.Background(), req, rd); err != nil {
 			if ctx.Err() != nil {
 				return
@@ -61,7 +60,7 @@ func startProbeServer(t *testing.T, ctx context.Context, testPayload string, r i
 		}
 		id := req.GetRequestId()
 
-		actionToResponse := map[string]*serverpb.ProbeReply{
+		actionToResponse := map[string]*configpb.ProbeReply{
 			"nopayload": {RequestId: proto.Int32(id)},
 			"payload": {
 				RequestId: proto.Int32(id),

--- a/probes/external/external_test.go
+++ b/probes/external/external_test.go
@@ -33,7 +33,6 @@ import (
 	payloadconfigpb "github.com/cloudprober/cloudprober/metrics/payload/proto"
 	"github.com/cloudprober/cloudprober/metrics/testutils"
 	configpb "github.com/cloudprober/cloudprober/probes/external/proto"
-	serverpb "github.com/cloudprober/cloudprober/probes/external/proto"
 	"github.com/cloudprober/cloudprober/probes/options"
 	probeconfigpb "github.com/cloudprober/cloudprober/probes/proto"
 	"github.com/cloudprober/cloudprober/targets"
@@ -350,7 +349,7 @@ func TestSendRequest(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to sendRequest: %v", err)
 	}
-	req := new(serverpb.ProbeRequest)
+	req := new(configpb.ProbeRequest)
 	var length int
 	_, err = fmt.Fscanf(&buf, "\nContent-Length: %d\n\n", &length)
 	if err != nil {


### PR DESCRIPTION
- configpb and serverpb were being imported independently because in Google internal code base corresponded to two different packages. Now that both proto files are merged, we no longer need to do that.