### PR TITLE
[targets.resolver] add dns-over-tls to dns_options

### DIFF
--- a/examples/targets/dns_options.cfg
+++ b/examples/targets/dns_options.cfg
@@ -1,0 +1,13 @@
+probe {
+  type: HTTP
+  name: "Resolving via DNS over TLS"
+  targets {
+    host_names: "www.google.com"
+    dns_options {
+      server: "tls://8.8.8.8"
+    }
+  }
+  http_probe {
+    protocol: HTTPS
+  }
+}

--- a/targets/proto/targets.pb.go
+++ b/targets/proto/targets.pb.go
@@ -295,12 +295,14 @@ type DNSOptions struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// DNS server to use for DNS resolution, instead of system's default. Server
 	// can be specified in the following format: [network://]ip[:port]
-	// where network is one of udp, tcp, tcp4, tcp6, udp4, udp6.
+	// where network is one of udp, tcp, tcp4, tcp6, udp4, udp6, tls.
 	// Example:
 	//   - "1.1.1.1"           // Use default network and port (53)
 	//
 	// - "tcp://1.1.1.1"      // Use tcp network and default port (53)
 	// - "tcp://1.1.1.1:513   // Use tcp network and port 513
+	// - "tls://8.8.8.8"     // Use tls network and default dot port (853)
+	// - "tls://8.8.8.8:8443" // Use tls network and port 8443
 	Server *string `protobuf:"bytes,1,opt,name=server" json:"server,omitempty"`
 	// DNS TTL (time to live). This controls how often backend DNS server will be
 	// queried.

--- a/targets/proto/targets.proto
+++ b/targets/proto/targets.proto
@@ -81,11 +81,13 @@ message K8sTargets {
 message DNSOptions {
   // DNS server to use for DNS resolution, instead of system's default. Server
   // can be specified in the following format: [network://]ip[:port]
-  // where network is one of udp, tcp, tcp4, tcp6, udp4, udp6.
+  // where network is one of udp, tcp, tcp4, tcp6, udp4, udp6, tls.
   // Example:
   //  - "1.1.1.1"           // Use default network and port (53)
   // - "tcp://1.1.1.1"      // Use tcp network and default port (53)
   // - "tcp://1.1.1.1:513   // Use tcp network and port 513
+  // - "tls://8.8.8.8"     // Use tls network and default dot port (853)
+  // - "tls://8.8.8.8:8443" // Use tls network and port 8443
   optional string server = 1;
 
   // DNS TTL (time to live). This controls how often backend DNS server will be

--- a/targets/resolver/resolver.go
+++ b/targets/resolver/resolver.go
@@ -128,12 +128,19 @@ func ParseOverrideAddress(dnsResolverOverride string) (string, string, error) {
 		addr = dnsResolverOverride
 	}
 
-	validNetworks := []string{"", "tcp", "tcp4", "tcp6", "udp", "udp4", "udp6"}
+	validNetworks := []string{"", "tcp", "tcp4", "tcp6", "udp", "udp4", "udp6", "tls"}
 	if !slices.Contains(validNetworks, network) {
 		return "", "", fmt.Errorf("invalid network: %s", network)
 	}
 
 	port := "53"
+
+	// use default dot port and change to tcp-tls for miekg/dns client
+	if network == "tls" {
+		network = "tcp-tls"
+		port = "853"
+	}
+
 	// Check if address includes a port number. If it doesn't parse as an IP
 	// address, but includes a :, then it might contain a port number
 	if ip := net.ParseIP(addr); ip == nil {

--- a/targets/resolver/resolver_test.go
+++ b/targets/resolver/resolver_test.go
@@ -397,6 +397,16 @@ func TestParseOverrideAddress(t *testing.T) {
 			wantAddr:            "1.1.1.1:53",
 		},
 		{
+			dnsResolverOverride: "tls://1.1.1.1",
+			wantNetwork:         "tcp-tls",
+			wantAddr:            "1.1.1.1:853",
+		},
+		{
+			dnsResolverOverride: "tls://1.1.1.1:8443",
+			wantNetwork:         "tcp-tls",
+			wantAddr:            "1.1.1.1:8443",
+		},
+		{
 			dnsResolverOverride: "udp65://1.1.1.1",
 			wantErr:             true,
 		},


### PR DESCRIPTION
adds dns-over-tls (dot) in standard `tls://<server>` notation with default port 853 unless otherwise specified as server option in dns_options