### PR TITLE
[probes.tcp] Add TLS support to TCP probe

### DIFF
--- a/probes/tcp/proto/config.pb.go
+++ b/probes/tcp/proto/config.pb.go
@@ -29,6 +29,8 @@ type ProbeConf struct {
 	// targets (e.g. kubernetes endpoint or service), that port is used.
 	Port *int32 `protobuf:"varint,1,opt,name=port" json:"port,omitempty"`
 	// Whether to perform a TLS handshake after TCP connection is established.
+	// When TLS handshake is enabled, we export two additional metrics:
+	// - connect_latency and tls_handshake_latency.
 	TlsHandshake *bool `protobuf:"varint,2,opt,name=tls_handshake,json=tlsHandshake,def=0" json:"tls_handshake,omitempty"`
 	// TLS configuration for TLS handshake.
 	TlsConfig *proto.TLSConfig `protobuf:"bytes,3,opt,name=tls_config,json=tlsConfig" json:"tls_config,omitempty"`

--- a/probes/tcp/proto/config.pb.go
+++ b/probes/tcp/proto/config.pb.go
@@ -7,6 +7,7 @@
 package proto
 
 import (
+	proto "github.com/cloudprober/cloudprober/common/tlsconfig/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -27,20 +28,25 @@ type ProbeConf struct {
 	// Port for TCP requests. If not specfied, and port is provided by the
 	// targets (e.g. kubernetes endpoint or service), that port is used.
 	Port *int32 `protobuf:"varint,1,opt,name=port" json:"port,omitempty"`
+	// Whether to perform a TLS handshake after TCP connection is established.
+	TlsHandshake *bool `protobuf:"varint,2,opt,name=tls_handshake,json=tlsHandshake,def=0" json:"tls_handshake,omitempty"`
+	// TLS configuration for TLS handshake.
+	TlsConfig *proto.TLSConfig `protobuf:"bytes,3,opt,name=tls_config,json=tlsConfig" json:"tls_config,omitempty"`
 	// Whether to resolve the target before making the request. If set to false,
 	// we hand over the target golang's net.Dial module, Otherwise, we resolve
 	// the target first to an IP address and make a request using that. By
 	// default we resolve first if it's a discovered resource, e.g., a k8s
 	// endpoint.
-	ResolveFirst *bool `protobuf:"varint,2,opt,name=resolve_first,json=resolveFirst" json:"resolve_first,omitempty"`
+	ResolveFirst *bool `protobuf:"varint,4,opt,name=resolve_first,json=resolveFirst" json:"resolve_first,omitempty"`
 	// Interval between targets.
-	IntervalBetweenTargetsMsec *int32 `protobuf:"varint,3,opt,name=interval_between_targets_msec,json=intervalBetweenTargetsMsec,def=10" json:"interval_between_targets_msec,omitempty"`
+	IntervalBetweenTargetsMsec *int32 `protobuf:"varint,5,opt,name=interval_between_targets_msec,json=intervalBetweenTargetsMsec,def=10" json:"interval_between_targets_msec,omitempty"`
 	unknownFields              protoimpl.UnknownFields
 	sizeCache                  protoimpl.SizeCache
 }
 
 // Default values for ProbeConf fields.
 const (
+	Default_ProbeConf_TlsHandshake               = bool(false)
 	Default_ProbeConf_IntervalBetweenTargetsMsec = int32(10)
 )
 
@@ -81,6 +87,20 @@ func (x *ProbeConf) GetPort() int32 {
 	return 0
 }
 
+func (x *ProbeConf) GetTlsHandshake() bool {
+	if x != nil && x.TlsHandshake != nil {
+		return *x.TlsHandshake
+	}
+	return Default_ProbeConf_TlsHandshake
+}
+
+func (x *ProbeConf) GetTlsConfig() *proto.TLSConfig {
+	if x != nil {
+		return x.TlsConfig
+	}
+	return nil
+}
+
 func (x *ProbeConf) GetResolveFirst() bool {
 	if x != nil && x.ResolveFirst != nil {
 		return *x.ResolveFirst
@@ -99,11 +119,14 @@ var File_github_com_cloudprober_cloudprober_probes_tcp_proto_config_proto protor
 
 const file_github_com_cloudprober_cloudprober_probes_tcp_proto_config_proto_rawDesc = "" +
 	"\n" +
-	"@github.com/cloudprober/cloudprober/probes/tcp/proto/config.proto\x12\x16cloudprober.probes.tcp\"\x8b\x01\n" +
+	"@github.com/cloudprober/cloudprober/probes/tcp/proto/config.proto\x12\x16cloudprober.probes.tcp\x1aFgithub.com/cloudprober/cloudprober/common/tlsconfig/proto/config.proto\"\xf8\x01\n" +
 	"\tProbeConf\x12\x12\n" +
-	"\x04port\x18\x01 \x01(\x05R\x04port\x12#\n" +
-	"\rresolve_first\x18\x02 \x01(\bR\fresolveFirst\x12E\n" +
-	"\x1dinterval_between_targets_msec\x18\x03 \x01(\x05:\x0210R\x1aintervalBetweenTargetsMsecB5Z3github.com/cloudprober/cloudprober/probes/tcp/proto"
+	"\x04port\x18\x01 \x01(\x05R\x04port\x12*\n" +
+	"\rtls_handshake\x18\x02 \x01(\b:\x05falseR\ftlsHandshake\x12?\n" +
+	"\n" +
+	"tls_config\x18\x03 \x01(\v2 .cloudprober.tlsconfig.TLSConfigR\ttlsConfig\x12#\n" +
+	"\rresolve_first\x18\x04 \x01(\bR\fresolveFirst\x12E\n" +
+	"\x1dinterval_between_targets_msec\x18\x05 \x01(\x05:\x0210R\x1aintervalBetweenTargetsMsecB5Z3github.com/cloudprober/cloudprober/probes/tcp/proto"
 
 var (
 	file_github_com_cloudprober_cloudprober_probes_tcp_proto_config_proto_rawDescOnce sync.Once
@@ -119,14 +142,16 @@ func file_github_com_cloudprober_cloudprober_probes_tcp_proto_config_proto_rawDe
 
 var file_github_com_cloudprober_cloudprober_probes_tcp_proto_config_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_github_com_cloudprober_cloudprober_probes_tcp_proto_config_proto_goTypes = []any{
-	(*ProbeConf)(nil), // 0: cloudprober.probes.tcp.ProbeConf
+	(*ProbeConf)(nil),       // 0: cloudprober.probes.tcp.ProbeConf
+	(*proto.TLSConfig)(nil), // 1: cloudprober.tlsconfig.TLSConfig
 }
 var file_github_com_cloudprober_cloudprober_probes_tcp_proto_config_proto_depIdxs = []int32{
-	0, // [0:0] is the sub-list for method output_type
-	0, // [0:0] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	1, // 0: cloudprober.probes.tcp.ProbeConf.tls_config:type_name -> cloudprober.tlsconfig.TLSConfig
+	1, // [1:1] is the sub-list for method output_type
+	1, // [1:1] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_github_com_cloudprober_cloudprober_probes_tcp_proto_config_proto_init() }

--- a/probes/tcp/proto/config.proto
+++ b/probes/tcp/proto/config.proto
@@ -2,6 +2,8 @@ syntax = "proto2";
 
 package cloudprober.probes.tcp;
 
+import "github.com/cloudprober/cloudprober/common/tlsconfig/proto/config.proto";
+
 option go_package = "github.com/cloudprober/cloudprober/probes/tcp/proto";
 
 // Next tag: 4
@@ -10,13 +12,19 @@ message ProbeConf {
   // targets (e.g. kubernetes endpoint or service), that port is used.
   optional int32 port = 1;
 
+  // Whether to perform a TLS handshake after TCP connection is established.
+  optional bool tls_handshake = 2 [default = false];
+  
+  // TLS configuration for TLS handshake.
+  optional tlsconfig.TLSConfig tls_config = 3;
+
   // Whether to resolve the target before making the request. If set to false,
   // we hand over the target golang's net.Dial module, Otherwise, we resolve
   // the target first to an IP address and make a request using that. By
   // default we resolve first if it's a discovered resource, e.g., a k8s
   // endpoint.
-  optional bool resolve_first = 2;
+  optional bool resolve_first = 4;
 
   // Interval between targets.
-  optional int32 interval_between_targets_msec = 3 [default = 10];
+  optional int32 interval_between_targets_msec = 5 [default = 10];
 }

--- a/probes/tcp/proto/config.proto
+++ b/probes/tcp/proto/config.proto
@@ -13,6 +13,8 @@ message ProbeConf {
   optional int32 port = 1;
 
   // Whether to perform a TLS handshake after TCP connection is established.
+  // When TLS handshake is enabled, we export two additional metrics:
+  // - connect_latency and tls_handshake_latency.
   optional bool tls_handshake = 2 [default = false];
   
   // TLS configuration for TLS handshake.

--- a/probes/tcp/tcp.go
+++ b/probes/tcp/tcp.go
@@ -17,17 +17,20 @@ package tcp
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"strconv"
 	"time"
 
+	"github.com/cloudprober/cloudprober/common/tlsconfig"
 	"github.com/cloudprober/cloudprober/internal/validators"
 	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/metrics"
 	"github.com/cloudprober/cloudprober/probes/common/sched"
 	"github.com/cloudprober/cloudprober/probes/options"
 	configpb "github.com/cloudprober/cloudprober/probes/tcp/proto"
+	"google.golang.org/protobuf/proto"
 )
 
 // Probe holds aggregate information about all probe runs, per-target.
@@ -38,14 +41,18 @@ type Probe struct {
 	l    *logger.Logger
 
 	// book-keeping params
-	network     string
-	dialContext func(context.Context, string, string) (net.Conn, error) // Keeps some dialing related config
+	network          string
+	tlsConfig        *tls.Config
+	dialContext      func(context.Context, string, string) (net.Conn, error) // Keeps some dialing related config
+	handshakeContext func(context.Context, *tls.Conn) error
 }
 
 type probeResult struct {
-	total, success    int64
-	latency           metrics.LatencyValue
-	validationFailure *metrics.Map[int64]
+	total, success      int64
+	latency             metrics.LatencyValue
+	connLatency         metrics.LatencyValue
+	tlsHandshakeLatency metrics.LatencyValue
+	validationFailure   *metrics.Map[int64]
 }
 
 func (p *Probe) newResult() sched.ProbeResult {
@@ -61,6 +68,16 @@ func (p *Probe) newResult() sched.ProbeResult {
 		result.latency = metrics.NewFloat(0)
 	}
 
+	if p.c.GetTlsHandshake() {
+		if p.opts.LatencyDist != nil {
+			result.connLatency = p.opts.LatencyDist.CloneDist()
+			result.tlsHandshakeLatency = p.opts.LatencyDist.CloneDist()
+		} else {
+			result.connLatency = metrics.NewFloat(0)
+			result.tlsHandshakeLatency = metrics.NewFloat(0)
+		}
+	}
+
 	return result
 }
 
@@ -70,6 +87,12 @@ func (result *probeResult) Metrics(ts time.Time, _ int64, opts *options.Options)
 		AddMetric("success", metrics.NewInt(result.success)).
 		AddMetric(opts.LatencyMetricName, result.latency.Clone()).
 		AddLabel("ptype", "tcp")
+
+	// If TLS handshake is enabled, add conn and tls_handshake latency metrics.
+	if result.tlsHandshakeLatency != nil {
+		em.AddMetric("connect_latency", result.connLatency.Clone())
+		em.AddMetric("tls_handshake_latency", result.tlsHandshakeLatency.Clone())
+	}
 
 	if result.validationFailure != nil {
 		em.AddMetric("validation_failure", result.validationFailure)
@@ -116,7 +139,48 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 	}
 	p.dialContext = dialer.DialContext
 
+	if p.c.GetTlsConfig() != nil {
+		if p.c.TlsHandshake == nil {
+			p.c.TlsHandshake = proto.Bool(true)
+		}
+
+		// tls_handshake is explicitly set to false, return error
+		if !p.c.GetTlsHandshake() {
+			return fmt.Errorf("tls_config is set, but tls_handshake is false")
+		}
+
+		p.tlsConfig = &tls.Config{}
+		if err := tlsconfig.UpdateTLSConfig(p.tlsConfig, p.c.GetTlsConfig()); err != nil {
+			return fmt.Errorf("tls_config error: %v", err)
+		}
+	}
+
 	return nil
+}
+
+func (p *Probe) connectAndHandshake(ctx context.Context, addr string, result *probeResult) (net.Conn, error) {
+	start := time.Now()
+	conn, err := p.dialContext(ctx, p.network, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	if p.c.GetTlsHandshake() {
+		result.connLatency.AddFloat64(time.Since(start).Seconds() / p.opts.LatencyUnit.Seconds())
+		start = time.Now()
+		tlsClient := tls.Client(conn, p.tlsConfig)
+		if p.handshakeContext == nil {
+			p.handshakeContext = func(ctx context.Context, tlsClient *tls.Conn) error {
+				return tlsClient.HandshakeContext(ctx)
+			}
+		}
+		if err := p.handshakeContext(ctx, tlsClient); err != nil {
+			return nil, err
+		}
+		result.tlsHandshakeLatency.AddFloat64(time.Since(start).Seconds() / p.opts.LatencyUnit.Seconds())
+	}
+
+	return conn, nil
 }
 
 func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetRequest) {
@@ -158,7 +222,7 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 	addr := net.JoinHostPort(host, strconv.Itoa(port))
 
 	start := time.Now()
-	conn, err := p.dialContext(ctx, p.network, addr)
+	conn, err := p.connectAndHandshake(ctx, addr, result)
 	latency := time.Since(start)
 	if conn != nil {
 		defer conn.Close()

--- a/probes/tcp/tcp_test.go
+++ b/probes/tcp/tcp_test.go
@@ -178,6 +178,7 @@ func TestConnectAndHandshake(t *testing.T) {
 			}
 
 			p.dialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				time.Sleep(1 * time.Millisecond)
 				if addr == test.addr && test.dialError == nil {
 					return &net.TCPConn{}, nil
 				}
@@ -185,6 +186,7 @@ func TestConnectAndHandshake(t *testing.T) {
 			}
 
 			p.handshakeContext = func(ctx context.Context, tlsClient *tls.Conn) error {
+				time.Sleep(1 * time.Millisecond)
 				return test.handshakeError
 			}
 

--- a/probes/tcp/tcp_test.go
+++ b/probes/tcp/tcp_test.go
@@ -16,15 +16,21 @@ package tcp
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/cloudprober/cloudprober/metrics"
 	"github.com/cloudprober/cloudprober/probes/common/sched"
 	"github.com/cloudprober/cloudprober/probes/options"
+	configpb "github.com/cloudprober/cloudprober/probes/tcp/proto"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
 )
 
 type dialState struct {
@@ -114,4 +120,191 @@ func TestRunProbe(t *testing.T) {
 		})
 	}
 
+}
+
+func TestConnectAndHandshake(t *testing.T) {
+	tests := []struct {
+		desc                   string
+		addr                   string
+		tlsHandshakeEnabled    bool
+		dialError              error
+		handshakeError         error
+		wantSuccess            bool
+		wantNonZeroConnLatency bool
+		wantNonZeroTLSLatency  bool
+	}{
+		{
+			desc:                   "success-with-tls-handshake",
+			addr:                   "test.com:443",
+			tlsHandshakeEnabled:    true,
+			wantSuccess:            true,
+			wantNonZeroConnLatency: true,
+			wantNonZeroTLSLatency:  true,
+		},
+		{
+			desc:                "success-without-tls-handshake",
+			addr:                "test.com:80",
+			tlsHandshakeEnabled: false,
+			wantSuccess:         true,
+		},
+		{
+			desc:                "dial-error",
+			addr:                "invalid.com:80",
+			tlsHandshakeEnabled: true,
+			dialError:           fmt.Errorf("dial error"),
+			wantSuccess:         false,
+		},
+		{
+			desc:                   "handshake-error",
+			addr:                   "test.com:443",
+			tlsHandshakeEnabled:    true,
+			handshakeError:         fmt.Errorf("handshake error"),
+			wantSuccess:            false,
+			wantNonZeroConnLatency: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			p := &Probe{}
+			opts := options.DefaultOptions()
+			p.opts = opts
+			p.network = "tcp"
+			p.c = &configpb.ProbeConf{}
+			p.tlsConfig = &tls.Config{}
+
+			if test.tlsHandshakeEnabled {
+				p.c.TlsHandshake = proto.Bool(true)
+			}
+
+			p.dialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				if addr == test.addr && test.dialError == nil {
+					return &net.TCPConn{}, nil
+				}
+				return nil, test.dialError
+			}
+
+			p.handshakeContext = func(ctx context.Context, tlsClient *tls.Conn) error {
+				return test.handshakeError
+			}
+
+			result := &probeResult{
+				connLatency:         metrics.NewFloat(0),
+				tlsHandshakeLatency: metrics.NewFloat(0),
+			}
+
+			conn, err := p.connectAndHandshake(context.Background(), test.addr, result)
+
+			if test.wantSuccess {
+				if err != nil {
+					t.Errorf("Expected success, but got error: %v", err)
+				}
+				if conn == nil {
+					t.Errorf("Expected a valid connection, but got nil")
+				}
+			} else {
+				if err == nil {
+					t.Errorf("Expected error, but got success")
+				}
+			}
+
+			if test.wantNonZeroConnLatency {
+				assert.NotZero(t, result.connLatency.(*metrics.Float).Float64(), "Expected non-zero connection latency")
+			} else {
+				assert.Zero(t, result.connLatency.(*metrics.Float).Float64(), "Expected zero connection latency")
+			}
+			if test.wantNonZeroTLSLatency {
+				assert.NotZero(t, result.tlsHandshakeLatency.(*metrics.Float).Float64(), "Expected non-zero TLS handshake latency")
+			} else {
+				assert.Zero(t, result.tlsHandshakeLatency.(*metrics.Float).Float64(), "Expected zero TLS handshake latency")
+			}
+		})
+	}
+}
+
+func TestNewResultAndMetrics(t *testing.T) {
+	total, success := int64(10), int64(8)
+	connLatency := metrics.NewFloat(0.1)
+	tlsHandshakeLatency := metrics.NewFloat(0.2)
+
+	tests := []struct {
+		desc                    string
+		enableTlsHandshake      bool
+		wantMetrics             map[string]int64
+		wantConnLatency         float64
+		wantTLSHandshakeLatency float64
+	}{
+		{
+			desc: "basic-metrics",
+			wantMetrics: map[string]int64{
+				"total":   total,
+				"success": success,
+			},
+			wantConnLatency:         -1,
+			wantTLSHandshakeLatency: -1,
+		},
+		{
+			desc:               "metrics-with-tls-handshake",
+			enableTlsHandshake: true,
+			wantMetrics: map[string]int64{
+				"total":   total,
+				"success": success,
+			},
+			wantConnLatency:         0.1,
+			wantTLSHandshakeLatency: 0.2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ts := time.Now()
+
+			p := &Probe{
+				opts: options.DefaultOptions(),
+			}
+			p.c = &configpb.ProbeConf{}
+			if test.enableTlsHandshake {
+				p.c.TlsHandshake = proto.Bool(true)
+			}
+
+			result := p.newResult().(*probeResult)
+			result.total = total
+			result.success = success
+			// Verify that connLatency and tlsHandshakeLatency are initialized
+			if test.enableTlsHandshake {
+				assert.NotNil(t, result.connLatency)
+				assert.NotNil(t, result.tlsHandshakeLatency)
+				result.connLatency = connLatency
+				result.tlsHandshakeLatency = tlsHandshakeLatency
+			}
+
+			emList := result.Metrics(ts, 0, &options.Options{})
+			if len(emList) != 1 {
+				t.Fatalf("Expected 1 EventMetrics, got %d", len(emList))
+			}
+
+			em := emList[0]
+
+			// Verify metrics
+			for metricName, wantValue := range test.wantMetrics {
+				assert.Equal(t, wantValue, em.Metric(metricName).(*metrics.Int).Int64())
+			}
+
+			// Verify label
+			assert.Equal(t, "tcp", em.Label("ptype"))
+
+			// Verify conn_latency and tls_handshake_latency if applicable
+			if test.wantConnLatency == -1 {
+				assert.Nil(t, em.Metric("connect_latency"))
+			} else {
+				assert.Equal(t, test.wantConnLatency, em.Metric("connect_latency").(*metrics.Float).Float64())
+			}
+
+			if test.wantTLSHandshakeLatency == -1 {
+				assert.Nil(t, em.Metric("tls_handshake_latency"))
+			} else {
+				assert.Equal(t, test.wantTLSHandshakeLatency, em.Metric("tls_handshake_latency").(*metrics.Float).Float64())
+			}
+		})
+	}
 }


### PR DESCRIPTION
- Add TLS check to TCP probe by just adding `tls_handshake` to `tcp_probe`.