### PR TITLE
[probes.http] Refactor http-probe:scheduler interface.

### DIFF
--- a/metrics/eventmetrics.go
+++ b/metrics/eventmetrics.go
@@ -35,6 +35,10 @@ const (
 	GAUGE
 )
 
+type EventMetricsOptions struct {
+	NotForAlerting bool
+}
+
 // EventMetrics respresents metrics associated with a particular time event.
 type EventMetrics struct {
 	mu        sync.RWMutex
@@ -51,6 +55,9 @@ type EventMetrics struct {
 	labelsKeys []string
 
 	LatencyUnit time.Duration
+
+	// EventMetricsOptions are additional options for the EventMetrics.
+	Options *EventMetricsOptions
 }
 
 // NewEventMetrics return a new EventMetrics object with internals maps initialized.

--- a/probes/common/sched/sched.go
+++ b/probes/common/sched/sched.go
@@ -49,9 +49,17 @@ type ProbeResult interface {
 	Metrics(timeStamp time.Time, runID int64, opts *options.Options) []*metrics.EventMetrics
 }
 
+// RunProbeForTargetRequest is used to pass information to RunProbeForTarget
+// function. It's created once per target and its address is passed to
+// the successive RunProbeForTarget calls.
 type RunProbeForTargetRequest struct {
-	Target      endpoint.Endpoint
-	Result      ProbeResult
+	Target endpoint.Endpoint
+	Result ProbeResult
+
+	// TargetState is an optional field that is used to pass around and retain
+	// state across probe runs. It's typically filled by the individual probe
+	// type. For example, http probe uses this field to cache HTTP request and
+	// clients.
 	TargetState any
 }
 

--- a/probes/common/sched/sched_test.go
+++ b/probes/common/sched/sched_test.go
@@ -38,8 +38,8 @@ type testProbeResult struct {
 	total int
 }
 
-func (tpr *testProbeResult) Metrics(ts time.Time, _ int64, opts *options.Options) *metrics.EventMetrics {
-	return metrics.NewEventMetrics(ts).AddMetric("total", metrics.NewInt(int64(tpr.total)))
+func (tpr *testProbeResult) Metrics(ts time.Time, _ int64, opts *options.Options) []*metrics.EventMetrics {
+	return []*metrics.EventMetrics{metrics.NewEventMetrics(ts).AddMetric("total", metrics.NewInt(int64(tpr.total)))}
 }
 
 func compareNumberOfMetrics(t *testing.T, ems []*metrics.EventMetrics, metricName string, targets [2]string, wantCloseRange bool) {
@@ -87,7 +87,7 @@ func TestUpdateTargetsAndStartProbes(t *testing.T) {
 		Opts:              opts,
 		DataChan:          make(chan *metrics.EventMetrics, 100),
 		NewResult:         func(_ *endpoint.Endpoint) ProbeResult { return &testProbeResult{} },
-		RunProbeForTarget: func(ctx context.Context, ep endpoint.Endpoint, r ProbeResult) { r.(*testProbeResult).total++ },
+		RunProbeForTarget: func(ctx context.Context, runReq *RunProbeForTargetRequest) { runReq.Result.(*testProbeResult).total++ },
 	}
 	s.init()
 
@@ -128,7 +128,7 @@ func TestRunProbeForTargetTimeout(t *testing.T) {
 		Opts:      opts,
 		DataChan:  make(chan *metrics.EventMetrics, 100),
 		NewResult: func(_ *endpoint.Endpoint) ProbeResult { return &testProbeResult{} },
-		RunProbeForTarget: func(ctx context.Context, ep endpoint.Endpoint, r ProbeResult) {
+		RunProbeForTarget: func(ctx context.Context, runReq *RunProbeForTargetRequest) {
 			select {
 			case <-ctx.Done():
 				if ctx.Err() != context.DeadlineExceeded {

--- a/probes/grpc/grpc.go
+++ b/probes/grpc/grpc.go
@@ -376,11 +376,10 @@ type targetState struct {
 
 // runProbeForTargetAndConn runs a single probe for a target + connection index.
 func (p *Probe) runProbeForTargetAndConn(ctx context.Context, runReq *sched.RunProbeForTargetRequest) {
-	tgtState := runReq.TargetState.(*targetState)
-	if tgtState == nil {
-		tgtState = &targetState{targetKey: runReq.Target.Key()}
-		runReq.TargetState = tgtState
+	if runReq.TargetState == nil {
+		runReq.TargetState = &targetState{targetKey: runReq.Target.Key()}
 	}
+	tgtState := runReq.TargetState.(*targetState)
 
 	msgPattern := fmt.Sprintf("%s,%s%s,connIndex:%s", p.src, p.c.GetUriScheme(), runReq.Target.Name, runReq.Target.Labels[connIndexLabel])
 	logAttrs := []slog.Attr{

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -16,7 +16,6 @@
 package http
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
@@ -48,8 +47,6 @@ import (
 
 const (
 	maxResponseSizeForMetrics = 128
-	targetsUpdateInterval     = 1 * time.Minute
-	largeBodyThreshold        = bytes.MinRead // 512.
 )
 
 // Probe holds aggregate information about all probe runs, per-target.

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -441,6 +441,8 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 	if runReq.Result == nil {
 		runReq.Result = p.newResult()
 	}
+
+	// We cache the HTTP requests and clients in the target state.
 	if runReq.TargetState == nil {
 		runReq.TargetState = &targetState{}
 	}
@@ -455,6 +457,8 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 	}
 
 	req, clients := runReq.TargetState.(*targetState).req, runReq.TargetState.(*targetState).clients
+
+	// If request is nil, just update the total count and return.
 	if req == nil {
 		result.total += int64(p.c.GetRequestsPerProbe())
 		return

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -93,7 +93,7 @@ type latencyDetails struct {
 
 type probeResult struct {
 	total, success, timeouts     int64
-	connEvent                    *metrics.Int
+	connEvent                    *metrics.AtomicInt
 	latency                      metrics.LatencyValue
 	respCodes                    *metrics.Map[int64]
 	respBodies                   *metrics.Map[int64]
@@ -502,7 +502,7 @@ func (p *Probe) newResult() *probeResult {
 	}
 
 	if p.c.GetKeepAlive() {
-		result.connEvent = metrics.NewInt(0)
+		result.connEvent = metrics.NewAtomicInt(0)
 	}
 
 	if p.opts.Validators != nil {

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -46,11 +46,6 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// DefaultTargetsUpdateInterval defines default frequency for target updates.
-// Actual targets update interval is:
-// max(DefaultTargetsUpdateInterval, probe_interval)
-var DefaultTargetsUpdateInterval = 1 * time.Minute
-
 const (
 	maxResponseSizeForMetrics = 128
 	targetsUpdateInterval     = 1 * time.Minute
@@ -75,9 +70,6 @@ type Probe struct {
 
 	responseParser *payload.Parser
 	dataChan       chan *metrics.EventMetrics
-
-	// How often to resolve targets (in probe counts), it's the minimum of
-	targetsUpdateInterval time.Duration
 
 	requestBody *httpreq.RequestBody
 }
@@ -244,13 +236,6 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 	}
 
 	p.targets = p.opts.Targets.ListEndpoints()
-
-	p.targetsUpdateInterval = DefaultTargetsUpdateInterval
-	// There is no point refreshing targets before probe interval.
-	if p.targetsUpdateInterval < p.opts.Interval {
-		p.targetsUpdateInterval = p.opts.Interval
-	}
-	p.l.Infof("Targets update interval: %v", p.targetsUpdateInterval)
 
 	return nil
 }

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -248,7 +248,7 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 		}
 	}
 
-	p.statsExportFrequency = sched.StatsExportFrequency(p.opts.Interval, p.opts.StatsExportInterval)
+	p.statsExportFrequency = p.opts.StatsExportFrequency()
 
 	p.targets = p.opts.Targets.ListEndpoints()
 
@@ -467,7 +467,7 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 	// If we are resolving first, we update the request object at every stats
 	// export interval. This is to make sure that we are using the correct IP
 	// address for the target.
-	if p.c.GetResolveFirst() && tgtState.runCnt%p.statsExportFrequency == 0 {
+	if p.c.GetResolveFirst() && tgtState.runCnt%p.opts.StatsExportFrequency() == 0 {
 		runReq.TargetState.(*targetState).req = p.httpRequestForTarget(target)
 	}
 

--- a/probes/http/http_test.go
+++ b/probes/http/http_test.go
@@ -293,11 +293,9 @@ func testProbeWithBody(t *testing.T, probeConf *configpb.ProbeConf, wantBody str
 	target := endpoint.Endpoint{Name: testTarget}
 
 	// Probe 1st run
-	result := p.newResult()
 	req := p.httpRequestForTarget(target)
 	runReq := &sched.RunProbeForTargetRequest{
 		Target: target,
-		Result: result,
 		TargetState: &targetState{
 			req: req,
 		},

--- a/probes/http/http_test.go
+++ b/probes/http/http_test.go
@@ -149,15 +149,12 @@ func testProbe(opts *options.Options) (*probeResult, error) {
 	}
 	patchWithTestTransport(p)
 
-	result := p.newResult()
-
 	runReq := &sched.RunProbeForTargetRequest{
 		Target: endpoint.Endpoint{Name: "test.com"},
-		Result: result,
 	}
 	p.runProbe(context.Background(), runReq)
 
-	return result, nil
+	return runReq.Result.(*probeResult), nil
 }
 
 func TestProbeInitError(t *testing.T) {

--- a/probes/http/http_test.go
+++ b/probes/http/http_test.go
@@ -316,6 +316,8 @@ func testProbeWithBody(t *testing.T, probeConf *configpb.ProbeConf, wantBody str
 }
 
 func TestProbeWithBody(t *testing.T) {
+	largeBodyThreshold := bytes.MinRead // 512.
+
 	for _, size := range []int{12, largeBodyThreshold - 1, largeBodyThreshold, largeBodyThreshold + 1, largeBodyThreshold * 2} {
 		t.Run(fmt.Sprintf("size:%d", size), func(t *testing.T) {
 			testBody := strings.Repeat("a", size)
@@ -536,6 +538,8 @@ func TestMultipleTargetsMultipleRequests(t *testing.T) {
 }
 
 func TestProbeWithReqBody(t *testing.T) {
+	largeBodyThreshold := bytes.MinRead // 512.
+
 	for _, size := range []int{0, 32, largeBodyThreshold + 1} {
 		for _, method := range []string{"GET", "POST"} {
 			for _, withRedirect := range []bool{false, true} {

--- a/probes/options/options.go
+++ b/probes/options/options.go
@@ -315,7 +315,7 @@ func (opts *Options) RecordMetrics(ep endpoint.Endpoint, em *metrics.EventMetric
 	opts.LogMetrics(em)
 	dataChan <- em
 
-	if !ro.NoAlert {
+	if !ro.NoAlert && (em.Options == nil || !em.Options.NotForAlerting) {
 		for _, ah := range opts.AlertHandlers {
 			ah.Record(ep, em)
 		}

--- a/probes/options/options.go
+++ b/probes/options/options.go
@@ -55,6 +55,13 @@ type Options struct {
 	logMetricsOverride  func(*metrics.EventMetrics)
 }
 
+func (opts *Options) StatsExportFrequency() int64 {
+	if f := opts.StatsExportInterval.Nanoseconds() / opts.Interval.Nanoseconds(); f != 0 {
+		return f
+	}
+	return 1
+}
+
 func (opts *Options) LogMetrics(em *metrics.EventMetrics) {
 	if opts.logMetricsOverride != nil {
 		opts.logMetricsOverride(em)

--- a/probes/options/options.go
+++ b/probes/options/options.go
@@ -55,6 +55,9 @@ type Options struct {
 	logMetricsOverride  func(*metrics.EventMetrics)
 }
 
+// StatsExportFrequency returns how often to export metrics (in probe counts),
+// initialized to statsExportInterval / p.opts.Interval. Metrics are exported
+// when (runCnt % statsExportFrequency) == 0
 func (opts *Options) StatsExportFrequency() int64 {
 	if f := opts.StatsExportInterval.Nanoseconds() / opts.Interval.Nanoseconds(); f != 0 {
 		return f

--- a/probes/options/options_test.go
+++ b/probes/options/options_test.go
@@ -536,3 +536,35 @@ func TestOptionsLogMetrics(t *testing.T) {
 		})
 	}
 }
+
+func TestOptions_StatsExportFrequency(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *Options
+		want int64
+	}{
+		{
+			name: "default",
+			opts: &Options{
+				Interval:            2 * time.Second,
+				StatsExportInterval: 10 * time.Second,
+			},
+			want: 5,
+		},
+		{
+			name: "default",
+			opts: &Options{
+				Interval:            20 * time.Second,
+				StatsExportInterval: 10 * time.Second,
+			},
+			want: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.opts.StatsExportFrequency(); got != tt.want {
+				t.Errorf("Options.StatsExportFrequency() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is all to support single run interface for Cloudprober probes (#969).

- Make HTTP probe use RunProbeForTarget interface. This change centralizes scheduler logic further in the scheduler package.
- Since we need to keep state across runs, change scheduler's `RunProbeForTarget` interface to pass more information through a request object, which will store "target state" across successive runs,
- Update all probes to use the new interface.

