### PR TITLE
[common.oauth] Simplify OAuth config

### DIFF
--- a/common/oauth/bearer.go
+++ b/common/oauth/bearer.go
@@ -20,10 +20,13 @@ import (
 	configpb "github.com/cloudprober/cloudprober/common/oauth/proto"
 	"github.com/cloudprober/cloudprober/logger"
 	"golang.org/x/oauth2"
+	"google.golang.org/protobuf/proto"
 )
 
 func newBearerTokenSource(btc *configpb.BearerToken, refreshExpiryBuffer time.Duration, l *logger.Logger) (oauth2.TokenSource, error) {
-	c := &configpb.Config{}
+	c := &configpb.Config{
+		RefreshIntervalSec: proto.Float32(btc.GetRefreshIntervalSec()),
+	}
 	switch btc.GetSource().(type) {
 	case *configpb.BearerToken_File:
 		c.Source = &configpb.Config_File{

--- a/common/oauth/bearer.go
+++ b/common/oauth/bearer.go
@@ -15,171 +15,33 @@
 package oauth
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"os"
-	"os/exec"
-	"strings"
 	"time"
 
 	configpb "github.com/cloudprober/cloudprober/common/oauth/proto"
-	"github.com/cloudprober/cloudprober/internal/file"
 	"github.com/cloudprober/cloudprober/logger"
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
-	"google.golang.org/protobuf/proto"
 )
 
-var k8sTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-
-type bearerTokenSource struct {
-	c                   *configpb.BearerToken
-	getTokenFromBackend func(*configpb.BearerToken) (*oauth2.Token, error)
-	cache               *tokenCache
-	l                   *logger.Logger
-}
-
-func bytesToToken(b []byte) *oauth2.Token {
-	tok := &jsonToken{}
-	err := json.Unmarshal(b, tok)
-	if err != nil {
-		return &oauth2.Token{AccessToken: string(b)}
-	}
-	return &oauth2.Token{
-		AccessToken: tok.AccessToken,
-		Expiry:      time.Now().Add(time.Duration(tok.ExpiresIn) * time.Second),
-	}
-}
-
-var tokenFunctions = struct {
-	fromFile, fromCmd, fromGCEMetadata, fromK8sTokenFile func(c *configpb.BearerToken) (*oauth2.Token, error)
-}{
-	fromFile: func(c *configpb.BearerToken) (*oauth2.Token, error) {
-		b, err := file.ReadFile(context.Background(), c.GetFile())
-		if err != nil {
-			return nil, err
-		}
-		return bytesToToken(b), nil
-	},
-	fromCmd: func(c *configpb.BearerToken) (*oauth2.Token, error) {
-		var cmd *exec.Cmd
-
-		cmdParts := strings.Split(c.GetCmd(), " ")
-		cmd = exec.Command(cmdParts[0], cmdParts[1:]...)
-
-		out, err := cmd.Output()
-		if err != nil {
-			return nil, fmt.Errorf("failed to execute command: %v", cmd)
-		}
-
-		return bytesToToken(out), nil
-	},
-	fromGCEMetadata: func(c *configpb.BearerToken) (*oauth2.Token, error) {
-		ts := google.ComputeTokenSource(c.GetGceServiceAccount())
-		tok, err := ts.Token()
-		if err != nil {
-			return nil, err
-		}
-		return tok, nil
-	},
-	fromK8sTokenFile: func(c *configpb.BearerToken) (*oauth2.Token, error) {
-		b, err := os.ReadFile(k8sTokenFile)
-		if err != nil {
-			return nil, err
-		}
-		return &oauth2.Token{AccessToken: string(b)}, nil
-	},
-}
-
-func newBearerTokenSource(c *configpb.BearerToken, refreshExpiryBuffer time.Duration, l *logger.Logger) (oauth2.TokenSource, error) {
-	ts := &bearerTokenSource{
-		c: c,
-		l: l,
-	}
-
-	var tokenBackendFunc func(*configpb.BearerToken) (*oauth2.Token, error)
-
-	switch ts.c.Source.(type) {
+func newBearerTokenSource(btc *configpb.BearerToken, refreshExpiryBuffer time.Duration, l *logger.Logger) (oauth2.TokenSource, error) {
+	c := &configpb.Config{}
+	switch btc.GetSource().(type) {
 	case *configpb.BearerToken_File:
-		tokenBackendFunc = tokenFunctions.fromFile
-
+		c.Source = &configpb.Config_File{
+			File: btc.GetFile(),
+		}
 	case *configpb.BearerToken_Cmd:
-		tokenBackendFunc = tokenFunctions.fromCmd
-
+		c.Source = &configpb.Config_Cmd{
+			Cmd: btc.GetCmd(),
+		}
 	case *configpb.BearerToken_GceServiceAccount:
-		tokenBackendFunc = tokenFunctions.fromGCEMetadata
-
+		c.Source = &configpb.Config_GceServiceAccount{
+			GceServiceAccount: btc.GetGceServiceAccount(),
+		}
 	case *configpb.BearerToken_K8SLocalToken:
-		if !c.GetK8SLocalToken() {
-			return nil, fmt.Errorf("k8s_local_token cannot be false, config: <%v>", c.String())
+		c.Source = &configpb.Config_K8SLocalToken{
+			K8SLocalToken: btc.GetK8SLocalToken(),
 		}
-		tokenBackendFunc = tokenFunctions.fromK8sTokenFile
-
-	default:
-		return nil, fmt.Errorf("unknown source: %v", ts.c.GetSource())
 	}
 
-	ts.getTokenFromBackend = func(c *configpb.BearerToken) (*oauth2.Token, error) {
-		l.Debugf("oauth.bearerTokenSource: Getting a new token using config: %s", c.String())
-		return tokenBackendFunc(c)
-	}
-
-	tok, err := ts.getTokenFromBackend(c)
-	if err != nil {
-		return nil, err
-	}
-	ts.cache = &tokenCache{
-		tok:                 tok,
-		refreshExpiryBuffer: refreshExpiryBuffer,
-		ignoreExpiryIfZero:  true,
-		getToken:            func() (*oauth2.Token, error) { return ts.getTokenFromBackend(c) },
-		l:                   l,
-	}
-
-	// For JSON tokens return now.
-	if tok != nil && !tok.Expiry.IsZero() {
-		return ts, nil
-	}
-
-	// Default refresh interval
-	if ts.c.RefreshIntervalSec == nil {
-		ts.c.RefreshIntervalSec = proto.Float32(30)
-	}
-	// Explicitly set to zero, so no refreshing.
-	if ts.c.GetRefreshIntervalSec() == 0 {
-		return ts, nil
-	}
-
-	go func() {
-		interval := time.Duration(ts.c.GetRefreshIntervalSec()) * time.Second
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-
-		for range ticker.C {
-			tok, err := ts.getTokenFromBackend(ts.c)
-
-			if err != nil {
-				ts.l.Warningf("oauth.bearerTokenSource: %s", err)
-				continue
-			}
-
-			ts.cache.setToken(tok)
-		}
-	}()
-
-	return ts, nil
-}
-
-func (ts *bearerTokenSource) Token() (*oauth2.Token, error) {
-	return ts.cache.Token()
-}
-
-func K8STokenSource(l *logger.Logger) (oauth2.TokenSource, error) {
-	return newBearerTokenSource(&configpb.BearerToken{
-		Source: &configpb.BearerToken_K8SLocalToken{
-			K8SLocalToken: true,
-		},
-		RefreshIntervalSec: proto.Float32(60),
-	}, time.Minute, l)
+	return newTokenSource(c, refreshExpiryBuffer, l)
 }

--- a/common/oauth/bearer.go
+++ b/common/oauth/bearer.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Cloudprober Authors.
+// Copyright 2019-2025 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/oauth/oauth.go
+++ b/common/oauth/oauth.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Cloudprober Authors.
+// Copyright 2019-2025 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/oauth/oauth.go
+++ b/common/oauth/oauth.go
@@ -44,13 +44,10 @@ func TokenSourceFromConfig(c *configpb.Config, l *logger.Logger) (oauth2.TokenSo
 		refreshExpiryBuffer = time.Duration(c.GetRefreshExpiryBufferSec()) * time.Second
 	}
 
-	switch c.Type.(type) {
-
+	switch c.Source.(type) {
 	case *configpb.Config_BearerToken:
+		l.Warningf("oauth.TokenSourceFromConfig: BearerToken is deprecated. Move bearer token source config to directly under oauth_config.")
 		return newBearerTokenSource(c.GetBearerToken(), refreshExpiryBuffer, l)
-
-	case *configpb.Config_HttpRequest:
-		return newHTTPTokenSource(c.GetHttpRequest(), refreshExpiryBuffer, l)
 
 	case *configpb.Config_GoogleCredentials:
 		f := c.GetGoogleCredentials().GetJsonFile()
@@ -84,5 +81,5 @@ func TokenSourceFromConfig(c *configpb.Config, l *logger.Logger) (oauth2.TokenSo
 		return creds.TokenSource, nil
 	}
 
-	return nil, fmt.Errorf("unknown oauth credentials type: %v", c.Type)
+	return newTokenSource(c, refreshExpiryBuffer, l)
 }

--- a/common/oauth/oauth_test.go
+++ b/common/oauth/oauth_test.go
@@ -73,7 +73,7 @@ func TestGoogleCredentials(t *testing.T) {
 	}
 
 	c := &configpb.Config{
-		Type: &configpb.Config_GoogleCredentials{
+		Source: &configpb.Config_GoogleCredentials{
 			GoogleCredentials: googleC,
 		},
 	}

--- a/common/oauth/proto/config.proto
+++ b/common/oauth/proto/config.proto
@@ -5,10 +5,32 @@ package cloudprober.oauth;
 option go_package = "github.com/cloudprober/cloudprober/common/oauth/proto";
 
 message Config {
-  oneof type {
-    HTTPRequest http_request = 3;
-    BearerToken bearer_token = 1;
-    GoogleCredentials google_credentials = 2;
+  oneof source {
+    // Path to token file.
+    string file = 1;
+
+    // Get token by making an HTTP request.
+    HTTPRequest http_request = 2;
+
+    // Run a comand to obtain the token, e.g.
+    // cat /var/lib/myapp/token, or
+    // /var/lib/run/get_token.sh
+    string cmd = 3;
+
+    // GCE metadata token
+    string gce_service_account = 4;
+
+    // K8s service account token file:
+    // /var/run/secrets/kubernetes.io/serviceaccount/token
+    bool k8s_local_token = 5;
+
+    // Google credentials, either from a default source or a JSON file.
+    GoogleCredentials google_credentials = 8;
+
+    // Bearer token (deprecated)
+    // This field is deprecated. Use one of the other source directly. This
+    // layer turned out to be unnecessary.
+    BearerToken bearer_token = 7;
   }
 
   // How long before the expiry do we refresh. Default is 60 (1m). This applies
@@ -16,6 +38,13 @@ message Config {
   // expiry in some way.
   // TODO(manugarg): Consider setting default based on probe interval.
   optional int32 refresh_expiry_buffer_sec = 20;
+
+  // If above sources return a JSON token with an expiry, we use that info to
+  // determine when to refresh tokens and refresh_interval_sec is completely
+  // ignored. If above sources return a string, we refresh from the source
+  // every 30s by default. To disable this behavior set refresh_interval_sec to
+  // zero.
+  optional float refresh_interval_sec = 21;
 }
 
 message HTTPRequest {
@@ -37,6 +66,8 @@ message HTTPRequest {
 
 // Bearer token is added to the HTTP request through an HTTP header:
 // "Authorization: Bearer <access_token>"
+//
+// This message is deprecated. Use these sources directly in Config instead.
 message BearerToken {
   oneof source {
     // Path to token file.

--- a/common/oauth/tokensource.go
+++ b/common/oauth/tokensource.go
@@ -1,0 +1,194 @@
+// Copyright 2019-2023 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	configpb "github.com/cloudprober/cloudprober/common/oauth/proto"
+	"github.com/cloudprober/cloudprober/internal/file"
+	"github.com/cloudprober/cloudprober/logger"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/protobuf/proto"
+)
+
+var k8sTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+type genericTokenSource struct {
+	c                   *configpb.Config
+	getTokenFromBackend func(*configpb.Config) (*oauth2.Token, error)
+	cache               *tokenCache
+	l                   *logger.Logger
+}
+
+func bytesToToken(b []byte) *oauth2.Token {
+	tok := &jsonToken{}
+	err := json.Unmarshal(b, tok)
+	if err != nil {
+		return &oauth2.Token{AccessToken: string(b)}
+	}
+	return &oauth2.Token{
+		AccessToken: tok.AccessToken,
+		Expiry:      time.Now().Add(time.Duration(tok.ExpiresIn) * time.Second),
+	}
+}
+
+func readFromFile(c *configpb.Config) (*oauth2.Token, error) {
+	b, err := file.ReadFile(context.Background(), c.GetFile())
+	if err != nil {
+		return nil, err
+	}
+	return bytesToToken(b), nil
+}
+
+func readFromCommand(c *configpb.Config) (*oauth2.Token, error) {
+	var cmd *exec.Cmd
+
+	cmdParts := strings.Split(c.GetCmd(), " ")
+	cmd = exec.Command(cmdParts[0], cmdParts[1:]...)
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute command: %v", cmd)
+	}
+
+	return bytesToToken(out), nil
+}
+
+var tokenFunctions = struct {
+	fromFile, fromCmd, fromGCEMetadata, fromK8sTokenFile func(c *configpb.Config) (*oauth2.Token, error)
+}{
+	fromFile: readFromFile,
+	fromCmd:  readFromCommand,
+	fromGCEMetadata: func(c *configpb.Config) (*oauth2.Token, error) {
+		ts := google.ComputeTokenSource(c.GetGceServiceAccount())
+		tok, err := ts.Token()
+		if err != nil {
+			return nil, err
+		}
+		return tok, nil
+	},
+	fromK8sTokenFile: func(c *configpb.Config) (*oauth2.Token, error) {
+		b, err := os.ReadFile(k8sTokenFile)
+		if err != nil {
+			return nil, err
+		}
+		return &oauth2.Token{AccessToken: string(b)}, nil
+	},
+}
+
+func newTokenSource(c *configpb.Config, refreshExpiryBuffer time.Duration, l *logger.Logger) (oauth2.TokenSource, error) {
+	// HTTP Request token source has its own implementation.
+	if c.GetHttpRequest() != nil {
+		return newHTTPTokenSource(c.GetHttpRequest(), refreshExpiryBuffer, l)
+	}
+
+	ts := &genericTokenSource{
+		c: c,
+		l: l,
+	}
+
+	var tokenBackendFunc func(*configpb.Config) (*oauth2.Token, error)
+
+	switch c.Source.(type) {
+	case *configpb.Config_File:
+		tokenBackendFunc = tokenFunctions.fromFile
+
+	case *configpb.Config_Cmd:
+		tokenBackendFunc = tokenFunctions.fromCmd
+
+	case *configpb.Config_GceServiceAccount:
+		tokenBackendFunc = tokenFunctions.fromGCEMetadata
+
+	case *configpb.Config_K8SLocalToken:
+		if !c.GetK8SLocalToken() {
+			return nil, fmt.Errorf("k8s_local_token cannot be false, config: <%v>", c.String())
+		}
+		tokenBackendFunc = tokenFunctions.fromK8sTokenFile
+
+	default:
+		return nil, fmt.Errorf("unknown source: %v", c.Source)
+	}
+
+	ts.getTokenFromBackend = func(c *configpb.Config) (*oauth2.Token, error) {
+		l.Debugf("oauth.genericTokenSource: Getting a new token using config: %s", c.String())
+		return tokenBackendFunc(c)
+	}
+
+	tok, err := ts.getTokenFromBackend(c)
+	if err != nil {
+		return nil, err
+	}
+	ts.cache = &tokenCache{
+		tok:                 tok,
+		refreshExpiryBuffer: refreshExpiryBuffer,
+		ignoreExpiryIfZero:  true,
+		getToken:            func() (*oauth2.Token, error) { return ts.getTokenFromBackend(c) },
+		l:                   l,
+	}
+
+	// For JSON token that have expiry return now.
+	if tok != nil && !tok.Expiry.IsZero() {
+		return ts, nil
+	}
+
+	// Default refresh interval
+	if ts.c.RefreshIntervalSec == nil {
+		ts.c.RefreshIntervalSec = proto.Float32(30)
+	}
+	// Explicitly set to zero, so no refreshing.
+	if ts.c.GetRefreshIntervalSec() == 0 {
+		return ts, nil
+	}
+
+	go func() {
+		interval := time.Duration(ts.c.GetRefreshIntervalSec()) * time.Second
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			tok, err := ts.getTokenFromBackend(ts.c)
+
+			if err != nil {
+				ts.l.Warningf("oauth.genericTokenSource: %s", err)
+				continue
+			}
+
+			ts.cache.setToken(tok)
+		}
+	}()
+
+	return ts, nil
+}
+
+func (ts *genericTokenSource) Token() (*oauth2.Token, error) {
+	return ts.cache.Token()
+}
+
+func K8STokenSource(l *logger.Logger) (oauth2.TokenSource, error) {
+	return newBearerTokenSource(&configpb.BearerToken{
+		Source: &configpb.BearerToken_K8SLocalToken{
+			K8SLocalToken: true,
+		},
+		RefreshIntervalSec: proto.Float32(60),
+	}, time.Minute, l)
+}

--- a/common/oauth/tokensource.go
+++ b/common/oauth/tokensource.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Cloudprober Authors.
+// Copyright 2019-2025 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/common/oauth/tokensource.go
+++ b/common/oauth/tokensource.go
@@ -185,8 +185,8 @@ func (ts *genericTokenSource) Token() (*oauth2.Token, error) {
 }
 
 func K8STokenSource(l *logger.Logger) (oauth2.TokenSource, error) {
-	return newBearerTokenSource(&configpb.BearerToken{
-		Source: &configpb.BearerToken_K8SLocalToken{
+	return newTokenSource(&configpb.Config{
+		Source: &configpb.Config_K8SLocalToken{
 			K8SLocalToken: true,
 		},
 		RefreshIntervalSec: proto.Float32(60),

--- a/common/oauth/tokensource_test.go
+++ b/common/oauth/tokensource_test.go
@@ -17,6 +17,7 @@ package oauth
 import (
 	"errors"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -350,6 +351,10 @@ func TestReadFromFile(t *testing.T) {
 }
 
 func TestReadFromCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows")
+	}
+
 	tests := []struct {
 		name      string
 		cmd       string

--- a/common/oauth/tokensource_test.go
+++ b/common/oauth/tokensource_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2023 The Cloudprober Authors.
+// Copyright 2019-2025 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@ package oauth
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -52,7 +51,7 @@ func callCounter() int {
 	return global.callCounter
 }
 
-func testTokenFromFile(c *configpb.BearerToken) (*oauth2.Token, error) {
+func testTokenFromFile(c *configpb.Config) (*oauth2.Token, error) {
 	suffix := ""
 	if callCounter() > 0 {
 		if strings.HasSuffix(c.GetFile(), "fail") {
@@ -69,7 +68,7 @@ func testTokenFromFile(c *configpb.BearerToken) (*oauth2.Token, error) {
 	return &oauth2.Token{AccessToken: c.GetFile() + "_file_token" + suffix, Expiry: exp}, nil
 }
 
-func testTokenFromCmd(c *configpb.BearerToken) (*oauth2.Token, error) {
+func testTokenFromCmd(c *configpb.Config) (*oauth2.Token, error) {
 	suffix := ""
 	if callCounter() > 0 {
 		suffix = "_new"
@@ -84,7 +83,7 @@ func testTokenFromCmd(c *configpb.BearerToken) (*oauth2.Token, error) {
 	return &oauth2.Token{AccessToken: c.GetCmd() + "_cmd_token" + suffix, Expiry: exp}, nil
 }
 
-func testTokenFromGCEMetadata(c *configpb.BearerToken) (*oauth2.Token, error) {
+func testTokenFromGCEMetadata(c *configpb.Config) (*oauth2.Token, error) {
 	suffix := ""
 	if callCounter() > 0 {
 		suffix = "_new"
@@ -93,7 +92,7 @@ func testTokenFromGCEMetadata(c *configpb.BearerToken) (*oauth2.Token, error) {
 	return &oauth2.Token{AccessToken: c.GetGceServiceAccount() + "_gce_token" + suffix, Expiry: time.Now().Add(time.Hour)}, nil
 }
 
-func testK8SToken(c *configpb.BearerToken) (*oauth2.Token, error) {
+func testK8SToken(c *configpb.Config) (*oauth2.Token, error) {
 	suffix := ""
 	if callCounter() > 0 {
 		suffix = "_new"
@@ -102,7 +101,7 @@ func testK8SToken(c *configpb.BearerToken) (*oauth2.Token, error) {
 	return &oauth2.Token{AccessToken: "k8s_token" + suffix, Expiry: time.Now().Add(time.Hour)}, nil
 }
 
-func TestNewBearerToken(t *testing.T) {
+func TestNewTokenSource(t *testing.T) {
 	oldTokenFunctions := tokenFunctions
 	tokenFunctions.fromFile = testTokenFromFile
 	tokenFunctions.fromCmd = testTokenFromCmd
@@ -167,23 +166,23 @@ func TestNewBearerToken(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name+":"+test.config, func(t *testing.T) {
 			resetCallCounter()
-			testC := &configpb.BearerToken{}
+			testC := &configpb.Config{}
 			assert.NoError(t, prototext.Unmarshal([]byte(test.config), testC), "error parsing test config")
 
 			testRefreshExpiryBuffer := 10 * time.Second
 
 			// Call counter should always increase during token source creation.
 			expectedC := callCounter() + 1
-			cts, err := newBearerTokenSource(testC, testRefreshExpiryBuffer, nil)
+			cts, err := newTokenSource(testC, testRefreshExpiryBuffer, nil)
 			if (err != nil) != test.wantErr {
-				t.Errorf("newBearerTokenSource() error = %v, wantErr %v", err, test.wantErr)
+				t.Errorf("newTokenSource() error = %v, wantErr %v", err, test.wantErr)
 			}
 			if err != nil {
 				return
 			}
 
 			// verify token cache
-			tc := cts.(*bearerTokenSource).cache
+			tc := cts.(*genericTokenSource).cache
 			assert.Equal(t, testRefreshExpiryBuffer, tc.refreshExpiryBuffer, "token cache refresh expiry buffer")
 			assert.Equal(t, tc.ignoreExpiryIfZero, true)
 
@@ -193,6 +192,7 @@ func TestNewBearerToken(t *testing.T) {
 			if test.wantNewToken {
 				time.Sleep(test.wait) // Wait for refresh
 				test.wantToken += "_new"
+				expectedC++
 			}
 			tok, err := cts.Token()
 			assert.NoError(t, err, "error getting token")
@@ -202,18 +202,19 @@ func TestNewBearerToken(t *testing.T) {
 }
 
 func testFileWithContent(t *testing.T, content string) string {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp(t.TempDir(), "")
 	if err != nil {
 		t.Fatalf("Error creating temporary file for testing: %v", err)
 		return ""
 	}
 
 	if _, err := f.Write([]byte(content)); err != nil {
-		os.Remove(f.Name()) // clean up
+		f.Close()
 		t.Fatalf("Error writing %s to temporary file: %s", content, f.Name())
 		return ""
 	}
 
+	f.Close()
 	return f.Name()
 }
 
@@ -258,6 +259,126 @@ func TestK8STokenSource(t *testing.T) {
 
 			gotToken, _ := ts.Token()
 			assert.Equal(t, tt.testToken, gotToken.AccessToken, "access token")
+		})
+	}
+}
+
+func TestReadFromFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		fileData  string
+		wantToken *oauth2.Token
+		wantErr   bool
+	}{
+		{
+			name:     "Valid token in plain text",
+			fileData: "plain-text-token",
+			wantToken: &oauth2.Token{
+				AccessToken: "plain-text-token",
+			},
+		},
+		{
+			name: "Valid token in JSON format",
+			fileData: `{
+				"access_token": "json-token",
+				"expires_in": 3600
+			}`,
+			wantToken: &oauth2.Token{
+				AccessToken: "json-token",
+				Expiry:      time.Now().Add(time.Hour).Truncate(time.Second),
+			},
+		},
+		{
+			name:     "Invalid file content",
+			fileData: `invalid-json`,
+			wantToken: &oauth2.Token{
+				AccessToken: "invalid-json",
+			},
+		},
+		{
+			name:    "File does not exist",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var filePath string
+			if tt.fileData != "" {
+				filePath = testFileWithContent(t, tt.fileData)
+			} else {
+				filePath = "/nonexistent/file/path"
+			}
+
+			testConfig := &configpb.Config{
+				Source: &configpb.Config_File{
+					File: filePath,
+				},
+			}
+
+			gotToken, err := readFromFile(testConfig)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("readFromFile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err == nil {
+				assert.Equal(t, tt.wantToken.AccessToken, gotToken.AccessToken, "Access token mismatch")
+				if !tt.wantToken.Expiry.IsZero() {
+					assert.WithinDuration(t, tt.wantToken.Expiry, gotToken.Expiry, time.Second, "Token expiry mismatch")
+				}
+			}
+		})
+	}
+}
+
+func TestReadFromCommand(t *testing.T) {
+	tests := []struct {
+		name      string
+		cmd       string
+		wantToken *oauth2.Token
+		wantErr   bool
+	}{
+		{
+			name: "Valid command with plain text token",
+			cmd:  "echo -n plain-text-token",
+			wantToken: &oauth2.Token{
+				AccessToken: "plain-text-token",
+			},
+		},
+		{
+			name: "Valid command with JSON token",
+			cmd:  `echo -e {"access_token": "json-token", "expires_in": 3600}`,
+			wantToken: &oauth2.Token{
+				AccessToken: "json-token",
+				Expiry:      time.Now().Add(time.Hour).Truncate(time.Second),
+			},
+		},
+		{
+			name:    "Invalid command",
+			cmd:     "invalid-command",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testConfig := &configpb.Config{
+				Source: &configpb.Config_Cmd{
+					Cmd: tt.cmd,
+				},
+			}
+
+			gotToken, err := readFromCommand(testConfig)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("readFromCommand() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err == nil {
+				assert.Equal(t, tt.wantToken.AccessToken, gotToken.AccessToken, "Access token mismatch")
+				if !tt.wantToken.Expiry.IsZero() {
+					assert.WithinDuration(t, tt.wantToken.Expiry, gotToken.Expiry, time.Second, "Token expiry mismatch")
+				}
+			}
 		})
 	}
 }

--- a/common/oauth/tokensource_test.go
+++ b/common/oauth/tokensource_test.go
@@ -365,7 +365,7 @@ func TestReadFromCommand(t *testing.T) {
 		},
 		{
 			name: "Valid command with JSON token",
-			cmd:  `echo -e {"access_token": "json-token", "expires_in": 3600}`,
+			cmd:  `echo {"access_token": "json-token", "expires_in": 3600}`,
 			wantToken: &oauth2.Token{
 				AccessToken: "json-token",
 				Expiry:      time.Now().Add(time.Hour).Truncate(time.Second),

--- a/probes/browser/artifacts/storage/storage_abs.go
+++ b/probes/browser/artifacts/storage/storage_abs.go
@@ -80,7 +80,7 @@ func (s *ABS) initAuth(ctx context.Context, cfg *configpb.ABS) error {
 	// If account key and auth config are not provided, we will use the metadata
 	// service to get the bearer token.
 	oauthTS, err := oauth.TokenSourceFromConfig(&oauthconfigpb.Config{
-		Type: &oauthconfigpb.Config_HttpRequest{
+		Source: &oauthconfigpb.Config_HttpRequest{
 			HttpRequest: &oauthconfigpb.HTTPRequest{
 				TokenUrl: identityEndpoint,
 				Header: map[string]string{

--- a/probes/browser/artifacts/storage/storage_gcs.go
+++ b/probes/browser/artifacts/storage/storage_gcs.go
@@ -48,7 +48,7 @@ func InitGCS(ctx context.Context, cfg *configpb.GCS, storagePath string, l *logg
 		cfg.Credentials.Scope = []string{"https://www.googleapis.com/auth/devstorage.read_write"}
 	}
 	oauthCfg := oauthconfigpb.Config{
-		Type: &oauthconfigpb.Config_GoogleCredentials{
+		Source: &oauthconfigpb.Config_GoogleCredentials{
 			GoogleCredentials: cfg.Credentials,
 		},
 	}


### PR DESCRIPTION
While writing documentation for OAuth I realized OAuth config doesn't flow nicely -- more specifically, bearer_token abstraction feels unnecessary.

This PR changes that. It's moving bearer_token fields outside, under oauth_config directly. We'll still continue to support bearer_token. It's not much burden as bearer_token implementation now uses the new implementation.

Old config:
```
oauth_config {
  bearer_token {
     file: ..
  }
}
```

New config (note: old config will still work):
```
oauth_config {
   file: ..
}
```
