### PR TITLE
[state] Rename config/runconfig to state

### DIFF
--- a/cloudprober.go
+++ b/cloudprober.go
@@ -36,13 +36,13 @@ import (
 
 	"github.com/cloudprober/cloudprober/config"
 	configpb "github.com/cloudprober/cloudprober/config/proto"
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/internal/servers"
 	"github.com/cloudprober/cloudprober/internal/sysvars"
 	"github.com/cloudprober/cloudprober/internal/tlsconfig"
 	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/prober"
 	"github.com/cloudprober/cloudprober/probes"
+	"github.com/cloudprober/cloudprober/state"
 	"github.com/cloudprober/cloudprober/surfacers"
 	"github.com/cloudprober/cloudprober/web"
 	"google.golang.org/grpc"
@@ -192,7 +192,7 @@ func initWithConfigSource(configSrc config.ConfigSource) error {
 	}
 	srvMux := http.NewServeMux()
 	setDebugHandlers(srvMux)
-	runconfig.SetDefaultHTTPServeMux(srvMux)
+	state.SetDefaultHTTPServeMux(srvMux)
 
 	var grpcLn net.Listener
 	if cfg.GetGrpcPort() != 0 {
@@ -220,7 +220,7 @@ func initWithConfigSource(configSrc config.ConfigSource) error {
 		reflection.Register(s)
 		// register channelz service to the default grpc server port
 		service.RegisterChannelzServiceToServer(s)
-		runconfig.SetDefaultGRPCServer(s)
+		state.SetDefaultGRPCServer(s)
 	}
 
 	pr := &prober.Prober{}
@@ -254,9 +254,9 @@ func Start(ctx context.Context) {
 	defer cloudProber.Unlock()
 
 	// Default servers
-	srvMux := runconfig.DefaultHTTPServeMux()
+	srvMux := state.DefaultHTTPServeMux()
 	httpSrv := &http.Server{Handler: srvMux}
-	grpcSrv := runconfig.DefaultGRPCServer()
+	grpcSrv := state.DefaultGRPCServer()
 
 	// Set up a goroutine to cleanup if context ends.
 	go func() {

--- a/cmd/cloudprober/main.go
+++ b/cmd/cloudprober/main.go
@@ -35,8 +35,8 @@ import (
 
 	"github.com/cloudprober/cloudprober"
 	"github.com/cloudprober/cloudprober/config"
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/logger"
+	"github.com/cloudprober/cloudprober/state"
 )
 
 var (
@@ -109,23 +109,23 @@ func main() {
 		version = version + " (dirty)"
 	}
 
-	runconfig.SetVersion(version)
+	state.SetVersion(version)
 	if buildTimestamp != "" {
 		ts, err := strconv.ParseInt(buildTimestamp, 10, 64)
 		if err != nil {
 			l.Criticalf("Error parsing build timestamp (%s). Err: %v", buildTimestamp, err)
 		}
-		runconfig.SetBuildTimestamp(time.Unix(ts, 0))
+		state.SetBuildTimestamp(time.Unix(ts, 0))
 	}
 
 	if *versionFlag {
-		fmt.Println(runconfig.Version())
+		fmt.Println(state.Version())
 		return
 	}
 
 	if *buildInfoFlag {
-		fmt.Println(runconfig.Version())
-		fmt.Println("Built at: ", runconfig.BuildTimestamp())
+		fmt.Println(state.Version())
+		fmt.Println("Built at: ", state.BuildTimestamp())
 		return
 	}
 

--- a/config/config_tmpl.go
+++ b/config/config_tmpl.go
@@ -122,7 +122,7 @@ import (
 	"cloud.google.com/go/compute/metadata"
 	"github.com/Masterminds/sprig/v3"
 	configpb "github.com/cloudprober/cloudprober/config/proto"
-	"github.com/cloudprober/cloudprober/config/runconfig"
+	"github.com/cloudprober/cloudprober/state"
 	"google.golang.org/protobuf/encoding/prototext"
 )
 
@@ -186,7 +186,7 @@ func parseTemplate(config string, tmplVars map[string]any, getGCECustomMetadata 
 			return matches[n], nil
 		},
 		"envSecret": func(s string) string { return "**$" + s + "**" },
-		"configDir": func() string { return filepath.Dir(runconfig.ConfigFilePath()) },
+		"configDir": func() string { return filepath.Dir(state.ConfigFilePath()) },
 	}
 
 	for name, f := range sprig.TxtFuncMap() {

--- a/config/config_tmpl_test.go
+++ b/config/config_tmpl_test.go
@@ -21,7 +21,7 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	configpb "github.com/cloudprober/cloudprober/config/proto"
-	"github.com/cloudprober/cloudprober/config/runconfig"
+	"github.com/cloudprober/cloudprober/state"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/encoding/prototext"
 )
@@ -172,9 +172,9 @@ func TestParseTemplateConfigDir(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping test on windows")
 	}
-	configFilePath := runconfig.ConfigFilePath()
-	defer runconfig.SetConfigFilePath(configFilePath)
-	runconfig.SetConfigFilePath("/cfg/cloudprober.cfg")
+	configFilePath := state.ConfigFilePath()
+	defer state.SetConfigFilePath(configFilePath)
+	state.SetConfigFilePath("/cfg/cloudprober.cfg")
 
 	testConfig := `
 probe {

--- a/config/configsource.go
+++ b/config/configsource.go
@@ -20,9 +20,9 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	configpb "github.com/cloudprober/cloudprober/config/proto"
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/internal/sysvars"
 	"github.com/cloudprober/cloudprober/logger"
+	"github.com/cloudprober/cloudprober/state"
 )
 
 var defaultConfigFile = "/etc/cloudprober.cfg"
@@ -100,9 +100,9 @@ func (dcs *defaultConfigSource) GetConfig() (*configpb.ProberConfig, error) {
 		}
 	}
 
-	// Set the config file path in runconfig. This can be used to find files
+	// Set the config file path in state. This can be used to find files
 	// relative to the config file.
-	runconfig.SetConfigFilePath(dcs.fileName)
+	state.SetConfigFilePath(dcs.fileName)
 
 	tmplVars := make(map[string]any)
 	for k, v := range dcs.baseVars {

--- a/internal/servers/grpc/grpc.go
+++ b/internal/servers/grpc/grpc.go
@@ -27,13 +27,13 @@ import (
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	configpb "github.com/cloudprober/cloudprober/internal/servers/grpc/proto"
 	pb "github.com/cloudprober/cloudprober/internal/servers/grpc/proto"
 	spb "github.com/cloudprober/cloudprober/internal/servers/grpc/proto"
 	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/metrics"
 	"github.com/cloudprober/cloudprober/probes/probeutils"
+	"github.com/cloudprober/cloudprober/state"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
@@ -109,7 +109,7 @@ func New(initCtx context.Context, c *configpb.ServerConf, l *logger.Logger) (*Se
 		return srv, nil
 	}
 
-	defGRPCSrv := runconfig.DefaultGRPCServer()
+	defGRPCSrv := state.DefaultGRPCServer()
 	if defGRPCSrv == nil {
 		return nil, errors.New("initialization of gRPC server failed as default gRPC server is not configured")
 	}

--- a/internal/servers/grpc/grpc_test.go
+++ b/internal/servers/grpc/grpc_test.go
@@ -24,11 +24,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	configpb "github.com/cloudprober/cloudprober/internal/servers/grpc/proto"
 	pb "github.com/cloudprober/cloudprober/internal/servers/grpc/proto"
 	spb "github.com/cloudprober/cloudprober/internal/servers/grpc/proto"
 	"github.com/cloudprober/cloudprober/logger"
+	"github.com/cloudprober/cloudprober/state"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 )
@@ -38,9 +38,9 @@ var once sync.Once
 // globalGRPCServer sets up runconfig and returns a gRPC server.
 func globalGRPCServer() (*grpc.Server, error) {
 	once.Do(func() {
-		runconfig.SetDefaultGRPCServer(grpc.NewServer())
+		state.SetDefaultGRPCServer(grpc.NewServer())
 	})
-	srv := runconfig.DefaultGRPCServer()
+	srv := state.DefaultGRPCServer()
 	if srv == nil {
 		return nil, errors.New("runconfig gRPC server not setup properly")
 	}

--- a/internal/sysvars/sysvars.go
+++ b/internal/sysvars/sysvars.go
@@ -27,9 +27,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/metrics"
+	"github.com/cloudprober/cloudprober/state"
 )
 
 var (
@@ -153,7 +153,7 @@ func Init(ll *logger.Logger, userVars map[string]string) error {
 	l = ll
 	startTime = time.Now()
 	sysVars = map[string]string{
-		"version": runconfig.Version(),
+		"version": state.Version(),
 	}
 
 	hostname, err := os.Hostname()

--- a/prober/prober.go
+++ b/prober/prober.go
@@ -34,7 +34,6 @@ import (
 	"time"
 
 	configpb "github.com/cloudprober/cloudprober/config/proto"
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	rdsserver "github.com/cloudprober/cloudprober/internal/rds/server"
 	"github.com/cloudprober/cloudprober/internal/servers"
 	"github.com/cloudprober/cloudprober/internal/sysvars"
@@ -44,6 +43,7 @@ import (
 	"github.com/cloudprober/cloudprober/probes"
 	"github.com/cloudprober/cloudprober/probes/options"
 	probes_configpb "github.com/cloudprober/cloudprober/probes/proto"
+	"github.com/cloudprober/cloudprober/state"
 	"github.com/cloudprober/cloudprober/surfacers"
 	"github.com/cloudprober/cloudprober/targets"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
@@ -131,7 +131,7 @@ func (pr *Prober) Init(ctx context.Context, cfg *configpb.ProberConfig, l *logge
 	pr.l = l
 
 	// Initialize cloudprober gRPC service if configured.
-	srv := runconfig.DefaultGRPCServer()
+	srv := state.DefaultGRPCServer()
 	if srv != nil {
 		pr.grpcStartProbeCh = make(chan string)
 		spb.RegisterCloudproberServer(srv, pr)
@@ -146,7 +146,7 @@ func (pr *Prober) Init(ctx context.Context, cfg *configpb.ProberConfig, l *logge
 			return err
 		}
 
-		runconfig.SetLocalRDSServer(rdsServer)
+		state.SetLocalRDSServer(rdsServer)
 		if srv != nil {
 			rdsServer.RegisterWithGRPC(srv)
 		}
@@ -237,7 +237,7 @@ func (pr *Prober) Start(ctx context.Context) {
 	} else {
 		pr.startProbesWithJitter(ctx)
 	}
-	if runconfig.DefaultGRPCServer() != nil {
+	if state.DefaultGRPCServer() != nil {
 		// Start a goroutine to handle starting of the probes added through gRPC.
 		// AddProbe adds new probes to the pr.grpcStartProbeCh channel and this
 		// goroutine reads from that channel and starts the probe using the overall

--- a/probes/browser/artifacts.go
+++ b/probes/browser/artifacts.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 	"slices"
 
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/logger"
+	"github.com/cloudprober/cloudprober/state"
 )
 
 type artifactsHandler struct {
@@ -104,7 +104,7 @@ func (p *Probe) initArtifactsHandler() error {
 	}
 
 	if p.c.GetArtifactsOptions().GetServeOnWeb() {
-		httpServerMux := runconfig.DefaultHTTPServeMux()
+		httpServerMux := state.DefaultHTTPServeMux()
 		if httpServerMux == nil {
 			return fmt.Errorf("default http server mux is not initialized")
 		}

--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -29,7 +29,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/internal/validators"
 	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/metrics"
@@ -39,6 +38,7 @@ import (
 	"github.com/cloudprober/cloudprober/probes/common/command"
 	"github.com/cloudprober/cloudprober/probes/common/sched"
 	"github.com/cloudprober/cloudprober/probes/options"
+	"github.com/cloudprober/cloudprober/state"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
 	"google.golang.org/protobuf/proto"
 )
@@ -146,7 +146,7 @@ func (p *Probe) initTemplateFile(templates embed.FS, fileName string, data any) 
 func (p *Probe) initTemplates() error {
 	testDir := p.c.GetTestDir()
 	if p.c.TestDir == nil {
-		testDir = filepath.Dir(runconfig.ConfigFilePath())
+		testDir = filepath.Dir(state.ConfigFilePath())
 	}
 
 	// Set up playwright config in workdir

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -23,10 +23,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/metrics"
 	configpb "github.com/cloudprober/cloudprober/probes/browser/proto"
 	"github.com/cloudprober/cloudprober/probes/options"
+	"github.com/cloudprober/cloudprober/state"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
@@ -192,9 +192,9 @@ func TestProbeInitTemplates(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	oldConfigFilePath := runconfig.ConfigFilePath()
-	defer runconfig.SetConfigFilePath(oldConfigFilePath)
-	runconfig.SetConfigFilePath("/cfg/cloudprober.cfg")
+	oldConfigFilePath := state.ConfigFilePath()
+	defer state.SetConfigFilePath(oldConfigFilePath)
+	state.SetConfigFilePath("/cfg/cloudprober.cfg")
 
 	defaultConfigContains := []string{
 		"testDir: \"/cfg\"",

--- a/state/state.go
+++ b/state/state.go
@@ -16,7 +16,7 @@
 Package runconfig stores cloudprober config that is specific to a single
 invocation. e.g., servers injected by external cloudprober users.
 */
-package runconfig
+package state
 
 import (
 	"net/http"
@@ -27,9 +27,9 @@ import (
 	"google.golang.org/grpc"
 )
 
-// runConfig stores cloudprober config that is specific to a single invocation.
+// state stores cloudprober config that is specific to a single invocation.
 // e.g., servers injected by external cloudprober users.
-type runConfig struct {
+type state struct {
 	sync.RWMutex
 	grpcSrv        *grpc.Server
 	version        string
@@ -39,92 +39,92 @@ type runConfig struct {
 	configFilePath string
 }
 
-var rc runConfig
+var st state
 
 // SetDefaultGRPCServer sets the default gRPC server.
 func SetDefaultGRPCServer(s *grpc.Server) {
-	rc.Lock()
-	defer rc.Unlock()
-	rc.grpcSrv = s
+	st.Lock()
+	defer st.Unlock()
+	st.grpcSrv = s
 }
 
 // DefaultGRPCServer returns the configured gRPC server and nil if gRPC server
 // was not set.
 func DefaultGRPCServer() *grpc.Server {
-	rc.Lock()
-	defer rc.Unlock()
-	return rc.grpcSrv
+	st.Lock()
+	defer st.Unlock()
+	return st.grpcSrv
 }
 
 // SetVersion sets the cloudprober version.
 func SetVersion(version string) {
-	rc.Lock()
-	defer rc.Unlock()
-	rc.version = version
+	st.Lock()
+	defer st.Unlock()
+	st.version = version
 }
 
 // Version returns the runconfig version set through the SetVersion() function
 // call. It's useful only if called after SetVersion(), otherwise it will
 // return an empty string.
 func Version() string {
-	rc.RLock()
-	defer rc.RUnlock()
-	return rc.version
+	st.RLock()
+	defer st.RUnlock()
+	return st.version
 }
 
 // SetBuildTimestamp sets the cloudprober build timestamp.
 func SetBuildTimestamp(ts time.Time) {
-	rc.Lock()
-	defer rc.Unlock()
-	rc.buildTimestamp = ts
+	st.Lock()
+	defer st.Unlock()
+	st.buildTimestamp = ts
 }
 
 // BuildTimestamp returns the recorded build timestamp.
 func BuildTimestamp() time.Time {
-	rc.RLock()
-	defer rc.RUnlock()
-	return rc.buildTimestamp
+	st.RLock()
+	defer st.RUnlock()
+	return st.buildTimestamp
 }
 
-// SetLocalRDSServer stores local RDS server in the runconfig. It can later
+// SetLocalRDSServer stores local RDS server in the state. It can later
 // be retrieved throuhg LocalRDSServer().
 func SetLocalRDSServer(srv *rdsserver.Server) {
-	rc.Lock()
-	defer rc.Unlock()
-	rc.rdsServer = srv
+	st.Lock()
+	defer st.Unlock()
+	st.rdsServer = srv
 }
 
 // LocalRDSServer returns the local RDS server, set through the
 // SetLocalRDSServer() call.
 func LocalRDSServer() *rdsserver.Server {
-	rc.RLock()
-	defer rc.RUnlock()
-	return rc.rdsServer
+	st.RLock()
+	defer st.RUnlock()
+	return st.rdsServer
 }
 
-// SetDefaultHTTPServeMux stores the default HTTP ServeMux in runconfig. This
+// SetDefaultHTTPServeMux stores the default HTTP ServeMux in state. This
 // allows other modules to add their own handlers to the common ServeMux.
 func SetDefaultHTTPServeMux(mux *http.ServeMux) {
-	rc.Lock()
-	defer rc.Unlock()
-	rc.httpServeMux = mux
+	st.Lock()
+	defer st.Unlock()
+	st.httpServeMux = mux
 }
 
 // DefaultHTTPServeMux returns the default HTTP ServeMux.
 func DefaultHTTPServeMux() *http.ServeMux {
-	rc.RLock()
-	defer rc.RUnlock()
-	return rc.httpServeMux
+	st.RLock()
+	defer st.RUnlock()
+	return st.httpServeMux
 }
 
 func SetConfigFilePath(configFilePath string) {
-	rc.Lock()
-	defer rc.Unlock()
-	rc.configFilePath = configFilePath
+	st.Lock()
+	defer st.Unlock()
+	st.configFilePath = configFilePath
 }
 
 func ConfigFilePath() string {
-	rc.RLock()
-	defer rc.RUnlock()
-	return rc.configFilePath
+	st.RLock()
+	defer st.RUnlock()
+	return st.configFilePath
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1,27 +1,62 @@
 package state
 
 import (
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )
 
-func TestRunConfigDefaultGRPCServer(t *testing.T) {
+func TestDefaultGRPCServer(t *testing.T) {
 	if srv := DefaultGRPCServer(); srv != nil {
-		t.Fatalf("RunConfig has server unexpectedly set. Got %v Want nil", srv)
+		t.Fatalf("State has server unexpectedly set. Got %v Want nil", srv)
 	}
 	testSrv := grpc.NewServer()
 	if testSrv == nil {
 		t.Fatal("Unable to create a test gRPC server")
 	}
 	SetDefaultGRPCServer(testSrv)
-	if srv := DefaultGRPCServer(); srv != testSrv {
-		t.Fatalf("Error retrieving stored service. Got %v Want %v", srv, testSrv)
-	}
+	assert.Equal(t, testSrv, DefaultGRPCServer(), "gRPC server")
 }
 
-func TestRunConfigConfigFilePath(t *testing.T) {
+func TestHTTPServeMux(t *testing.T) {
+	if mux := DefaultHTTPServeMux(); mux != nil {
+		t.Fatalf("State has http serve mux unexpectedly set. Got %v Want nil", mux)
+	}
+	testMux := http.NewServeMux()
+	if testMux == nil {
+		t.Fatal("Unable to create a test http serve mux")
+	}
+	SetDefaultHTTPServeMux(testMux)
+	assert.Equal(t, testMux, DefaultHTTPServeMux(), "http serve mux")
+}
+
+func TestConfigFilePath(t *testing.T) {
 	SetConfigFilePath("/cfg/cloudprober.cfg")
 	assert.Equal(t, "/cfg/cloudprober.cfg", ConfigFilePath(), "config file path")
+}
+
+func TestVersion(t *testing.T) {
+	if v := Version(); v != "" {
+		t.Fatalf("State has version unexpectedly set. Got %v Want \"\"", v)
+	}
+	SetVersion("v1.0.0")
+	assert.Equal(t, "v1.0.0", Version(), "version")
+}
+
+func TestBuildTimestamp(t *testing.T) {
+	if ts := BuildTimestamp(); !ts.IsZero() {
+		t.Fatalf("State has build timestamp unexpectedly set. Got %v Want \"\"", ts)
+	}
+	ts := time.Now()
+	SetBuildTimestamp(ts)
+	assert.Equal(t, ts, BuildTimestamp(), "build timestamp")
+}
+
+func TestLocalRDSServer(t *testing.T) {
+	if rds := LocalRDSServer(); rds != nil {
+		t.Fatalf("State has LocalRDSServer unexpectedly set. Got %v Want nil", rds)
+	}
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1,4 +1,4 @@
-package runconfig
+package state
 
 import (
 	"testing"

--- a/surfacers/internal/common/options/options.go
+++ b/surfacers/internal/common/options/options.go
@@ -23,9 +23,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/metrics"
+	"github.com/cloudprober/cloudprober/state"
 	surfacerpb "github.com/cloudprober/cloudprober/surfacers/proto"
 )
 
@@ -179,12 +179,12 @@ func buildOptions(sdef *surfacerpb.SurfacerDef, ignoreInit bool, l *logger.Logge
 	opts := &Options{
 		Config:            sdef,
 		Logger:            l,
-		HTTPServeMux:      runconfig.DefaultHTTPServeMux(),
+		HTTPServeMux:      state.DefaultHTTPServeMux(),
 		MetricsBufferSize: int(sdef.GetMetricsBufferSize()),
 		AddFailureMetric:  sdef.GetAddFailureMetric(),
 	}
 
-	serveMux := runconfig.DefaultHTTPServeMux()
+	serveMux := state.DefaultHTTPServeMux()
 	if serveMux == nil && !ignoreInit {
 		return nil, errors.New("default ServeMux is not configured, called before cloudprober initialization")
 	}

--- a/surfacers/internal/common/options/options_test.go
+++ b/surfacers/internal/common/options/options_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/metrics"
+	"github.com/cloudprober/cloudprober/state"
 	configpb "github.com/cloudprober/cloudprober/surfacers/proto"
 	surfacerpb "github.com/cloudprober/cloudprober/surfacers/proto"
 	"github.com/stretchr/testify/assert"
@@ -213,9 +213,9 @@ func TestAllowMetric(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	runconfig.SetDefaultHTTPServeMux(http.NewServeMux())
+	state.SetDefaultHTTPServeMux(http.NewServeMux())
 	code := m.Run()
-	runconfig.SetDefaultHTTPServeMux(nil)
+	state.SetDefaultHTTPServeMux(nil)
 	os.Exit(code)
 }
 
@@ -275,7 +275,7 @@ func TestBuildOptions(t *testing.T) {
 				tt.want.MetricsBufferSize = 10000
 			}
 			if tt.want.HTTPServeMux == nil {
-				tt.want.HTTPServeMux = runconfig.DefaultHTTPServeMux()
+				tt.want.HTTPServeMux = state.DefaultHTTPServeMux()
 			}
 
 			if tt.want.latencyMetricRe == nil {

--- a/surfacers/surfacers_test.go
+++ b/surfacers/surfacers_test.go
@@ -21,15 +21,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/metrics"
+	"github.com/cloudprober/cloudprober/state"
 	surfacerpb "github.com/cloudprober/cloudprober/surfacers/proto"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
 )
 
 func TestDefaultConfig(t *testing.T) {
-	runconfig.SetDefaultHTTPServeMux(http.NewServeMux())
+	state.SetDefaultHTTPServeMux(http.NewServeMux())
 
 	surfacers, err := Init(context.Background(), []*surfacerpb.SurfacerDef{})
 	if err != nil {
@@ -50,7 +50,7 @@ func TestDefaultConfig(t *testing.T) {
 }
 
 func TestEmptyConfig(t *testing.T) {
-	runconfig.SetDefaultHTTPServeMux(http.NewServeMux())
+	state.SetDefaultHTTPServeMux(http.NewServeMux())
 
 	s, err := Init(context.Background(), []*surfacerpb.SurfacerDef{{}})
 	if err != nil {
@@ -113,7 +113,7 @@ var testEventMetrics = []*metrics.EventMetrics{
 }
 
 func TestUserDefinedAndFiltering(t *testing.T) {
-	runconfig.SetDefaultHTTPServeMux(http.NewServeMux())
+	state.SetDefaultHTTPServeMux(http.NewServeMux())
 
 	ts1, ts2 := &testSurfacer{}, &testSurfacer{}
 	Register("s1", ts1)
@@ -174,7 +174,7 @@ func TestUserDefinedAndFiltering(t *testing.T) {
 }
 
 func TestFailureMetric(t *testing.T) {
-	runconfig.SetDefaultHTTPServeMux(http.NewServeMux())
+	state.SetDefaultHTTPServeMux(http.NewServeMux())
 
 	ts1, ts2 := &testSurfacer{}, &testSurfacer{}
 	Register("s1", ts1)
@@ -232,7 +232,7 @@ func TestFailureMetric(t *testing.T) {
 }
 
 func TestAdditionalLabel(t *testing.T) {
-	runconfig.SetDefaultHTTPServeMux(http.NewServeMux())
+	state.SetDefaultHTTPServeMux(http.NewServeMux())
 
 	ts1, ts2 := &testSurfacer{}, &testSurfacer{}
 	Register("s1", ts1)

--- a/targets/lameduck/lameduck.go
+++ b/targets/lameduck/lameduck.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 
 	"cloud.google.com/go/compute/metadata"
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	rdsclient "github.com/cloudprober/cloudprober/internal/rds/client"
 	rdsclientpb "github.com/cloudprober/cloudprober/internal/rds/client/proto"
 	"github.com/cloudprober/cloudprober/internal/rds/gcp"
@@ -34,6 +33,7 @@ import (
 	"github.com/cloudprober/cloudprober/internal/rds/server"
 	serverconfigpb "github.com/cloudprober/cloudprober/internal/rds/server/proto"
 	"github.com/cloudprober/cloudprober/logger"
+	"github.com/cloudprober/cloudprober/state"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
 	configpb "github.com/cloudprober/cloudprober/targets/lameduck/proto"
 	targetspb "github.com/cloudprober/cloudprober/targets/proto"
@@ -244,7 +244,7 @@ func newLister(globalOpts *targetspb.GlobalTargetsOptions, l *logger.Logger) (*l
 
 	// If no RDS server options are configured, look for a local one.
 	if li.rdsServerOpts == nil {
-		localRDSServer := runconfig.LocalRDSServer()
+		localRDSServer := state.LocalRDSServer()
 		if localRDSServer == nil {
 			li.l.Infof("rds_server_address not given and found no local RDS server, creating a new one.")
 

--- a/targets/targets.go
+++ b/targets/targets.go
@@ -31,11 +31,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	rdsclient "github.com/cloudprober/cloudprober/internal/rds/client"
 	rdsclientpb "github.com/cloudprober/cloudprober/internal/rds/client/proto"
 	rdspb "github.com/cloudprober/cloudprober/internal/rds/proto"
 	"github.com/cloudprober/cloudprober/logger"
+	"github.com/cloudprober/cloudprober/state"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
 	"github.com/cloudprober/cloudprober/targets/file"
 	"github.com/cloudprober/cloudprober/targets/gce"
@@ -280,7 +280,7 @@ func rdsClientConf(pb *targetspb.RDSTargets, globalOpts *targetspb.GlobalTargets
 	// If rds_server_address is not given in both, local options and in global
 	// options, look for the locally running RDS server.
 	if serverOpts == nil {
-		localRDSServer := runconfig.LocalRDSServer()
+		localRDSServer := state.LocalRDSServer()
 		if localRDSServer == nil {
 			return nil, nil, fmt.Errorf("rds_server_address not given and found no local RDS server")
 		}

--- a/web/resources/header.go
+++ b/web/resources/header.go
@@ -20,8 +20,8 @@ import (
 	"html/template"
 	"time"
 
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/internal/sysvars"
+	"github.com/cloudprober/cloudprober/state"
 )
 
 var t = template.Must(template.New("header").Parse(`
@@ -46,8 +46,8 @@ func Header() template.HTML {
 	if err := t.Execute(&buf, struct {
 		Version, BuiltAt, StartTime, Uptime, RightDiv interface{}
 	}{
-		Version:   runconfig.Version(),
-		BuiltAt:   runconfig.BuildTimestamp(),
+		Version:   state.Version(),
+		BuiltAt:   state.BuildTimestamp(),
 		StartTime: startTime,
 		Uptime:    uptime,
 	}); err != nil {

--- a/web/web.go
+++ b/web/web.go
@@ -23,11 +23,11 @@ import (
 	"net/http"
 
 	"github.com/cloudprober/cloudprober/config"
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/internal/alerting"
 	"github.com/cloudprober/cloudprober/internal/servers"
 	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/probes"
+	"github.com/cloudprober/cloudprober/state"
 	"github.com/cloudprober/cloudprober/surfacers"
 	"github.com/cloudprober/cloudprober/web/resources"
 	"github.com/cloudprober/cloudprober/web/webutils"
@@ -118,7 +118,7 @@ var secretConfigRunningMsg = `
 
 // InitWithDataFuncs initializes cloudprober web interface handler.
 func InitWithDataFuncs(fn DataFuncs) error {
-	srvMux := runconfig.DefaultHTTPServeMux()
+	srvMux := state.DefaultHTTPServeMux()
 	for _, url := range []string{"/config", "/config-running", "/static/"} {
 		if webutils.IsHandled(srvMux, url) {
 			return fmt.Errorf("url %s is already handled", url)

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -21,9 +21,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/cloudprober/cloudprober/config/runconfig"
 	"github.com/cloudprober/cloudprober/internal/servers"
 	"github.com/cloudprober/cloudprober/probes"
+	"github.com/cloudprober/cloudprober/state"
 	"github.com/cloudprober/cloudprober/surfacers"
 	"github.com/stretchr/testify/assert"
 )
@@ -69,10 +69,10 @@ func TestInitWithDataFuncs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			oldSrvMux := runconfig.DefaultHTTPServeMux()
-			defer runconfig.SetDefaultHTTPServeMux(oldSrvMux)
+			oldSrvMux := state.DefaultHTTPServeMux()
+			defer state.SetDefaultHTTPServeMux(oldSrvMux)
 			srvMux := http.NewServeMux()
-			runconfig.SetDefaultHTTPServeMux(srvMux)
+			state.SetDefaultHTTPServeMux(srvMux)
 
 			httpSrv := httptest.NewServer(srvMux)
 			defer httpSrv.Close()


### PR DESCRIPTION
- State is a more appropriate name for what this package does and we want to start using state for more things, e.g. to implement #1004.