### PR TITLE
[build] Fix fips multiarch image

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -248,7 +248,6 @@ jobs:
           ref: ${{ github.event.inputs.tag }}
 
       - name: Download cloudprober binary
-        if: ${{ matrix.image_type != 'fips' }}
         uses: actions/download-artifact@v4
         with:
           name: cloudprober-ubuntu-latest-dist
@@ -304,8 +303,8 @@ jobs:
       - name: Build and push release Docker Image (main)
         if: ${{ matrix.image_type == 'fips' }}
         run: |
-          make docker_multiarch_fips FIPS_ARCHS=linux/amd64
-          make docker_multiarch_fips FIPS_ARCHS=linux/amd64 DOCKER_IMAGE=ghcr.io/cloudprober/cloudprober
+          make docker_multiarch_fips
+          make docker_multiarch_fips DOCKER_IMAGE=ghcr.io/cloudprober/cloudprober
 
       - name: Build and push release Docker Image
         if: ${{ matrix.image_type == 'playwright' }}

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -4,19 +4,20 @@
 # Docker image built using this can executed in the following manner:
 #   docker run --net host -v $PWD/cloudprober.cfg:/etc/cloudprober.cfg \
 #                         cloudprober/cloudprober
-FROM golang:latest as builder
-
-WORKDIR /go
-COPY . .
-RUN CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go build -ldflags "-linkmode external -extldflags -static"  -o cloudprober ./cmd/cloudprober
-RUN go tool nm ./cloudprober | grep crypto/internal/boring/sig.BoringCrypto.abi0 > /dev/null
-
-FROM alpine:latest as certs
+FROM alpine:latest AS temp
 RUN apk --update add ca-certificates
 
+COPY cloudprober-fips-linux-* ./
+
+ARG TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+  mv cloudprober-fips-linux-amd64 cloudprober && rm cloudprober-fips-linux-*; fi
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+  mv cloudprober-fips-linux-arm64 cloudprober && rm cloudprober-fips-linux-*; fi
+
 FROM scratch
-COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=builder /go/cloudprober /cloudprober
+COPY --from=temp /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=temp /cloudprober /cloudprober
 
 # Metadata params
 ARG BUILD_DATE

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,9 @@ docker_multiarch: $(addprefix cloudprober-, $(LINUX_PLATFORMS)) Dockerfile
 		--platform linux/amd64,linux/arm64,linux/arm/v7 \
 		$(DOCKER_TAGS) .
 
-FIPS_ARCHS := "linux-amd64,linux-arm64"
-docker_multiarch_fips: Dockerfile.fips
+docker_multiarch_fips: cloudprober-fips-linux-amd64 cloudprober-fips-linux-arm64 Dockerfile.fips
 	docker buildx build --push $(DOCKER_BUILD_ARGS) \
-		--platform $(FIPS_ARCHS) \
+		--platform linux/amd64,linux/arm64 \
 		$(DOCKER_FIPS_TAGS) -f Dockerfile.fips .
 
 docker_multiarch_pw: Dockerfile.pw

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ endef
 cloudprober-fips: $(SOURCES)
 	$(GO_BUILD_FLAGS) CGO_ENABLED=1 GOEXPERIMENT=boringcrypto go build -o cloudprober-fips -tags netgo,osusergo -ldflags "$(VAR_LD_FLAGS) -w -linkmode external -extldflags -static" $(BINARY_SOURCE)
 	go tool nm cloudprober-fips | grep crypto/internal/boring/sig.BoringCrypto.abi0 > /dev/null || (echo "FIPS build failed: BoringCrypto not used" && rm cloudprober-fips && exit 1)
+	strip cloudprober-fips
 
 test:
 	go test -v -race -covermode=atomic ./...


### PR DESCRIPTION
- This is a proper fix for not being able to build arm64 image using `docker buildx` on github default runners, due to resources. Workaround was this: https://github.com/cloudprober/cloudprober/pull/990
- Now we build fips image the same way as non-fips image.
- Other than the builtin check in the Makefile target, you can verify that a Go binary is built with boringcrypto like this:
  ```
  $ go version ./cloudprober-fips-linux-amd64
  ./cloudprober-fips-linux-amd64: go1.23.5 X:boringcrypto
   ```