### PR TITLE
[logger] Fix disable_cloud_logging for global resolver

### DIFF
--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -88,7 +88,7 @@ func TestEnvVarSet(t *testing.T) {
 				os.Setenv(varName, row.v)
 			}
 
-			got := envVarSet(varName)
+			got := isEnvSet(varName)
 			if got != row.expected {
 				t.Errorf("Variable set: got=%v, expected=%v", got, row.expected)
 			}

--- a/targets/statictargets.go
+++ b/targets/statictargets.go
@@ -78,6 +78,5 @@ func staticTargets(hosts string) (Targets, error) {
 	}
 
 	t.lister = sl
-	t.resolver = globalResolver
 	return t, nil
 }

--- a/targets/targets.go
+++ b/targets/targets.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 The Cloudprober Authors.
+// Copyright 2017-2025 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,8 +49,16 @@ import (
 // resolver by targets. It is a singleton because dnsRes.Resolver provides a
 // cache layer that is best shared by all probes.
 var (
-	globalResolver dnsRes.Resolver
+	globalRes     dnsRes.Resolver
+	globalResOnce sync.Once
 )
+
+func globalResolver() dnsRes.Resolver {
+	globalResOnce.Do(func() {
+		globalRes = dnsRes.New()
+	})
+	return globalRes
+}
 
 // Targets must have refreshed this much time after the lameduck for them to
 // become valid again. This is to take care of the following race between
@@ -219,7 +227,7 @@ func baseTargets(targetsDef *targetspb.TargetsDef, ldLister endpoint.Lister, l *
 	}
 	tgts := &targets{
 		l:        l,
-		resolver: globalResolver,
+		resolver: globalResolver(),
 		ldLister: ldLister,
 	}
 
@@ -322,7 +330,6 @@ func New(targetsDef *targetspb.TargetsDef, ldLister endpoint.Lister, globalOpts 
 		return nil, fmt.Errorf("targets.New(): Error making baseTargets: %v", err)
 	}
 
-	t.resolver = globalResolver
 	opts, err := dnsRes.GetResolverOptions(targetsDef, l)
 	if err != nil {
 		return nil, fmt.Errorf("targets.New(): error creating resolver: %v", err)
@@ -436,9 +443,4 @@ func SetSharedTargets(name string, tgts Targets) {
 	sharedTargetsMu.Lock()
 	defer sharedTargetsMu.Unlock()
 	sharedTargets[name] = tgts
-}
-
-// init initializes the package by creating a new global resolver.
-func init() {
-	globalResolver = dnsRes.New()
 }

--- a/targets/targets_test.go
+++ b/targets/targets_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cloudprober/cloudprober/targets/endpoint"
 	eppb "github.com/cloudprober/cloudprober/targets/endpoint/proto"
 	targetspb "github.com/cloudprober/cloudprober/targets/proto"
+	dnsRes "github.com/cloudprober/cloudprober/targets/resolver"
 	testdatapb "github.com/cloudprober/cloudprober/targets/testdata"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
@@ -289,6 +290,7 @@ func TestRDSClientConf(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
+	var gotResolver dnsRes.Resolver
 	tests := []struct {
 		name       string
 		targetsDef *targetspb.TargetsDef
@@ -337,6 +339,11 @@ func TestNew(t *testing.T) {
 				return
 			}
 			gotNames := endpoint.NamesFromEndpoints(got.ListEndpoints())
+			if gotResolver == nil {
+				gotResolver = got.(*targets).resolver
+			} else {
+				assert.Equal(t, gotResolver, got.(*targets).resolver, "Unexpected resolver")
+			}
 			assert.Equal(t, tt.wantNames, gotNames, "Unexpected targets")
 		})
 	}


### PR DESCRIPTION
- targets.globalResolver get initialized in `init()` which means that it will get initialized before flags are parsed, making `--disable_cloud_logging` ineffective. This PR moves globalResolver initialization out of init().
- While here, also move a bunch of stuff out of `logger`'s init.