### PR TITLE
[build] Upgrade Go to 1.23.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudprober/cloudprober
 
-go 1.23.5
+go 1.23.6
 
 require (
 	cloud.google.com/go/bigquery v1.59.1


### PR DESCRIPTION
go 1.23.6 includes a security fix: https://go.dev/doc/devel/release#go1.23.0