### PR TITLE
[prober] Improve inter-probe wait for large interval probes

### DIFF
--- a/prober/prober_test.go
+++ b/prober/prober_test.go
@@ -103,7 +103,7 @@ func TestInterProbeWait(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s:%d", tt.interval, tt.numProbes), func(t *testing.T) {
-			assert.Equal(t, tt.wantGap, interProbeWait(tt.interval, tt.numProbes))
+			assert.Equal(t, tt.wantGap, interProbeGap(tt.interval, tt.numProbes))
 		})
 	}
 }

--- a/prober/prober_test.go
+++ b/prober/prober_test.go
@@ -33,27 +33,33 @@ import (
 
 func TestRandomDuration(t *testing.T) {
 	tests := []struct {
-		duration time.Duration
-		ceiling  time.Duration
+		duration        time.Duration
+		wantMaxDuration time.Duration
 	}{
 		{
-			duration: 0,
-			ceiling:  10 * time.Second,
+			duration:        0,
+			wantMaxDuration: 0,
 		},
 		{
-			duration: 5 * time.Second,
-			ceiling:  10 * time.Second,
+			duration:        5 * time.Second,
+			wantMaxDuration: 5 * time.Second,
 		},
 		{
-			duration: 30 * time.Second,
-			ceiling:  10 * time.Second,
+			duration:        30 * time.Second,
+			wantMaxDuration: 30 * time.Second,
+		},
+		{
+			duration:        10 * time.Minute,
+			wantMaxDuration: 1 * time.Minute,
+		},
+		{
+			duration:        1 * time.Hour,
+			wantMaxDuration: 1 * time.Minute,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%v", tt), func(t *testing.T) {
-			got := randomDuration(tt.duration, tt.ceiling)
-			assert.LessOrEqual(t, got, tt.duration)
-			assert.LessOrEqual(t, got, tt.ceiling)
+			assert.LessOrEqual(t, randomDuration(tt.duration), tt.wantMaxDuration)
 		})
 	}
 }
@@ -62,22 +68,42 @@ func TestInterProbeWait(t *testing.T) {
 	tests := []struct {
 		interval  time.Duration
 		numProbes int
-		want      time.Duration
+		wantGap   time.Duration
 	}{
 		{
-			interval:  2 * time.Second,
-			numProbes: 16,
-			want:      125 * time.Millisecond,
+			interval:  5 * time.Second,
+			numProbes: 20,
+			wantGap:   250 * time.Millisecond, // Last at 4.75s
 		},
 		{
 			interval:  30 * time.Second,
 			numProbes: 12,
-			want:      2 * time.Second,
+			wantGap:   2500 * time.Millisecond, // Last at 29.5s
+		},
+		{
+			interval:  5 * time.Minute,
+			numProbes: 4,
+			wantGap:   1 * time.Minute, // Last at 3m
+		},
+		{
+			interval:  10 * time.Minute,
+			numProbes: 6,
+			wantGap:   1 * time.Minute, // Last at 5m
+		},
+		{
+			interval:  1 * time.Hour,
+			numProbes: 12,
+			wantGap:   1 * time.Minute, // Last at 11m
+		},
+		{
+			interval:  24 * time.Hour,
+			numProbes: 3,
+			wantGap:   1 * time.Minute,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s:%d", tt.interval, tt.numProbes), func(t *testing.T) {
-			assert.Equal(t, tt.want, interProbeWait(tt.interval, tt.numProbes))
+			assert.Equal(t, tt.wantGap, interProbeWait(tt.interval, tt.numProbes))
 		})
 	}
 }


### PR DESCRIPTION
The way we spread probes is like this:

We arrange probes into interval buckets. Then:
- In each interval bucket, we spread the probes equally, i.e. we sleep for a fixed duration before starting the next probe. This gap between the probes (interProbeGap) was capped at 2s, this PR raises the cap to 1min.
- Each interval bucket is randomly spaced out from each other, but that space is capped at minimum of interval and 10s (this is also changing to 1m).

This behavior was initially introduced for high frequency native probes (<2s interval) that's why we capped inter-probe gap at 2s and interval bucket start delay at 10s. Idea was that 2s gap should be good enough for native probe types (e.g. HTTP) from performance impact point of view.

Now, with the introduction of browser probe types, this doesn't hold true. Browser probes require a ton of memory and CPU, and they usually have a higher interval, say 2-15min. If we have 6 browser probes as 10 min interval, we don't want them to start at 2s gap. This PR raise the max gap from 2s to 1min. We don't want this gap to be too high as the last probe in the interval bucket will start after (n-1)*gapDuration, moreover we may not benefit from a gap greater than 1m.

(Note to self: We should probably make this inter probe gap configurable.)

Fixes: #1070 