### PR TITLE
[probes] Initialize probe config with zero values if config is not given

### DIFF
--- a/probes/udp/udp.go
+++ b/probes/udp/udp.go
@@ -139,6 +139,9 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 	}
 	p.src = sysvars.GetVar("hostname")
 	p.c = c
+	if p.c == nil {
+		p.c = &configpb.ProbeConf{}
+	}
 	p.fsm = udpmessage.NewFlowStateMap()
 	p.res = make(map[flow]*probeResult)
 

--- a/probes/udplistener/udplistener.go
+++ b/probes/udplistener/udplistener.go
@@ -170,6 +170,9 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 		p.l = &logger.Logger{}
 	}
 	p.c = c
+	if p.c == nil {
+		p.c = &configpb.ProbeConf{}
+	}
 	p.echoMode = p.c.GetType() == configpb.ProbeConf_ECHO
 
 	p.fsm = udpmessage.NewFlowStateMap()


### PR DESCRIPTION
Exactly like for the PR https://github.com/cloudprober/cloudprober/pull/237 but for UDP and External probing