### PR TITLE
[build] Add makefile rules to build static fips binaries

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -144,6 +144,47 @@ jobs:
           name: cloudprober-${{ matrix.os }}-dist
           path: cloudprober-*
 
+
+  build-fips-binaries:
+    name: Build binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+        include:
+          - os: ubuntu-latest
+            distname: linux-amd64
+          - os: ubuntu-24.04-arm
+            distname: linux-arm64
+    steps:
+      - name: Check out code into the Go module directory
+        if: ${{ !contains(github.event_name, 'workflow_dispatch') }}
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Check out code into the Go module directory
+        if: ${{ contains(github.event_name, 'workflow_dispatch') }}
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.tag }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+          cache: true
+        id: go
+
+      - run: make cloudprober-fips FIPS_BINARY_NAME=cloudprober-${{ matrix.distname }}
+
+      - name: Upload cloudprober dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloudprober-fips-${{ matrix.distname }}-dist
+          path: cloudprober-fips
+        
   build-dist:
     name: Build cloudprober release
     needs: [build-and-test, build-binaries]

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -183,7 +183,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: cloudprober-fips-${{ matrix.distname }}-dist
-          path: cloudprober-fips
+          path: cloudprober-*
         
   build-dist:
     name: Build cloudprober release

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -248,10 +248,23 @@ jobs:
           ref: ${{ github.event.inputs.tag }}
 
       - name: Download cloudprober binary
+        if: ${{ matrix.image_type != 'fips' }}
         uses: actions/download-artifact@v4
         with:
           name: cloudprober-ubuntu-latest-dist
 
+      - name: Download fips cloudprober amd64 binary
+        if: ${{ matrix.image_type == 'fips' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: cloudprober-fips-linux-amd64-dist
+
+      - name: Download fips cloudprober arm64 binary
+        if: ${{ matrix.image_type == 'fips' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: cloudprober-fips-linux-arm64-dist
+  
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -177,7 +177,7 @@ jobs:
           cache: true
         id: go
 
-      - run: make cloudprober-fips FIPS_BINARY_NAME=cloudprober-${{ matrix.distname }}
+      - run: make cloudprober-fips && mv cloudprober-fips cloudprober-fips-${{ matrix.distname }}
 
       - name: Upload cloudprober dist
         uses: actions/upload-artifact@v4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -146,7 +146,7 @@ jobs:
 
 
   build-fips-binaries:
-    name: Build binaries
+    name: Build fips binaries
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ BINARY ?= cloudprober
 DOCKER_IMAGE ?= cloudprober/cloudprober
 DOCKER_BUILD_ARGS ?= --build-arg BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") --build-arg VERSION=$(VERSION) --build-arg VCS_REF=$(GIT_COMMIT)
 SOURCES := $(shell find . -name '*.go')
-LDFLAGS ?= "-s -w -X main.version=$(VERSION) -X main.buildTimestamp=$(BUILD_DATE) -X main.dirty=$(DIRTY) -extldflags -static"
+VAR_LD_FLAGS := -X main.version=$(VERSION) -X main.buildTimestamp=$(BUILD_DATE) -X main.dirty=$(DIRTY)
+LDFLAGS ?= "$(VAR_LD_FLAGS) -s -w -extldflags -static"
 BINARY_SOURCE ?= "./cmd/cloudprober/."
 
 LINUX_PLATFORMS := linux-amd64 linux-arm64 linux-armv7
@@ -32,6 +33,12 @@ $1: $(SOURCES)
 	GOARM=$(subst armv7,7,$(filter armv7,$(word 3,$(subst -, ,$1)))) ; \
 	CGO_ENABLED=0 GOOS=$$$${GOOS} GOARCH=$$$${GOARCH} GOARM=$$$${GOARM} go build -o $1 -ldflags $(LDFLAGS) $(BINARY_SOURCE)
 endef
+
+FIPS_BINARY_NAME := cloudprober-fips
+# To cross-compile, for linux arm64 e.g., set GO_BUILD_FLAGS like this:
+# make cloudprober-fips GO_BUILD_FLAGS="GOARCH=arm64 CC_FOR_TARGET=gcc-aarch64-linux-gnu CC=aarch64-linux-gnu-gcc"
+cloudprober-fips: $(SOURCES)
+	$(GO_BUILD_FLAGS) CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go build -o $(FIPS_BINARY_NAME) -tags netgo,osusergo -ldflags "$(VAR_LD_FLAGS) -w -linkmode external -extldflags -static" $(BINARY_SOURCE)
 
 test:
 	go test -v -race -covermode=atomic ./...

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,11 @@ $1: $(SOURCES)
 	CGO_ENABLED=0 GOOS=$$$${GOOS} GOARCH=$$$${GOARCH} GOARM=$$$${GOARM} go build -o $1 -ldflags $(LDFLAGS) $(BINARY_SOURCE)
 endef
 
-FIPS_BINARY_NAME := cloudprober-fips
 # To cross-compile, for linux arm64 e.g., set GO_BUILD_FLAGS like this:
 # make cloudprober-fips GO_BUILD_FLAGS="GOARCH=arm64 CC_FOR_TARGET=gcc-aarch64-linux-gnu CC=aarch64-linux-gnu-gcc"
 cloudprober-fips: $(SOURCES)
-	$(GO_BUILD_FLAGS) CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go build -o $(FIPS_BINARY_NAME) -tags netgo,osusergo -ldflags "$(VAR_LD_FLAGS) -w -linkmode external -extldflags -static" $(BINARY_SOURCE)
+	$(GO_BUILD_FLAGS) CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go build -o cloudprober-fips -tags netgo,osusergo -ldflags "$(VAR_LD_FLAGS) -w -linkmode external -extldflags -static" $(BINARY_SOURCE)
+	go tool nm cloudprober-fips | grep crypto/internal/boring/sig.BoringCrypto.abi0 > /dev/null || (echo "FIPS build failed: BoringCrypto not used" && rm cloudprober-fips && exit 1)
 
 test:
 	go test -v -race -covermode=atomic ./...


### PR DESCRIPTION
- Call these rules to build static FIPS-compliant binaries for linux-amd64 and linux-arm64 in an independent job.
- We'll later use these binaries for the fips docker image.