### PR TITLE
[common.oauth] Streamline token refresh behavior

### DIFF
--- a/common/oauth/http_token_test.go
+++ b/common/oauth/http_token_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Cloudprober Authors.
+// Copyright 2023-2025 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -78,15 +78,21 @@ func TestHTTPTokenSourceToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			param := `{"grant_type":"client_credentials"}`
-			ots, err := newHTTPTokenSource(&configpb.HTTPRequest{
-				Data: []string{param},
+			ots, err := newTokenSource(&configpb.Config{
+				Source: &configpb.Config_HttpRequest{
+					HttpRequest: &configpb.HTTPRequest{
+						Data: []string{param},
+					},
+				},
 			}, 0, nil)
 			if err != nil {
-				t.Errorf("error creating httpTokenSource: %v", err)
+				t.Errorf("error creating HTTP token source: %v", err)
 			}
-			ts := ots.(*httpTokenSource)
+			ts := ots.(*genericTokenSource)
 
-			ts.httpClient = &http.Client{
+			oldHTTPClient := httpClient
+			defer func() { httpClient = oldHTTPClient }()
+			httpClient = &http.Client{
 				Transport: &testTransport{
 					t:       t,
 					respMap: map[string]string{param: tt.httpResp},
@@ -128,11 +134,15 @@ func TestHTTPTokenSourceToken(t *testing.T) {
 func TestNewHTTPTokenSource(t *testing.T) {
 	testRefreshExpiryBuffer := 10 * time.Second
 
-	ts, _ := newHTTPTokenSource(&configpb.HTTPRequest{}, testRefreshExpiryBuffer, nil)
-	tc := ts.(*httpTokenSource).cache
+	ts, _ := newTokenSource(&configpb.Config{
+		Source: &configpb.Config_HttpRequest{
+			HttpRequest: &configpb.HTTPRequest{},
+		},
+	}, testRefreshExpiryBuffer, nil)
+
+	tc := ts.(*genericTokenSource).cache
 
 	assert.Equal(t, testRefreshExpiryBuffer, tc.refreshExpiryBuffer, "token cache refresh expiry buffer")
-	assert.Equal(t, tc.ignoreExpiryIfZero, false)
 }
 
 func TestRedact(t *testing.T) {

--- a/common/oauth/http_token_test.go
+++ b/common/oauth/http_token_test.go
@@ -131,20 +131,6 @@ func TestHTTPTokenSourceToken(t *testing.T) {
 	}
 }
 
-func TestNewHTTPTokenSource(t *testing.T) {
-	testRefreshExpiryBuffer := 10 * time.Second
-
-	ts, _ := newTokenSource(&configpb.Config{
-		Source: &configpb.Config_HttpRequest{
-			HttpRequest: &configpb.HTTPRequest{},
-		},
-	}, testRefreshExpiryBuffer, nil)
-
-	tc := ts.(*genericTokenSource).cache
-
-	assert.Equal(t, testRefreshExpiryBuffer, tc.refreshExpiryBuffer, "token cache refresh expiry buffer")
-}
-
 func TestRedact(t *testing.T) {
 	tests := []struct {
 		in   string

--- a/common/oauth/oauth_test.go
+++ b/common/oauth/oauth_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	configpb "github.com/cloudprober/cloudprober/common/oauth/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 func createTempFile(t *testing.T, b []byte) string {
@@ -69,7 +70,7 @@ func TestGoogleCredentials(t *testing.T) {
 	jsonF := createTempFile(t, []byte(testJSONKey()))
 
 	googleC := &configpb.GoogleCredentials{
-		JsonFile: jsonF,
+		JsonFile: proto.String(jsonF),
 	}
 
 	c := &configpb.Config{
@@ -84,7 +85,7 @@ func TestGoogleCredentials(t *testing.T) {
 	}
 
 	// Set audience, it should fail as jwt_as_access_token is not set.
-	googleC.Audience = "test-audience"
+	googleC.Audience = proto.String("test-audience")
 
 	_, err = TokenSourceFromConfig(c, nil)
 	if err == nil {
@@ -92,7 +93,7 @@ func TestGoogleCredentials(t *testing.T) {
 	}
 
 	// Set jwt_as_access_token, no errors now.
-	googleC.JwtAsAccessToken = true
+	googleC.JwtAsAccessToken = proto.Bool(true)
 
 	_, err = TokenSourceFromConfig(c, nil)
 	if err != nil {

--- a/common/oauth/proto/config.proto
+++ b/common/oauth/proto/config.proto
@@ -1,4 +1,4 @@
-syntax = "proto3";
+syntax = "proto2";
 
 package cloudprober.oauth;
 
@@ -33,24 +33,29 @@ message Config {
     BearerToken bearer_token = 7;
   }
 
-  // How long before the expiry do we refresh. Default is 60 (1m). This applies
-  // only to http_request and bearer_token types, and only if token presents
-  // expiry in some way.
+  // If auto-refreshing based on token's expiry, how long before the expiry do we
+  // refresh.
+  //
   // TODO(manugarg): Consider setting default based on probe interval.
-  optional int32 refresh_expiry_buffer_sec = 20;
+  optional int32 refresh_expiry_buffer_sec = 20 [default = 60];
 
-  // If above sources return a JSON token with an expiry, we use that info to
-  // determine when to refresh tokens and refresh_interval_sec is completely
-  // ignored. If above sources return a string, we refresh from the source
-  // every 30s by default. To disable this behavior set refresh_interval_sec to
-  // zero.
-  optional float refresh_interval_sec = 21;
+  // If set explicitly, we'll refresh token at this interval regardless of
+  // token's expiry value.
+  //
+  // If not set explicitly, we don't refresh at regular interval if token's
+  // expiry is set, otherwise we refresh at the default interval (30s).
+  //
+  // To disable refresh on interval even if expiry is not set, set this to 0.
+  //
+  // In most cases, Cloudprober does the right thing based on the retrieved
+  // token and you don't need to set this field.
+  optional float refresh_interval_sec = 21 [default = 30];
 }
 
 message HTTPRequest {
-  string token_url = 1;
+  required string token_url = 1;
   
-  string method = 2;
+  optional string method = 2;
 
   // Data to be sent as request body. If there are multiple "data" fields, we combine
   // their values with a '&' in between. Note: 1) If data appears to be a valid json,
@@ -97,13 +102,13 @@ message BearerToken {
 // Google credentials in JSON format. We simply use oauth2/google package to
 // use these credentials.
 message GoogleCredentials {
-  string json_file = 1;
+  optional string json_file = 1;
   repeated string scope = 2;
 
   // Use encoded JWT directly as access token, instead of implementing the whole
   // OAuth2.0 flow.
-  bool jwt_as_access_token = 4;
+  optional bool jwt_as_access_token = 4;
 
   // Audience works only if jwt_as_access_token is true.
-  string audience = 3;
+  optional string audience = 3;
 }

--- a/common/oauth/tokencache_test.go
+++ b/common/oauth/tokencache_test.go
@@ -55,15 +55,14 @@ func getTokenFunc(exp time.Time, failSecond bool) func() (*oauth2.Token, error) 
 	}
 }
 
-func Test_tokenCache_Token(t *testing.T) {
+func TestTokenCacheToken(t *testing.T) {
 	tests := []struct {
-		name               string
-		expiresIn          time.Duration
-		buffer             time.Duration
-		wait               time.Duration
-		ignoreExpiryIfZero bool
-		failSecond         bool
-		wantNewToken       bool
+		name         string
+		expiresIn    time.Duration
+		buffer       time.Duration
+		wait         time.Duration
+		failSecond   bool
+		wantNewToken bool
 	}{
 		{
 			name:         "expired_token_1ms_expiry",
@@ -76,14 +75,7 @@ func Test_tokenCache_Token(t *testing.T) {
 			name:         "zero_expiry",
 			expiresIn:    -1, // Sets expiry to 0.
 			wait:         1 * time.Millisecond,
-			wantNewToken: true,
-		},
-		{
-			name:               "zero_expiry_but_ignore",
-			expiresIn:          -1, // Sets expiry to 0.
-			ignoreExpiryIfZero: true,
-			wait:               1 * time.Millisecond,
-			wantNewToken:       false,
+			wantNewToken: false,
 		},
 		{
 			name:         "unexpired_but_out_of_default_expiry_buffer_60s",
@@ -107,12 +99,11 @@ func Test_tokenCache_Token(t *testing.T) {
 			wantNewToken: true,
 		},
 		{
-			name:               "renew_fails_return_cached_token",
-			failSecond:         true,
-			ignoreExpiryIfZero: true,
-			expiresIn:          time.Millisecond,
-			wait:               10 * time.Millisecond,
-			wantNewToken:       false,
+			name:         "renew_fails_return_cached_token",
+			failSecond:   true,
+			expiresIn:    time.Millisecond,
+			wait:         10 * time.Millisecond,
+			wantNewToken: false,
 		},
 	}
 	for _, tt := range tests {
@@ -126,7 +117,7 @@ func Test_tokenCache_Token(t *testing.T) {
 			tc := &tokenCache{
 				getToken:            getTokenFunc(exp, tt.failSecond),
 				refreshExpiryBuffer: tt.buffer,
-				ignoreExpiryIfZero:  tt.ignoreExpiryIfZero,
+				//ignoreExpiryIfZero:  tt.ignoreExpiryIfZero,
 			}
 
 			got, err := tc.Token()

--- a/common/oauth/tokensource.go
+++ b/common/oauth/tokensource.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"
@@ -32,6 +33,7 @@ import (
 )
 
 var k8sTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+var httpClient = http.DefaultClient
 
 type genericTokenSource struct {
 	c                   *configpb.Config
@@ -75,7 +77,7 @@ func readFromCommand(c *configpb.Config) (*oauth2.Token, error) {
 }
 
 var tokenFunctions = struct {
-	fromFile, fromCmd, fromGCEMetadata, fromK8sTokenFile func(c *configpb.Config) (*oauth2.Token, error)
+	fromFile, fromCmd, fromGCEMetadata, fromK8sTokenFile, fromHTTP func(c *configpb.Config) (*oauth2.Token, error)
 }{
 	fromFile: readFromFile,
 	fromCmd:  readFromCommand,
@@ -94,71 +96,98 @@ var tokenFunctions = struct {
 		}
 		return &oauth2.Token{AccessToken: string(b)}, nil
 	},
+	fromHTTP: func(c *configpb.Config) (*oauth2.Token, error) {
+		hc := c.GetHttpRequest()
+		req, err := newRequest(hc)
+		if err != nil {
+			return nil, err
+		}
+		return tokenFromHTTP(httpClient, req, &logger.Logger{})
+	},
+}
+
+func (ts *genericTokenSource) verifyTokenSource(c *configpb.Config) (*oauth2.Token, error) {
+	// For HTTP request, only verify that request parameters are correct.
+	if c.GetHttpRequest() != nil {
+		_, err := newRequest(c.GetHttpRequest())
+		if err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+	return ts.getTokenFromBackend(c)
+}
+
+func (ts *genericTokenSource) refreshOnInterval(initToken *oauth2.Token) bool {
+	if ts.c.GetRefreshIntervalSec() == 0 {
+		return false
+	}
+
+	// Set explicitly to non-zero value, we want to refresh regardless
+	if ts.c.RefreshIntervalSec != nil {
+		return true
+	}
+
+	// If we got a non-nil token but it doesn't have expiry, we refresh at
+	// default interval
+	if initToken != nil && initToken.Expiry.IsZero() {
+		return true
+	}
+
+	// This should handle the http request case, where we don't have initial
+	// token, but we don't want to refresh on interval as well, unless
+	// explicitly specified (covered in the first case).
+	return false
 }
 
 func newTokenSource(c *configpb.Config, refreshExpiryBuffer time.Duration, l *logger.Logger) (oauth2.TokenSource, error) {
-	// HTTP Request token source has its own implementation.
-	if c.GetHttpRequest() != nil {
-		return newHTTPTokenSource(c.GetHttpRequest(), refreshExpiryBuffer, l)
-	}
-
 	ts := &genericTokenSource{
 		c: c,
 		l: l,
 	}
 
-	var tokenBackendFunc func(*configpb.Config) (*oauth2.Token, error)
-
 	switch c.Source.(type) {
 	case *configpb.Config_File:
-		tokenBackendFunc = tokenFunctions.fromFile
+		ts.getTokenFromBackend = tokenFunctions.fromFile
+
+	case *configpb.Config_HttpRequest:
+		ts.getTokenFromBackend = tokenFunctions.fromHTTP
 
 	case *configpb.Config_Cmd:
-		tokenBackendFunc = tokenFunctions.fromCmd
+		ts.getTokenFromBackend = tokenFunctions.fromCmd
 
 	case *configpb.Config_GceServiceAccount:
-		tokenBackendFunc = tokenFunctions.fromGCEMetadata
+		ts.getTokenFromBackend = tokenFunctions.fromGCEMetadata
 
 	case *configpb.Config_K8SLocalToken:
 		if !c.GetK8SLocalToken() {
 			return nil, fmt.Errorf("k8s_local_token cannot be false, config: <%v>", c.String())
 		}
-		tokenBackendFunc = tokenFunctions.fromK8sTokenFile
+		ts.getTokenFromBackend = tokenFunctions.fromK8sTokenFile
 
 	default:
 		return nil, fmt.Errorf("unknown source: %v", c.Source)
 	}
 
-	ts.getTokenFromBackend = func(c *configpb.Config) (*oauth2.Token, error) {
-		l.Debugf("oauth.genericTokenSource: Getting a new token using config: %s", c.String())
-		return tokenBackendFunc(c)
-	}
-
-	tok, err := ts.getTokenFromBackend(c)
-	if err != nil {
-		return nil, err
-	}
 	ts.cache = &tokenCache{
-		tok:                 tok,
 		refreshExpiryBuffer: refreshExpiryBuffer,
-		ignoreExpiryIfZero:  true,
 		getToken:            func() (*oauth2.Token, error) { return ts.getTokenFromBackend(c) },
 		l:                   l,
 	}
 
-	// For JSON token that have expiry return now.
-	if tok != nil && !tok.Expiry.IsZero() {
+	// Verify and get initial token if available.
+	tok, err := ts.verifyTokenSource(c)
+	if err != nil {
+		return nil, err
+	}
+	ts.cache.tok = tok
+
+	if !ts.refreshOnInterval(tok) {
 		return ts, nil
 	}
 
-	// Default refresh interval
-	if ts.c.RefreshIntervalSec == nil {
-		ts.c.RefreshIntervalSec = proto.Float32(30)
-	}
-	// Explicitly set to zero, so no refreshing.
-	if ts.c.GetRefreshIntervalSec() == 0 {
-		return ts, nil
-	}
+	// Since we're refreshing at regular interval, disable refreshing in cache.
+	ts.cache.disableRefresh = true
 
 	go func() {
 		interval := time.Duration(ts.c.GetRefreshIntervalSec()) * time.Second

--- a/common/oauth/tokensource.go
+++ b/common/oauth/tokensource.go
@@ -187,7 +187,7 @@ func newTokenSource(c *configpb.Config, refreshExpiryBuffer time.Duration, l *lo
 	}
 
 	// Since we're refreshing at regular interval, disable refreshing in cache.
-	ts.cache.disableRefresh = true
+	ts.cache.refreshingOnInterval = true
 
 	go func() {
 		interval := time.Duration(ts.c.GetRefreshIntervalSec()) * time.Second

--- a/probes/browser/artifacts/storage/storage_abs.go
+++ b/probes/browser/artifacts/storage/storage_abs.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cloudprober/cloudprober/logger"
 	configpb "github.com/cloudprober/cloudprober/probes/browser/artifacts/proto"
 	"golang.org/x/oauth2"
+	"google.golang.org/protobuf/proto"
 )
 
 type ABS struct {
@@ -82,7 +83,7 @@ func (s *ABS) initAuth(ctx context.Context, cfg *configpb.ABS) error {
 	oauthTS, err := oauth.TokenSourceFromConfig(&oauthconfigpb.Config{
 		Source: &oauthconfigpb.Config_HttpRequest{
 			HttpRequest: &oauthconfigpb.HTTPRequest{
-				TokenUrl: identityEndpoint,
+				TokenUrl: proto.String(identityEndpoint),
 				Header: map[string]string{
 					"Metadata": "true",
 				},


### PR DESCRIPTION
- Merge some of the http_token logic into tokensource.go to make it more consistent with other types and reduce some duplication.
- This change also allows http_token to be refreshed at interval if `refresh_interval_sec` is explicitly given.