### PR TITLE
[build] Set caching related GO* variables to "D:" on windows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,6 +43,14 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag }}
 
+      - name: Set up Go env vars on Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          echo "GOCACHE=D:\gocache" >> $env:GITHUB_ENV
+          echo "GOMODCACHE=D:\gomodcache" >> $env:GITHUB_ENV
+          echo "GOTMPDIR=D:\gotmp" >> $env:GITHUB_ENV
+          mkdir D:\gotmp
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
This is based on the conversation here: https://github.com/actions/setup-go/pull/515