### PR TITLE
[probes.browser] Quickly identify artifacts for failed probes.

### DIFF
--- a/probes/browser/artifacts/web/artifacts.js
+++ b/probes/browser/artifacts/web/artifacts.js
@@ -98,8 +98,22 @@ function onChange() {
     }
 }
 
+function failureOnlyChange() {
+    const params = new URLSearchParams(window.location.search);
+    if (failureOnlyInput.checked) {
+        params.set('failureOnly', 'true');
+    } else {
+        params.delete('failureOnly');
+    }
+    window.location.search = params.toString();
+}
+
 startDatetimeInput.addEventListener('change', onChange);
 endDatetimeInput.addEventListener('change', onChange);
+
+const failureOnlyInput = document.getElementById('failure-only');
+failureOnlyInput.checked = urlParams.get('failureOnly') === 'true';
+failureOnlyInput.addEventListener('change', failureOnlyChange);
 
 // Initial validation
 validate();

--- a/probes/browser/artifacts/web/dirs.go
+++ b/probes/browser/artifacts/web/dirs.go
@@ -76,7 +76,7 @@ func getTimestampDirectories(root string, reqQuery url.Values, max int) ([]DirEn
 	}
 
 	failureOnly := false
-	if reqQuery.Has("failure_only") && reqQuery.Get("failure_only") != "false" {
+	if reqQuery.Has("failureOnly") && reqQuery.Get("failureOnly") != "false" {
 		failureOnly = true
 	}
 

--- a/probes/browser/artifacts/web/dirs.go
+++ b/probes/browser/artifacts/web/dirs.go
@@ -35,7 +35,7 @@ type DirEntry struct {
 	Failed  bool
 }
 
-func probeFailed(path string) bool {
+func containsFailureMarker(path string) bool {
 	_, err := os.Stat(filepath.Join(path, FailureMarkerFile))
 	if err == nil {
 		return true
@@ -136,7 +136,7 @@ func getTimestampDirectories(root string, reqQuery url.Values, max int) ([]DirEn
 				continue
 			}
 
-			failed := probeFailed(filepath.Join(datePath, tsDir.Name()))
+			failed := containsFailureMarker(filepath.Join(datePath, tsDir.Name()))
 			if failureOnly && !failed {
 				continue
 			}

--- a/probes/browser/artifacts/web/dirs_test.go
+++ b/probes/browser/artifacts/web/dirs_test.go
@@ -174,7 +174,7 @@ func TestGetTimestampDirectories(t *testing.T) {
 	}
 }
 
-func TestProbeFailed(t *testing.T) {
+func TestContainsFailureMarker(t *testing.T) {
 	root := t.TempDir()
 
 	// Case 1: No failure marker
@@ -182,7 +182,7 @@ func TestProbeFailed(t *testing.T) {
 	if err := os.Mkdir(dir1, 0o755); err != nil {
 		t.Fatalf("Failed to create dir1: %v", err)
 	}
-	assert.False(t, probeFailed(dir1), "probeFailed should be false when no marker exists")
+	assert.False(t, containsFailureMarker(dir1), "probeFailed should be false when no marker exists")
 
 	// Case 2: Failure marker in root
 	marker := filepath.Join(dir1, FailureMarkerFile)
@@ -191,7 +191,7 @@ func TestProbeFailed(t *testing.T) {
 	} else {
 		f.Close()
 	}
-	assert.True(t, probeFailed(dir1), "probeFailed should be true when marker exists in root")
+	assert.True(t, containsFailureMarker(dir1), "probeFailed should be true when marker exists in root")
 
 	// Case 3: Failure marker in subdirectory
 	dir2 := filepath.Join(root, "dir2")
@@ -199,16 +199,16 @@ func TestProbeFailed(t *testing.T) {
 	if err := os.MkdirAll(subdir, 0o755); err != nil {
 		t.Fatalf("Failed to create subdir: %v", err)
 	}
-	assert.False(t, probeFailed(dir2), "probeFailed should be false when no marker exists anywhere")
+	assert.False(t, containsFailureMarker(dir2), "probeFailed should be false when no marker exists anywhere")
 	marker2 := filepath.Join(subdir, FailureMarkerFile)
 	if f, err := os.Create(marker2); err != nil {
 		t.Fatalf("Failed to create failure marker in subdir: %v", err)
 	} else {
 		f.Close()
 	}
-	assert.True(t, probeFailed(dir2), "probeFailed should be true when marker exists in subdir")
+	assert.True(t, containsFailureMarker(dir2), "probeFailed should be true when marker exists in subdir")
 
 	// Case 4: Directory does not exist
 	nonexistent := filepath.Join(root, "doesnotexist")
-	assert.False(t, probeFailed(nonexistent), "probeFailed should be false for nonexistent directory")
+	assert.False(t, containsFailureMarker(nonexistent), "probeFailed should be false for nonexistent directory")
 }

--- a/probes/browser/artifacts/web/dirs_test.go
+++ b/probes/browser/artifacts/web/dirs_test.go
@@ -173,3 +173,42 @@ func TestGetTimestampDirectories(t *testing.T) {
 		})
 	}
 }
+
+func TestProbeFailed(t *testing.T) {
+	root := t.TempDir()
+
+	// Case 1: No failure marker
+	dir1 := filepath.Join(root, "dir1")
+	if err := os.Mkdir(dir1, 0o755); err != nil {
+		t.Fatalf("Failed to create dir1: %v", err)
+	}
+	assert.False(t, probeFailed(dir1), "probeFailed should be false when no marker exists")
+
+	// Case 2: Failure marker in root
+	marker := filepath.Join(dir1, FailureMarkerFile)
+	if f, err := os.Create(marker); err != nil {
+		t.Fatalf("Failed to create failure marker: %v", err)
+	} else {
+		f.Close()
+	}
+	assert.True(t, probeFailed(dir1), "probeFailed should be true when marker exists in root")
+
+	// Case 3: Failure marker in subdirectory
+	dir2 := filepath.Join(root, "dir2")
+	subdir := filepath.Join(dir2, "sub")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatalf("Failed to create subdir: %v", err)
+	}
+	assert.False(t, probeFailed(dir2), "probeFailed should be false when no marker exists anywhere")
+	marker2 := filepath.Join(subdir, FailureMarkerFile)
+	if f, err := os.Create(marker2); err != nil {
+		t.Fatalf("Failed to create failure marker in subdir: %v", err)
+	} else {
+		f.Close()
+	}
+	assert.True(t, probeFailed(dir2), "probeFailed should be true when marker exists in subdir")
+
+	// Case 4: Directory does not exist
+	nonexistent := filepath.Join(root, "doesnotexist")
+	assert.False(t, probeFailed(nonexistent), "probeFailed should be false for nonexistent directory")
+}

--- a/probes/browser/artifacts/web/template.go
+++ b/probes/browser/artifacts/web/template.go
@@ -78,6 +78,7 @@ func tsDirTmpl(currentPath string) *template.Template {
     }
     .failed {
       font-size: 10px;
+      color: #d32f2f;
     }
   </style>
 </head>
@@ -110,7 +111,7 @@ func tsDirTmpl(currentPath string) *template.Template {
 {{ range .TSDirs }}
 <li>
   <a href="tree/{{ $dateDir }}/{{.Timestamp}}">{{.Timestamp}} ({{.TimeStr}})</a>
-  {{if .Failed}}<small class="failed">❌</small>{{end}}
+  {{if .Failed}}<span class="failed">failed</span>{{end}}
 </li>
 {{ end }}
 </ul>

--- a/probes/browser/artifacts/web/template.go
+++ b/probes/browser/artifacts/web/template.go
@@ -76,6 +76,9 @@ func tsDirTmpl(currentPath string) *template.Template {
     .error.show {
       display: block;
     }
+    .failed {
+      font-size: 10px;
+    }
   </style>
 </head>
 <body>
@@ -100,8 +103,11 @@ func tsDirTmpl(currentPath string) *template.Template {
  {{ $dateDir := .DateDir }}
  <li><a href="tree/{{ $dateDir }}">{{ $dateDir }}</a></li>
 <ul>
-{{ range .Timestamp }}
-<li><a href="tree/{{ $dateDir }}/{{.}}">{{.}}</a></li>
+{{ range .TSDirs }}
+<li>
+  <a href="tree/{{ $dateDir }}/{{.Timestamp}}">{{.Timestamp}} ({{.TimeStr}})</a>
+  {{if .Failed}}<small class="failed">❌</small>{{end}}
+</li>
 {{ end }}
 </ul>
 {{ end }}

--- a/probes/browser/artifacts/web/template.go
+++ b/probes/browser/artifacts/web/template.go
@@ -36,7 +36,7 @@ func tsDirTmpl(currentPath string) *template.Template {
 	  padding-left: 20px;
 	  line-height: 1.6;
 	}
-	.datetime-selector {
+	.selectors {
       background: #fff;
       padding: 2px;
       max-width: 600px;
@@ -49,20 +49,20 @@ func tsDirTmpl(currentPath string) *template.Template {
       flex: 1;
       min-width: 200px;
     }
-    .datetime-selector label {
+    .selectors label {
       font-size: 14px;
       color: #333;
       margin-bottom: 5px;
       display: block;
     }
-    .datetime-selector input[type="datetime-local"] {
+    .selectors input[type="datetime-local"] {
       padding: 4px;
       border: 1px solid #ddd;
       border-radius: 4px;
       font-size: 14px;
       box-sizing: border-box;
     }
-    .datetime-selector input[type="datetime-local"]:focus {
+    .selectors input[type="datetime-local"]:focus {
       outline: none;
       border-color: #007bff;
       box-shadow: 0 0 5px rgba(0, 123, 255, 0.3);
@@ -85,7 +85,7 @@ func tsDirTmpl(currentPath string) *template.Template {
 %s
 <div style="display: block; clear: both; padding-top: 10px">
   <hr>
-  <div class="datetime-selector">
+  <div class="selectors">
     <div class="datetime-group">
       <div class="datetime-field">
         <label for="start-datetime">Start Date and Time</label>
@@ -95,6 +95,10 @@ func tsDirTmpl(currentPath string) *template.Template {
         <label for="end-datetime">End Date and Time</label>
         <input type="datetime-local" id="end-datetime" required>
         <span class="error" id="error-message">End date and time must be after start</span>
+      </div>
+      <div>
+        <label for="failure-only">Failure Only</label>
+        <input type="checkbox" id="failure-only">
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Add a failure marker (cloudprober_probe_failed file) to artifacts of the failed probe.
- Use this marker to identify failed artifacts in the web UI. Show test `failed` in front of failed probes' artifacts.
- Also, add the ability to show only failed probes.
- See screenshot below to get an idea.