### PR TITLE
[probes.browser] Make accessing playwright reports quicker

### DIFF
--- a/probes/browser/artifacts/artifacts.go
+++ b/probes/browser/artifacts/artifacts.go
@@ -34,7 +34,8 @@ import (
 var initGlobalServingOnce sync.Once
 
 type ArtifactsHandler struct {
-	basePath        string
+	destPathFn func(string) (string, error)
+
 	s3Storage       []*storage.S3
 	gcsStorage      []*storage.GCS
 	absStorage      []*storage.ABS
@@ -123,10 +124,10 @@ func initGlobalArtifactsServing(opts *configpb.ArtifactsOptions, l *logger.Logge
 	return err
 }
 
-func InitArtifactsHandler(ctx context.Context, opts *configpb.ArtifactsOptions, outputDir string, pOpts *options.Options, l *logger.Logger) (*ArtifactsHandler, error) {
+func InitArtifactsHandler(ctx context.Context, opts *configpb.ArtifactsOptions, outputDir string, pOpts *options.Options, destPathFn func(string) (string, error), l *logger.Logger) (*ArtifactsHandler, error) {
 	ah := &ArtifactsHandler{
-		basePath: outputDir,
-		l:        l,
+		destPathFn: destPathFn,
+		l:          l,
 	}
 
 	if opts == nil {
@@ -205,7 +206,7 @@ func InitArtifactsHandler(ctx context.Context, opts *configpb.ArtifactsOptions, 
 func (ah *ArtifactsHandler) Handle(ctx context.Context, path string) {
 	for _, s3 := range ah.s3Storage {
 		go func(s3 *storage.S3) {
-			if err := s3.Store(ctx, path, ah.basePath); err != nil {
+			if err := s3.Store(ctx, path, ah.destPathFn); err != nil {
 				ah.l.Errorf("error uploading artifacts to S3: %v", err)
 			}
 		}(s3)
@@ -213,7 +214,7 @@ func (ah *ArtifactsHandler) Handle(ctx context.Context, path string) {
 
 	for _, gcs := range ah.gcsStorage {
 		go func(gcs *storage.GCS) {
-			if err := gcs.Store(ctx, path, ah.basePath); err != nil {
+			if err := gcs.Store(ctx, path, ah.destPathFn); err != nil {
 				ah.l.Errorf("error uploading artifacts to GCS: %v", err)
 			}
 		}(gcs)
@@ -221,7 +222,7 @@ func (ah *ArtifactsHandler) Handle(ctx context.Context, path string) {
 
 	for _, abs := range ah.absStorage {
 		go func(abs *storage.ABS) {
-			if err := abs.Store(ctx, path, ah.basePath); err != nil {
+			if err := abs.Store(ctx, path, ah.destPathFn); err != nil {
 				ah.l.Errorf("error uploading artifacts to ABS: %v", err)
 			}
 		}(abs)
@@ -229,7 +230,7 @@ func (ah *ArtifactsHandler) Handle(ctx context.Context, path string) {
 
 	for _, lStorage := range ah.localStorage {
 		go func(lStorage *storage.Local) {
-			if err := lStorage.Store(ctx, path, ah.basePath); err != nil {
+			if err := lStorage.Store(ctx, path, ah.destPathFn); err != nil {
 				ah.l.Errorf("error saving artifacts locally: %v", err)
 			}
 		}(lStorage)

--- a/probes/browser/artifacts/artifacts.go
+++ b/probes/browser/artifacts/artifacts.go
@@ -34,7 +34,7 @@ import (
 var initGlobalServingOnce sync.Once
 
 type ArtifactsHandler struct {
-	destPathFn func(string) (string, error)
+	destPathFn func(string) string
 
 	s3Storage       []*storage.S3
 	gcsStorage      []*storage.GCS
@@ -124,7 +124,7 @@ func initGlobalArtifactsServing(opts *configpb.ArtifactsOptions, l *logger.Logge
 	return err
 }
 
-func InitArtifactsHandler(ctx context.Context, opts *configpb.ArtifactsOptions, outputDir string, pOpts *options.Options, destPathFn func(string) (string, error), l *logger.Logger) (*ArtifactsHandler, error) {
+func InitArtifactsHandler(ctx context.Context, opts *configpb.ArtifactsOptions, outputDir string, pOpts *options.Options, destPathFn func(string) string, l *logger.Logger) (*ArtifactsHandler, error) {
 	ah := &ArtifactsHandler{
 		destPathFn: destPathFn,
 		l:          l,

--- a/probes/browser/artifacts/storage/storage.go
+++ b/probes/browser/artifacts/storage/storage.go
@@ -25,13 +25,14 @@ import (
 	"github.com/cloudprober/cloudprober/logger"
 )
 
-// StripPathPartFn returns a function that strips a part from the path.
+// RemovePathSegmentFn returns a function that removes a segment from the path
+// and returns the relative path.
 // basePath is the base path to which the relative path is computed.
-// part is the part to be stripped from the path.
-func StripPathPartFn(basePath, part string) func(string) (string, error) {
+// segment is the segment to be removed from the path.
+func RemovePathSegmentFn(basePath, segment string) func(string) (string, error) {
 	return func(localPath string) (string, error) {
 		sep := string(filepath.Separator) // / on Unix, \ on Windows
-		return filepath.Rel(basePath, strings.Replace(localPath, sep+part+sep, sep, 1))
+		return filepath.Rel(basePath, strings.Replace(localPath, sep+segment+sep, sep, 1))
 	}
 }
 

--- a/probes/browser/artifacts/storage/storage_abs.go
+++ b/probes/browser/artifacts/storage/storage_abs.go
@@ -182,10 +182,10 @@ func (s *ABS) upload(ctx context.Context, r io.Reader, relPath string) error {
 }
 
 // store syncs a local directory to an S3 path
-func (s *ABS) Store(ctx context.Context, localPath, basePath string) error {
+func (s *ABS) Store(ctx context.Context, localPath string, destPathFn func(string) (string, error)) error {
 	s.l.Infof("Uploading artifacts from %s to: %s", localPath, s.endpoint)
 
-	return walkAndSave(ctx, localPath, basePath, func(ctx context.Context, r io.Reader, relPath string) error {
+	return walkAndSave(ctx, localPath, destPathFn, func(ctx context.Context, r io.Reader, relPath string) error {
 		return s.upload(ctx, r, relPath)
 	})
 }

--- a/probes/browser/artifacts/storage/storage_abs.go
+++ b/probes/browser/artifacts/storage/storage_abs.go
@@ -182,7 +182,7 @@ func (s *ABS) upload(ctx context.Context, r io.Reader, relPath string) error {
 }
 
 // store syncs a local directory to an S3 path
-func (s *ABS) Store(ctx context.Context, localPath string, destPathFn func(string) (string, error)) error {
+func (s *ABS) Store(ctx context.Context, localPath string, destPathFn func(string) string) error {
 	s.l.Infof("Uploading artifacts from %s to: %s", localPath, s.endpoint)
 
 	return walkAndSave(ctx, localPath, destPathFn, func(ctx context.Context, r io.Reader, relPath string) error {

--- a/probes/browser/artifacts/storage/storage_gcs.go
+++ b/probes/browser/artifacts/storage/storage_gcs.go
@@ -88,10 +88,10 @@ func (s *GCS) upload(ctx context.Context, r io.Reader, relPath string) error {
 }
 
 // store syncs a local directory to an S3 path
-func (s *GCS) Store(ctx context.Context, localPath, basePath string) error {
+func (s *GCS) Store(ctx context.Context, localPath string, destPathFn func(string) (string, error)) error {
 	s.l.Infof("Uploading artifacts from %s to: %s", localPath, s.baseURL)
 
-	return walkAndSave(ctx, localPath, basePath, func(ctx context.Context, r io.Reader, relPath string) error {
+	return walkAndSave(ctx, localPath, destPathFn, func(ctx context.Context, r io.Reader, relPath string) error {
 		return s.upload(ctx, r, relPath)
 	})
 }

--- a/probes/browser/artifacts/storage/storage_gcs.go
+++ b/probes/browser/artifacts/storage/storage_gcs.go
@@ -88,7 +88,7 @@ func (s *GCS) upload(ctx context.Context, r io.Reader, relPath string) error {
 }
 
 // store syncs a local directory to an S3 path
-func (s *GCS) Store(ctx context.Context, localPath string, destPathFn func(string) (string, error)) error {
+func (s *GCS) Store(ctx context.Context, localPath string, destPathFn func(string) string) error {
 	s.l.Infof("Uploading artifacts from %s to: %s", localPath, s.baseURL)
 
 	return walkAndSave(ctx, localPath, destPathFn, func(ctx context.Context, r io.Reader, relPath string) error {

--- a/probes/browser/artifacts/storage/storage_s3.go
+++ b/probes/browser/artifacts/storage/storage_s3.go
@@ -83,10 +83,10 @@ func InitS3(ctx context.Context, s3config *configpb.S3, storagePath string, l *l
 }
 
 // store syncs a local directory to an S3 path
-func (s *S3) Store(ctx context.Context, localPath, basePath string) error {
+func (s *S3) Store(ctx context.Context, localPath string, destPathFn func(string) (string, error)) error {
 	s.l.Infof("Uploading artifacts from %s to: s3://%s/%s", localPath, s.bucket, s.path)
 
-	return walkAndSave(ctx, localPath, basePath, func(ctx context.Context, r io.Reader, relPath string) error {
+	return walkAndSave(ctx, localPath, destPathFn, func(ctx context.Context, r io.Reader, relPath string) error {
 		s3Key := filepath.Join(s.path, relPath)
 
 		if _, err := s.client.PutObject(ctx, &s3.PutObjectInput{

--- a/probes/browser/artifacts/storage/storage_s3.go
+++ b/probes/browser/artifacts/storage/storage_s3.go
@@ -83,7 +83,7 @@ func InitS3(ctx context.Context, s3config *configpb.S3, storagePath string, l *l
 }
 
 // store syncs a local directory to an S3 path
-func (s *S3) Store(ctx context.Context, localPath string, destPathFn func(string) (string, error)) error {
+func (s *S3) Store(ctx context.Context, localPath string, destPathFn func(string) string) error {
 	s.l.Infof("Uploading artifacts from %s to: s3://%s/%s", localPath, s.bucket, s.path)
 
 	return walkAndSave(ctx, localPath, destPathFn, func(ctx context.Context, r io.Reader, relPath string) error {

--- a/probes/browser/artifacts/storage/storage_test.go
+++ b/probes/browser/artifacts/storage/storage_test.go
@@ -52,7 +52,7 @@ func TestWalkAndSave(t *testing.T) {
 	tests := []struct {
 		name       string
 		localPath  string
-		destPathFn func(string) (string, error)
+		destPathFn func(string) string
 		wantFiles  map[string]string
 		wantErr    bool
 	}{
@@ -110,8 +110,9 @@ func TestWalkAndSave(t *testing.T) {
 			}
 
 			if tt.destPathFn == nil {
-				tt.destPathFn = func(in string) (string, error) {
-					return filepath.Rel(tempDir, in)
+				tt.destPathFn = func(in string) string {
+					path, _ := filepath.Rel(tempDir, in)
+					return path
 				}
 			}
 

--- a/probes/browser/artifacts/storage/storage_test.go
+++ b/probes/browser/artifacts/storage/storage_test.go
@@ -50,10 +50,11 @@ func TestWalkAndSave(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		localPath string
-		wantFiles map[string]string
-		wantErr   bool
+		name       string
+		localPath  string
+		destPathFn func(string) (string, error)
+		wantFiles  map[string]string
+		wantErr    bool
 	}{
 		{
 			name:      "Valid walk and save - 1",
@@ -61,6 +62,24 @@ func TestWalkAndSave(t *testing.T) {
 			wantFiles: map[string]string{
 				"date1/ts1/report/data/file.png": "image1",
 				"date1/ts1/report/index.html":    "report1",
+			},
+		},
+		{
+			name:       "Valid walk and save - with stripPathFn",
+			localPath:  filepath.Join(tempDir, "date1/ts1/report"),
+			destPathFn: StripPathPartFn(tempDir, "report"),
+			wantFiles: map[string]string{
+				"date1/ts1/data/file.png": "image1",
+				"date1/ts1/index.html":    "report1",
+			},
+		},
+		{
+			name:       "Valid walk and save - with stripPathFn - 2",
+			localPath:  filepath.Join(tempDir, "date1/ts1/report"),
+			destPathFn: StripPathPartFn(tempDir, "date1"),
+			wantFiles: map[string]string{
+				"ts1/report/data/file.png": "image1",
+				"ts1/report/index.html":    "report1",
 			},
 		},
 		{
@@ -90,7 +109,13 @@ func TestWalkAndSave(t *testing.T) {
 				return nil
 			}
 
-			err := walkAndSave(context.TODO(), tt.localPath, tempDir, fn)
+			if tt.destPathFn == nil {
+				tt.destPathFn = func(in string) (string, error) {
+					return filepath.Rel(tempDir, in)
+				}
+			}
+
+			err := walkAndSave(context.TODO(), tt.localPath, tt.destPathFn, fn)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("walkAndSave() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/probes/browser/artifacts/storage/storage_test.go
+++ b/probes/browser/artifacts/storage/storage_test.go
@@ -67,7 +67,7 @@ func TestWalkAndSave(t *testing.T) {
 		{
 			name:       "Valid walk and save - with stripPathFn",
 			localPath:  filepath.Join(tempDir, "date1/ts1/report"),
-			destPathFn: StripPathPartFn(tempDir, "report"),
+			destPathFn: RemovePathSegmentFn(tempDir, "report"),
 			wantFiles: map[string]string{
 				"date1/ts1/data/file.png": "image1",
 				"date1/ts1/index.html":    "report1",
@@ -76,7 +76,7 @@ func TestWalkAndSave(t *testing.T) {
 		{
 			name:       "Valid walk and save - with stripPathFn - 2",
 			localPath:  filepath.Join(tempDir, "date1/ts1/report"),
-			destPathFn: StripPathPartFn(tempDir, "date1"),
+			destPathFn: RemovePathSegmentFn(tempDir, "date1"),
 			wantFiles: map[string]string{
 				"ts1/report/data/file.png": "image1",
 				"ts1/report/index.html":    "report1",

--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cloudprober/cloudprober/metrics/payload"
 	payload_configpb "github.com/cloudprober/cloudprober/metrics/payload/proto"
 	"github.com/cloudprober/cloudprober/probes/browser/artifacts"
+	"github.com/cloudprober/cloudprober/probes/browser/artifacts/storage"
 	configpb "github.com/cloudprober/cloudprober/probes/browser/proto"
 	"github.com/cloudprober/cloudprober/probes/common/command"
 	"github.com/cloudprober/cloudprober/probes/common/sched"
@@ -43,6 +44,8 @@ import (
 	"github.com/cloudprober/cloudprober/targets/endpoint"
 	"google.golang.org/protobuf/proto"
 )
+
+const playwrightReportDir = "_playwright_report"
 
 // Probe holds aggregate information about all probe runs, per-target.
 type Probe struct {
@@ -255,7 +258,10 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 		return fmt.Errorf("failed to initialize templates: %v", err)
 	}
 
-	ah, err := artifacts.InitArtifactsHandler(context.Background(), p.c.GetArtifactsOptions(), p.outputDir, p.opts, p.l)
+	// We strip unnecessary /_playwright_report/ subdirectory from the path.
+	destPathFn := storage.StripPathPartFn(p.outputDir, playwrightReportDir)
+
+	ah, err := artifacts.InitArtifactsHandler(context.Background(), p.c.GetArtifactsOptions(), p.outputDir, p.opts, destPathFn, p.l)
 	if err != nil {
 		return fmt.Errorf("failed to initialize artifacts handler: %v", err)
 	}
@@ -309,7 +315,7 @@ func (p *Probe) prepareCommand(target endpoint.Endpoint, ts time.Time) (*command
 	runID := p.generateRunID(target)
 
 	outputDir := p.outputDirPath(target, ts)
-	reportDir := filepath.Join(outputDir, "report")
+	reportDir := filepath.Join(outputDir, playwrightReportDir)
 
 	envVars := []string{
 		fmt.Sprintf("NODE_PATH=%s", filepath.Join(p.playwrightDir, "node_modules")),

--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -259,7 +259,7 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 	}
 
 	// We strip unnecessary /_playwright_report/ subdirectory from the path.
-	destPathFn := storage.StripPathPartFn(p.outputDir, playwrightReportDir)
+	destPathFn := storage.RemovePathSegmentFn(p.outputDir, playwrightReportDir)
 
 	ah, err := artifacts.InitArtifactsHandler(context.Background(), p.c.GetArtifactsOptions(), p.outputDir, p.opts, destPathFn, p.l)
 	if err != nil {

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -37,7 +37,7 @@ func TestProbePrepareCommand(t *testing.T) {
 	defer os.Unsetenv("PLAYWRIGHT_DIR")
 
 	baseEnvVars := func(pwDir string) []string {
-		return []string{"NODE_PATH=" + pwDir + "/node_modules", "PLAYWRIGHT_HTML_REPORT={OUTPUT_DIR}/report", "PLAYWRIGHT_HTML_OPEN=never"}
+		return []string{"NODE_PATH=" + pwDir + "/node_modules", "PLAYWRIGHT_HTML_REPORT={OUTPUT_DIR}/" + playwrightReportDir, "PLAYWRIGHT_HTML_OPEN=never"}
 	}
 
 	cmdLine := func(npxPath string) []string {


### PR DESCRIPTION
- Playwright report is always saved in a subdirectory under the output directory, e.g. `date1/ts1/pw-report` where `date1/ts1` is the output directory for a specific run. Date and timestamp are useful, but 'pw-report' here adds an unnecessary step while accessing the report.
- This change removes this subdirectory while saving the artifacts, making report access quicker.

For example, report will now be at this path: `http://localhost:9313/artifacts/test_browser_probe/2025-04-28/1745861849606/` instead of `http://localhost:9313/artifacts/test_browser_probe/2025-04-28/1745861849606/report`