### PR TITLE
[Dockerfile][dev] fix builds

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,13 +1,14 @@
 # Dockerfile for quick development and testing
 # To build:
 #    docker build -t cloudprober:test . -f Dockerfile.dev
-FROM golang:1.21-alpine as build
+FROM golang:1.23-alpine AS build
 
 WORKDIR /app
-COPY . /
-RUN if [[ ! -f /cloudprober ]]; then go build -o /cloudprober /cmd/cloudprober.go; fi 
+COPY . .
+RUN go build -o cloudprober ./cmd/cloudprober
 
 FROM alpine
-COPY --from=build /cloudprober /cloudprober
-COPY cmd/cloudprober_test.cfg /etc/cloudprober.cfg
+COPY --from=build /app/cloudprober /cloudprober
+COPY --from=build /app/cmd/cloudprober_test.cfg /etc/cloudprober.cfg
+
 ENTRYPOINT ["/cloudprober"]


### PR DESCRIPTION
Was working on something else and tried to test with dev docker

```
 => ERROR [build 4/4] RUN if [[ ! -f /cloudprober ]]; then go build -o /cloudprober /cmd/cloudprober.go; fi                                                      0.1s
------
 > [build 4/4] RUN if [[ ! -f /cloudprober ]]; then go build -o /cloudprober /cmd/cloudprober.go; fi:
0.113 stat /cmd/cloudprober.go: directory not found
------

 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 4)
Dockerfile.dev:8
--------------------
   6 |     WORKDIR /app
   7 |     COPY . /
   8 | >>> RUN if [[ ! -f /cloudprober ]]; then go build -o /cloudprober /cmd/cloudprober.go; fi 
   9 |     
  10 |     FROM alpine
--------------------
ERROR: failed to solve: process "/bin/sh -c if [[ ! -f /cloudprober ]]; then go build -o /cloudprober /cmd/cloudprober.go; fi" did not complete successfully: exit code: 1
```