### PR TITLE
[probes.external] Make payload labels parsing more robust.

### DIFF
--- a/metrics/payload/line_metric_test.go
+++ b/metrics/payload/line_metric_test.go
@@ -353,6 +353,7 @@ func TestParseLabels(t *testing.T) {
 		// More allowed characters inside quotes
 		`svc=A,dc="x/y"`:                {{"svc", "A"}, {"dc", "x/y"}},
 		`svc="svc A",dc="xx",`:          {{"svc", "svc A"}, {"dc", "xx"}},
+		`svc="svc	A",dc="xx",`:          {{"svc", "svc	A"}, {"dc", "xx"}},
 		`svcs="svc A, svc B",dc=xx`:     {{"svcs", "svc A, svc B"}, {"dc", "xx"}},
 		`svcs="svc \"A\", svc B",dc=xx`: {{"svcs", `svc \"A\", svc B`}, {"dc", "xx"}},
 

--- a/metrics/payload/line_metric_test.go
+++ b/metrics/payload/line_metric_test.go
@@ -326,9 +326,9 @@ func TestParseLabels(t *testing.T) {
 		"svc=A,dc=44 \"xx\"",     // invalid dc label value
 		"svc=A,dc=xx\" 56",       // missing closing quote
 		"svc=\"svc A\",dc=xx 56", // space in unquoted value
-		"svc=A,dc=xx,56",         // missing value
+		"svc=A,dc=xx,56",         // , in unquoted value
 		"svc=A,dc=x/x,",          // invalid character in unquoted value
-		`svcs=""A", B",dc=xx`,    // single doublequote in quoted value
+		`svcs=""A, B",dc=xx`,     // single doublequote in quoted value
 	}
 	for _, line := range invalidLabelLines {
 		labels, err := parseLabels(line)
@@ -344,6 +344,7 @@ func TestParseLabels(t *testing.T) {
 		"svc=\"svc A\",dc=":             {{"svc", "svc A"}, {"dc", ""}},
 		"svc=\"svc A\",dc=xx":           {{"svc", "svc A"}, {"dc", "xx"}},
 		"svc=\"svc A\",dc=xx,":          {{"svc", "svc A"}, {"dc", "xx"}},
+		"svc=A,dc=\"x/y\"":              {{"svc", "A"}, {"dc", "x/y"}},
 		"svc=\"svc A\",dc=\"xx\",":      {{"svc", "svc A"}, {"dc", "xx"}},
 		"svcs=\"svc A, svc B\",dc=xx":   {{"svcs", "svc A, svc B"}, {"dc", "xx"}},
 		`svcs="svc \"A\", svc B",dc=xx`: {{"svcs", `svc \"A\", svc B`}, {"dc", "xx"}},

--- a/metrics/payload/line_metric_test.go
+++ b/metrics/payload/line_metric_test.go
@@ -328,11 +328,11 @@ func TestParseLabels(t *testing.T) {
 		`svcs=""A, B",dc=xx`, // single doublequote in quoted value
 
 		// Bad character in unquoted value
-		`svc=A,dc=xx 56`, // space in unquoted value
-		`svc=A,dc=xx,56`, // invalid character (,) in unquoted value
-		`svc=A,dc=x/x,`,  // invalid character (/) in unquoted value
-		`svc=A,dc=x:x,`,  // invalid character (/) in unquoted value
-		`svc=A,dc=x;x,`,  // invalid character (/) in unquoted value
+		`svc=A,dc=xx 56`,
+		`svc=A,dc=xx,56`,
+		`svc=A,dc=x/x,`,
+		`svc=A,dc=x\x,`,
+		`svc=A,dc=x:x,`,
 	}
 	for _, line := range invalidLabelLines {
 		labels, err := parseLabels(line)
@@ -357,13 +357,9 @@ func TestParseLabels(t *testing.T) {
 		`svcs="svc \"A\", svc B",dc=xx`: {{"svcs", `svc \"A\", svc B`}, {"dc", "xx"}},
 
 		// Unquoted allowed chars
-		"svc=A,dc=x@y":  {{"svc", "A"}, {"dc", "x@y"}},
 		"svc=A_B,dc=xx": {{"svc", "A_B"}, {"dc", "xx"}},
-		"svc=A.B,dc=xx": {{"svc", "A.B"}, {"dc", "xx"}},
-		"svc=A&B,dc=xx": {{"svc", "A&B"}, {"dc", "xx"}},
 		"svc=A-B,dc=xx": {{"svc", "A-B"}, {"dc", "xx"}},
-		"svc=A+B,dc=xx": {{"svc", "A+B"}, {"dc", "xx"}},
-		"svc=A*B,dc=xx": {{"svc", "A*B"}, {"dc", "xx"}},
+		"svc=A.B,dc=xx": {{"svc", "A.B"}, {"dc", "xx"}},
 	}
 	for input, wantLabels := range inputToLabels {
 		labels, err := parseLabels(input)

--- a/metrics/payload/line_metric_test.go
+++ b/metrics/payload/line_metric_test.go
@@ -241,64 +241,52 @@ func TestAggreagateInCloudprober(t *testing.T) {
 
 func TestParseLine(t *testing.T) {
 	tests := []struct {
-		desc    string
-		line    string
-		metric  string
-		labels  [][2]string
-		value   string
-		wantErr bool
+		desc       string
+		line       string
+		wantMetric string
+		wantLabels [][2]string
+		wantValue  string
+		wantErr    bool
 	}{
 		{
-			desc:   "metric with no labels",
-			line:   "op_total 56",
-			metric: "op_total",
-			value:  "56",
+			desc:       "metric with no labels",
+			line:       "op_total 56",
+			wantMetric: "op_total",
+			wantValue:  "56",
 		},
 		{
-			desc:   "metric with no labels, but more spaces",
-			line:   "op_total   56",
-			metric: "op_total",
-			value:  "56",
+			desc:       "metric with no labels, but more spaces",
+			line:       "op_total   56",
+			wantMetric: "op_total",
+			wantValue:  "56",
 		},
 		{
-			desc:   "standard metric with labels",
-			line:   "op_total{svc=serviceA,dc=xx} 56",
-			metric: "op_total",
-			labels: [][2]string{
-				{"service", "serviceA"},
-				{"dc", "xx"},
-			},
-			value: "56",
+			desc:       "standard metric with labels",
+			line:       "op_total{svc=serviceA,dc=xx} 56",
+			wantMetric: "op_total",
+			wantLabels: [][2]string{{"svc", "serviceA"}, {"dc", "xx"}},
+			wantValue:  "56",
 		},
 		{
-			desc:   "quoted labels, same result",
-			line:   "op_total{svc=\"serviceA\",dc=\"xx\"} 56",
-			metric: "op_total",
-			labels: [][2]string{
-				{"service", "serviceA"},
-				{"dc", "xx"},
-			},
-			value: "56",
+			desc:       "quoted labels, same result",
+			line:       "op_total{svc=\"serviceA\",dc=\"xx\"} 56",
+			wantMetric: "op_total",
+			wantLabels: [][2]string{{"svc", "serviceA"}, {"dc", "xx"}},
+			wantValue:  "56",
 		},
 		{
-			desc:   "a label value has space and more spaces",
-			line:   "op_total{svc=\"svc A\", dcs= \"xx,yy\"} 56",
-			metric: "op_total",
-			labels: [][2]string{
-				{"service", "svc A"},
-				{"dcs", "xx,yy"},
-			},
-			value: "56",
+			desc:       "a label value has space and more spaces",
+			line:       "op_total{svc=\"svc A\", dcs= \"xx,yy\"} 56",
+			wantMetric: "op_total",
+			wantLabels: [][2]string{{"svc", "svc A"}, {"dcs", "xx,yy"}},
+			wantValue:  "56",
 		},
 		{
-			desc:   "label and value have a space",
-			line:   "version{svc=\"svc A\",dc=xx} \"version 1.5\"",
-			metric: "version",
-			labels: [][2]string{
-				{"service", "svc A"},
-				{"dc", "xx"},
-			},
-			value: "\"version 1.5\"",
+			desc:       "label and value have a space",
+			line:       "version{svc=\"svc A\",dc=xx} \"version 1.5\"",
+			wantMetric: "version",
+			wantLabels: [][2]string{{"svc", "svc A"}, {"dc", "xx"}},
+			wantValue:  "\"version 1.5\"",
 		},
 		{
 			desc:    "invalid line",
@@ -313,9 +301,6 @@ func TestParseLine(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if test.desc != "empty dc label" {
-			continue
-		}
 		t.Run(test.desc, func(t *testing.T) {
 			m, v, l, err := parseLine(test.line)
 			if err != nil {
@@ -327,9 +312,9 @@ func TestParseLine(t *testing.T) {
 			if test.wantErr {
 				t.Errorf("Expected error, but didn't get any.")
 			}
-			assert.Equal(t, test.metric, m)
-			assert.Equal(t, test.labels, l)
-			assert.Equal(t, test.value, v)
+			assert.Equal(t, test.wantMetric, m)
+			assert.Equal(t, test.wantLabels, l)
+			assert.Equal(t, test.wantValue, v)
 		})
 	}
 }

--- a/metrics/payload/line_metrics.go
+++ b/metrics/payload/line_metrics.go
@@ -77,10 +77,9 @@ func readLabelValue(s string) (string, string, error) {
 	}
 
 	// Unquoted value, for unquoted value, we support only specific chars.
-	allowedChars := []byte{'-', '_', '.', '+', '@', '&', '*'}
 	i := 0
 	for ; i < len(s) && s[i] != ','; i++ {
-		if !isAlphanumeric(s[i]) && !slices.Contains(allowedChars, s[i]) {
+		if !isAlphanumeric(s[i]) && !slices.Contains([]byte{'-', '_', '.'}, s[i]) {
 			return "", "", fmt.Errorf("invalid unquoted char (%v) in value, input: %s", s[i], s)
 		}
 	}

--- a/metrics/payload/line_metrics.go
+++ b/metrics/payload/line_metrics.go
@@ -16,6 +16,7 @@ package payload
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -23,15 +24,15 @@ import (
 	"github.com/cloudprober/cloudprober/metrics"
 )
 
-func isAlphanumericOrUnderscore(c byte) bool {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
+func isAlphanumeric(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
 }
 
 func readLabelKey(s string) (string, string, error) {
 	s = strings.TrimLeft(s, " ")
 	i := 0
 	for i < len(s) && s[i] != '=' {
-		if !isAlphanumericOrUnderscore(s[i]) {
+		if !isAlphanumeric(s[i]) && s[i] != '_' {
 			return "", "", fmt.Errorf("invalid key char (%v), input: %s", s[i], s)
 		}
 		i++
@@ -75,10 +76,11 @@ func readLabelValue(s string) (string, string, error) {
 		return "", "", fmt.Errorf("no closing quote found in the input: %s", s)
 	}
 
-	// Unquoted value, for unquoted value, we support only alphanumeric plus underscore.
+	// Unquoted value, for unquoted value, we support only specific chars.
+	allowedChars := []byte{'-', '_', '.', '+', '@', '&', '*'}
 	i := 0
 	for ; i < len(s) && s[i] != ','; i++ {
-		if !isAlphanumericOrUnderscore(s[i]) {
+		if !isAlphanumeric(s[i]) && !slices.Contains(allowedChars, s[i]) {
 			return "", "", fmt.Errorf("invalid unquoted char (%v) in value, input: %s", s[i], s)
 		}
 	}

--- a/metrics/payload/line_metrics.go
+++ b/metrics/payload/line_metrics.go
@@ -23,8 +23,8 @@ import (
 	"github.com/cloudprober/cloudprober/metrics"
 )
 
-func isAlphanumericOrUnderscore(r byte) bool {
-	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_'
+func isAlphanumericOrUnderscore(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_'
 }
 
 func readLabelKey(s string) (string, string, error) {
@@ -43,7 +43,7 @@ func readLabelKey(s string) (string, string, error) {
 }
 
 func readLabelValue(s string) (string, string, error) {
-	s = strings.TrimSpace(s)
+	s = strings.TrimLeft(s, " ")
 	if len(s) == 0 {
 		return "", "", nil
 	}

--- a/metrics/payload/line_metrics.go
+++ b/metrics/payload/line_metrics.go
@@ -23,24 +23,96 @@ import (
 	"github.com/cloudprober/cloudprober/metrics"
 )
 
-func parseLabels(labelStr string) [][2]string {
-	var labels [][2]string
-	for _, l := range strings.Split(labelStr, ",") {
-		parts := strings.SplitN(strings.TrimSpace(l), "=", 2)
-		if len(parts) != 2 {
-			continue
+func isAlphanumericOrUnderscore(r byte) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_'
+}
+
+func readLabelKey(s string) (string, string, error) {
+	s = strings.TrimLeft(s, " ")
+	i := 0
+	for i < len(s) && s[i] != '=' {
+		if !isAlphanumericOrUnderscore(s[i]) {
+			return "", "", fmt.Errorf("invalid key char (%v), input: %s", s[i], s)
 		}
-		key, val := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
-		// Unquote val if it is a quoted string. strconv returns an error if string
-		// is not quoted at all or is unproperly quoted. We use raw string in that
-		// case.
-		uval, err := strconv.Unquote(val)
-		if err == nil {
-			val = uval
-		}
-		labels = append(labels, [2]string{key, val})
+		i++
 	}
-	return labels
+	if i == len(s) || s[i] != '=' {
+		return "", "", fmt.Errorf("no value found in the input: %s", s)
+	}
+	return s[:i], s[i+1:], nil
+}
+
+func readLabelValue(s string) (string, string, error) {
+	s = strings.TrimSpace(s)
+	if len(s) == 0 {
+		return "", "", nil
+	}
+
+	// Verify that we either have zero remainder or it starts with a ','
+	verifyReturn := func(val, rem string) (string, string, error) {
+		if len(rem) == 0 {
+			return val, rem, nil
+		}
+		if rem[0] != ',' {
+			return "", "", fmt.Errorf("value doesn't end with a ',' and not final value: %s", rem)
+		}
+		return val, rem[1:], nil
+	}
+
+	if s[0] == '"' {
+		// Quoted value
+		s = s[1:]
+		for i := 0; i < len(s); i++ {
+			if s[i] == '\\' {
+				i++ // skip next char
+				continue
+			}
+			if s[i] == '"' {
+				return verifyReturn(s[:i], s[i+1:])
+			}
+		}
+		// Coming out of this loop means we don't find closing quote
+		return "", "", fmt.Errorf("no closing quote found in the input: %s", s)
+	}
+
+	// Unquoted value, for unquoted value, we support only alphanumeric plus underscore.
+	i := 0
+	for ; i < len(s) && s[i] != ','; i++ {
+		if !isAlphanumericOrUnderscore(s[i]) {
+			return "", "", fmt.Errorf("invalid unquoted char (%v) in value, input: %s", s[i], s)
+		}
+	}
+	return verifyReturn(s[:i], s[i:])
+}
+
+// parseLabels parses key="value" pairs from the input string
+func parseLabels(input string) ([][2]string, error) {
+	var labels [][2]string
+	key := ""
+	s := strings.TrimSpace(input)
+	for len(s) != 0 {
+		if key == "" {
+			k, rem, err := readLabelKey(s)
+			if err != nil {
+				return nil, err
+			}
+			key = k
+			s = rem
+		} else {
+			v, rem, err := readLabelValue(s)
+			if err != nil {
+				return nil, err
+			}
+			labels = append(labels, [2]string{key, v})
+			key = ""
+			s = rem
+		}
+	}
+	if key != "" {
+		labels = append(labels, [2]string{key, ""})
+	}
+
+	return labels, nil
 }
 
 func parseLine(line string) (metricName, value string, labels [][2]string, err error) {
@@ -77,7 +149,11 @@ func parseLine(line string) (metricName, value string, labels [][2]string, err e
 	}
 
 	// Capture label string and move line-beginning forward.
-	labels, value = parseLabels(line[:eb]), strings.TrimSpace(line[eb+1:])
+	labels, err = parseLabels(line[:eb])
+	if err != nil {
+		return
+	}
+	value = strings.TrimSpace(line[eb+1:])
 	return
 }
 


### PR DESCRIPTION
Instead of splitting label line at `,` and then parsing parts into key-values, do a more methodical parsing:

- Read keys until `=` and enforce prometheus validity criteria on key characters (alpha-numeric and `_`).
- For values, consider the following cases:
   - If value starts with `"`, it's a quoted string and read until next `"`, while taking into account escaped characters, including a `\"`.
   - If value doesn't start with `"`, it's an unquoted string. Unquoted strings can contain only alpha-numeric characters and `-`, `_`, `.` (this is to cause less surprises for existing users, in case someone is exporting domain names as values).
   - Values should either end with `,` or be the last value in the line.