### PR TITLE
[prober] Refactor prober init and startup code to simplify and streamline

### DIFF
--- a/cloudprober.go
+++ b/cloudprober.go
@@ -223,8 +223,6 @@ func initWithConfigSource(configSrc config.ConfigSource) error {
 		state.SetDefaultGRPCServer(s)
 	}
 
-	pr := &prober.Prober{}
-
 	// initCtx is used to clean up in case of partial initialization failures. For
 	// example, user-configured servers open listeners during initialization and
 	// if initialization fails at a later stage, say in probers or surfacers,
@@ -232,7 +230,8 @@ func initWithConfigSource(configSrc config.ConfigSource) error {
 	// close their listeners.
 	// TODO(manugarg): Plumb init context from cmd/cloudprober.
 	initCtx, cancelFunc := context.WithCancel(context.TODO())
-	if err := pr.Init(initCtx, cfg, globalLogger); err != nil {
+	pr, err := prober.Init(initCtx, cfg, globalLogger)
+	if err != nil {
 		cancelFunc()
 		ln.Close()
 		return err

--- a/prober/prober_test.go
+++ b/prober/prober_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Cloudprober Authors.
+// Copyright 2023-2025 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,17 +15,19 @@
 package prober
 
 import (
+	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	configpb "github.com/cloudprober/cloudprober/config/proto"
+	"github.com/cloudprober/cloudprober/metrics"
 	"github.com/cloudprober/cloudprober/probes"
-	probespb "github.com/cloudprober/cloudprober/probes/proto"
+	"github.com/cloudprober/cloudprober/probes/options"
+	probes_configpb "github.com/cloudprober/cloudprober/probes/proto"
+	testdatapb "github.com/cloudprober/cloudprober/probes/testdata"
+	targetspb "github.com/cloudprober/cloudprober/targets/proto"
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -80,69 +82,85 @@ func TestInterProbeWait(t *testing.T) {
 	}
 }
 
-func TestSaveProbesConfigUnprotected(t *testing.T) {
-	probes := map[string]*probes.ProbeInfo{
-		"test-probe-1": {
-			ProbeDef: &probespb.ProbeDef{
-				Name: proto.String("test-probe-1"),
-				Type: probespb.ProbeDef_DNS.Enum(),
-			},
-		},
-		"test-probe-2": {
-			ProbeDef: &probespb.ProbeDef{
-				Name: proto.String("test-probe-2"),
-				Type: probespb.ProbeDef_PING.Enum(),
-			},
-		},
-	}
-
-	tempDir := os.TempDir()
-
-	tests := []struct {
-		name       string
-		filePath   string
-		wantConfig string
-		wantErr    bool
-	}{
-		{
-			name:    "empty_file",
-			wantErr: true,
-		},
-		{
-			name:     "dir_path",
-			filePath: tempDir,
-			wantErr:  true,
-		},
-		{
-			name:     "normal",
-			filePath: filepath.Join(tempDir, "cp_probes.cfg"),
-			wantConfig: `probe: {
-  name: "test-probe-1"
-  type: DNS
+// testProbe implements the probes.Probe interface, while providing
+// facilities to examine the probe status for the purpose of testing.
+// Since cloudprober has to be aware of the probe type, we add testProbe to
+// cloudprober as an EXTENSION probe type (done through the init() function
+// below).
+type testProbe struct {
+	intialized      bool
+	startTime       time.Time
+	runningStatusCh chan bool
 }
-probe: {
-  name: "test-probe-2"
-  type: PING
-}
-`,
+
+// We use an EXTENSION probe for testing. Following has the same effect as:
+// This has the same effect as using the following in your config:
+//
+//	probe {
+//	   name: "<name>"
+//	   targets {
+//	    dummy_targets{}
+//	   }
+//	   [cloudprober.probes.testdata.fancy_probe] {
+//	     name: "fancy"
+//	   }
+//	}
+func testProbeDef(name string) *probes_configpb.ProbeDef {
+	probeDef := &probes_configpb.ProbeDef{
+		Name: proto.String(name),
+		Type: probes_configpb.ProbeDef_EXTENSION.Enum(),
+		Targets: &targetspb.TargetsDef{
+			Type: &targetspb.TargetsDef_DummyTargets{},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pr := &Prober{
-				Probes: probes,
-			}
-			if err := pr.saveProbesConfigUnprotected(tt.filePath); (err != nil) != tt.wantErr {
-				t.Errorf("Prober.saveProbesConfigUnprotected() error = %v, wantErr %v", err, tt.wantErr)
-			}
+	proto.SetExtension(probeDef, testdatapb.E_FancyProbe, &testdatapb.FancyProbe{Name: proto.String("fancy-" + name)})
+	return probeDef
+}
 
-			got, _ := os.ReadFile(tt.filePath)
+func (p *testProbe) Init(name string, opts *options.Options) error {
+	p.intialized = true
+	p.runningStatusCh = make(chan bool)
+	return nil
+}
 
-			var g configpb.ProberConfig
-			var w configpb.ProberConfig
-			assert.NoError(t, prototext.Unmarshal(got, &g))
-			assert.NoError(t, prototext.Unmarshal([]byte(tt.wantConfig), &w))
-			assert.Equal(t, w.String(), g.String())
-		})
+func (p *testProbe) Start(ctx context.Context, dataChan chan *metrics.EventMetrics) {
+	p.startTime = time.Now()
+
+	p.runningStatusCh <- true
+
+	// If context is done (used to stop a running probe before removing it),
+	// change probe state to not-running.
+	<-ctx.Done()
+	p.runningStatusCh <- false
+	close(p.runningStatusCh)
+}
+
+func init() {
+	// Register extension probe.
+	probes.RegisterProbeType(200, func() probes.Probe {
+		return &testProbe{}
+	})
+}
+
+func TestStartProbesWithJitter(t *testing.T) {
+	pr, cancel := testProber(t, &configpb.ProberConfig{
+		Probe: []*probes_configpb.ProbeDef{
+			testProbeDef("test-probe-1"),
+			testProbeDef("test-probe-2"),
+		},
+	})
+	defer cancel()
+
+	var startTimes []time.Time
+	for _, p := range pr.Probes {
+		tp := p.Probe.(*testProbe)
+		<-tp.runningStatusCh
+		startTimes = append(startTimes, tp.startTime)
 	}
+	assert.Equal(t, 2, len(startTimes))
+	delay := startTimes[1].Sub(startTimes[0])
+	if delay < 0 {
+		delay = -delay
+	}
+	assert.GreaterOrEqual(t, delay, time.Second)
 }


### PR DESCRIPTION
- Make it easier to reason about which code is protected behind locks and which code is not. Explain in comments as well.
- Make the mutex RWMutex.
- Improve SaveProbesToConfig tests.
- Add tests for startProbesWithJitter