### PR TITLE
[surfacers.probestatus] Restrict to just one proberstatus instance

### DIFF
--- a/surfacers/internal/probestatus/probestatus.go
+++ b/surfacers/internal/probestatus/probestatus.go
@@ -134,7 +134,7 @@ func New(ctx context.Context, config *configpb.SurfacerConf, opts *options.Optio
 	}
 
 	if config.GetUrl() != "/status" {
-		l.Warningf("Setting status page url is deprecated. In future versions, url will always fixed at /status and setting it to anything else will result in an error")
+		l.Warningf("Setting status page url is deprecated. In future versions, url will always be fixed at /status and setting it to anything else will result in an error")
 	}
 
 	ps := &Surfacer{

--- a/surfacers/internal/probestatus/probestatus.go
+++ b/surfacers/internal/probestatus/probestatus.go
@@ -133,7 +133,7 @@ func New(ctx context.Context, config *configpb.SurfacerConf, opts *options.Optio
 		res = time.Minute
 	}
 
-	if config.Url != nil && config.GetUrl() != "/status" {
+	if config.GetUrl() != "/status" {
 		l.Warningf("Setting status page url is deprecated. In future versions, url will always fixed at /status and setting it to anything else will result in an error")
 	}
 

--- a/surfacers/internal/probestatus/probestatus.go
+++ b/surfacers/internal/probestatus/probestatus.go
@@ -133,6 +133,10 @@ func New(ctx context.Context, config *configpb.SurfacerConf, opts *options.Optio
 		res = time.Minute
 	}
 
+	if config.Url != nil && config.GetUrl() != "/status" {
+		l.Warningf("Setting status page url is deprecated. In future versions, url will always fixed at /status and setting it to anything else will result in an error")
+	}
+
 	ps := &Surfacer{
 		c:            config,
 		opts:         opts,

--- a/surfacers/internal/probestatus/proto/config.pb.go
+++ b/surfacers/internal/probestatus/proto/config.pb.go
@@ -32,6 +32,8 @@ type SurfacerConf struct {
 	// Max targets per probe.
 	MaxTargetsPerProbe *int32 `protobuf:"varint,3,opt,name=max_targets_per_probe,json=maxTargetsPerProbe,def=20" json:"max_targets_per_probe,omitempty"`
 	// ProbeStatus URL
+	// This field is now deprecated and soon setting it will result in an
+	// error.
 	// Note that older default URL /probestatus forwards to this URL to avoid
 	// breaking older default setups.
 	Url *string `protobuf:"bytes,4,opt,name=url,def=/status" json:"url,omitempty"`

--- a/surfacers/internal/probestatus/proto/config.proto
+++ b/surfacers/internal/probestatus/proto/config.proto
@@ -17,6 +17,8 @@ message SurfacerConf {
     optional int32 max_targets_per_probe = 3 [default = 20];
 
     // ProbeStatus URL
+    // This field is now deprecated and soon setting it will result in an
+    // error. 
     // Note that older default URL /probestatus forwards to this URL to avoid
     // breaking older default setups.
     optional string url = 4 [default = "/status"];

--- a/surfacers/surfacers.go
+++ b/surfacers/surfacers.go
@@ -265,6 +265,10 @@ func Init(ctx context.Context, sDefs []*surfacerpb.SurfacerDef) ([]*SurfacerInfo
 			sType = inferType(sDef)
 		}
 
+		if sType == surfacerpb.Type_PROBESTATUS && foundSurfacers[sType] {
+			return nil, fmt.Errorf("probestatus surfacer cannot be defined more than once")
+		}
+
 		s, err := initSurfacer(ctx, sDef, sType)
 		if err != nil {
 			return nil, err

--- a/tools/gen_pb_go.sh
+++ b/tools/gen_pb_go.sh
@@ -17,7 +17,6 @@
 # This script generates Go code for the config protobufs.
 
 PROTOC_VERSION="27.5"
-PROJECT="cloudprober"
 
 GOPATH=$(go env GOPATH)
 
@@ -31,12 +30,11 @@ echo GOPATH=${GOPATH}
 if [ -z ${PROJECTROOT+x} ]; then
   # If PROJECTROOT is not set, try to determine it from script's location
   SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-  if [[ $SCRIPTDIR == *"$PROJECT/tools"* ]]; then
-    PROJECTROOT="${SCRIPTDIR}/../.."
+  if [[ $SCRIPTDIR == *"/tools"* ]]; then
+    PROJECTROOT="${SCRIPTDIR}/.."
   else
     echo "PROJECTROOT is not set and we are not able to determine PROJECTROOT"
-    echo "from script's path. PROJECTROOT should be set such that project files "
-    echo " are located at $PROJECT relative to the PROJECTROOT."
+    echo "from script's path."
     exit 1
   fi
 fi
@@ -92,8 +90,8 @@ cd $PROJECTROOT
 # Create a temporary director to generate protobuf Go files.
 TMPDIR=$(mktemp -d)
 echo $TMPDIR
-mkdir -p ${TMPDIR}/github.com/cloudprober
-rsync -mr --exclude='.git' --include='*/' --include='*.proto' --include='*.cue' --exclude='*' $PROJECT $TMPDIR/github.com/cloudprober
+mkdir -p ${TMPDIR}/github.com/cloudprober/cloudprober
+rsync -mr --exclude='.git' --include='*/' --include='*.proto' --include='*.cue' --exclude='*' . $TMPDIR/github.com/cloudprober/cloudprober
 
 cd $TMPDIR
 
@@ -122,7 +120,7 @@ mv github/com/cloudprober/cloudprober/probes/external/proto/server_pb2.py ${PY_S
 find ${MODULE} \( -name *.pb.go -o -name *.py \) | \
   while read -r pbgofile
   do
-    dst=${PROJECTROOT}/${pbgofile/github.com\/cloudprober\//}
+    dst=${PROJECTROOT}/${pbgofile/github.com\/cloudprober\/cloudprober\//}
     cp "$pbgofile" "$dst"
   done
 


### PR DESCRIPTION
- Also add a warning if this surfacer's URL is not set to /status.
- Fix protobuf code generation script to work with any directory path.