### PR TITLE
[probes.browser] Fix bug in localstorage cleanup handler

### DIFF
--- a/probes/browser/artifacts.go
+++ b/probes/browser/artifacts.go
@@ -87,7 +87,7 @@ func (p *Probe) initArtifactsHandler() error {
 
 		if localStorage := storageConfig.GetLocalStorage(); localStorage != nil {
 			if localStorage.GetCleanupOptions() != nil {
-				cleanupHandler, err := newCleanupHandler(localStorage.GetCleanupOptions(), p.l)
+				cleanupHandler, err := newCleanupHandler(localStorage.GetDir(), localStorage.GetCleanupOptions(), p.l)
 				if err != nil {
 					return fmt.Errorf("error initializing cleanup handler for local storage: %v", err)
 				}

--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -241,7 +241,7 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 	}
 
 	if p.c.GetWorkdirCleanupOptions() != nil {
-		ch, err := newCleanupHandler(p.c.GetWorkdirCleanupOptions(), p.l)
+		ch, err := newCleanupHandler(p.outputDir, p.c.GetWorkdirCleanupOptions(), p.l)
 		if err != nil {
 			return fmt.Errorf("failed to initialize cleanup handler: %v", err)
 		}
@@ -403,7 +403,7 @@ func (p *Probe) Start(ctx context.Context, dataChan chan *metrics.EventMetrics) 
 	p.startCtx = ctx
 
 	for _, ch := range p.cleanupHandlers {
-		go ch.start(p.startCtx, p.outputDir)
+		go ch.start(p.startCtx)
 	}
 
 	p.dataChan = dataChan

--- a/probes/browser/cleanup_test.go
+++ b/probes/browser/cleanup_test.go
@@ -27,9 +27,11 @@ import (
 )
 
 func TestNewCleanupHandler(t *testing.T) {
+	testDir := "/tmp/x"
 	tests := []struct {
 		name    string
 		opts    *configpb.CleanupOptions
+		dir     string
 		want    *cleanupHandler
 		wantErr bool
 	}{
@@ -62,7 +64,9 @@ func TestNewCleanupHandler(t *testing.T) {
 			opts: &configpb.CleanupOptions{
 				MaxAgeSec: proto.Int32(1),
 			},
+			dir: testDir,
 			want: &cleanupHandler{
+				dir:      testDir,
 				interval: time.Second,
 				maxAge:   time.Second,
 			},
@@ -70,7 +74,7 @@ func TestNewCleanupHandler(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := newCleanupHandler(tt.opts, nil)
+			got, err := newCleanupHandler(tt.dir, tt.opts, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("newCleanupHandler() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -106,9 +110,10 @@ func TestCleanupHandlerCleanupCycle(t *testing.T) {
 
 	maxAge := 150 * time.Millisecond
 	ch := &cleanupHandler{
+		dir:    dir,
 		maxAge: maxAge,
 	}
-	ch.cleanupCycle(dir)
+	ch.cleanupCycle()
 
 	remainingDirs, err := os.ReadDir(dir)
 	if err != nil {


### PR DESCRIPTION
- Cleanup handler was running on the probe's output directory even when configured for the local storage.
- To solve, make cleanup handler store the directory as well that it needs to work on, instead of passing that directory at the cleanup time.