### PR TITLE
[probes.browser] Make testspec matching less sensitive to testDir path.

### DIFF
--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -210,10 +210,14 @@ func (p *Probe) computeTestSpecArgs() []string {
 			args = append(args, ts)
 			continue
 		}
+		// If test spec is not a regex, make it a regex that matches the given
+		// test spec. This is important because playwright treats test specs as
+		// regexes.
 		ts = regexp.QuoteMeta(ts)
 		if !filepath.IsAbs(ts) {
 			pathSep := string(filepath.Separator)
 			if pathSep == `\` {
+				// "/" needs to be escaped in regex
 				pathSep = `\\`
 			}
 			ts = ".*" + pathSep + ts

--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -210,10 +210,15 @@ func (p *Probe) computeTestSpecArgs() []string {
 			args = append(args, ts)
 			continue
 		}
+		ts = regexp.QuoteMeta(ts)
 		if !filepath.IsAbs(ts) {
-			ts = filepath.Join(p.testDirPath(), ts)
+			pathSep := string(filepath.Separator)
+			if pathSep == `\` {
+				pathSep = `\\`
+			}
+			ts = ".*" + pathSep + ts
 		}
-		args = append(args, "^"+regexp.QuoteMeta(ts)+"$")
+		args = append(args, "^"+ts+"$")
 	}
 
 	return args

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -392,10 +392,11 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 			wantArgsWin: []string{`^.*\\myspec\.js$`},
 		},
 		{
-			name:     "single_spec_absolute",
-			testDir:  "/tests",
-			testSpec: []string{"/abs/path/spec.js"},
-			wantArgs: []string{`^/abs/path/spec\.js$`},
+			name:        "single_spec_absolute",
+			testDir:     "/tests",
+			testSpec:    []string{"/abs/path/spec.js"},
+			wantArgs:    []string{`^/abs/path/spec\.js$`},
+			wantArgsWin: []string{`^abs/path/spec\.js$`},
 		},
 		{
 			name:     "multiple_specs_mixed",
@@ -407,7 +408,7 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 			},
 			wantArgsWin: []string{
 				`^.*\\foo\.js$`,
-				`^/bar/baz\.js$`,
+				`^\\bar\\baz\.js$`,
 			},
 		},
 		{
@@ -423,6 +424,10 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 			filterInclude: "mytest",
 			wantArgs: []string{
 				"--grep=mytest",
+				`^.*/foo\.js$`,
+			},
+			wantArgsWin: []string{
+				"--grep=mytest",
 				`^.*\\foo\.js$`,
 			},
 		},
@@ -432,6 +437,10 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 			testSpec:      []string{"foo.js"},
 			filterExclude: "skipme",
 			wantArgs: []string{
+				"--grep-invert=skipme",
+				`^.*/foo\.js$`,
+			},
+			wantArgsWin: []string{
 				"--grep-invert=skipme",
 				`^.*\\foo\.js$`,
 			},
@@ -445,6 +454,11 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 			wantArgs: []string{
 				"--grep=mytest",
 				"--grep-invert=skipme",
+				`^.*/foo\.js$`,
+			},
+			wantArgsWin: []string{
+				"--grep=mytest",
+				"--grep-invert=skipme",
 				`^.*\\foo\.js$`,
 			},
 		},
@@ -453,8 +467,12 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 			testDir:  "/dir",
 			testSpec: []string{"foo.js", `^bar.*\.js$`},
 			wantArgs: []string{
-				`^.*\\foo\.js$`,
+				`^.*/foo\.js$`,
 				`^bar.*\.js$`,
+			},
+			wantArgsWin: []string{
+				`^.*\\foo\.js$`,
+				`^bar.*\\js$`,
 			},
 		},
 	}
@@ -462,8 +480,8 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			conf := &configpb.ProbeConf{}
-			if tt.testSpec != nil {
-				conf.TestSpec = tt.testSpec
+			for _, spec := range tt.testSpec {
+				conf.TestSpec = append(conf.TestSpec, filepath.FromSlash(spec))
 			}
 			if tt.filterInclude != "" || tt.filterExclude != "" {
 				conf.TestSpecFilter = &configpb.TestSpecFilter{}

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -396,7 +396,7 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 			testDir:     "/tests",
 			testSpec:    []string{"/abs/path/spec.js"},
 			wantArgs:    []string{`^/abs/path/spec\.js$`},
-			wantArgsWin: []string{`^abs/path/spec\.js$`},
+			wantArgsWin: []string{`^\\abs\\path\\spec\.js$`},
 		},
 		{
 			name:     "multiple_specs_mixed",
@@ -472,7 +472,7 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 			},
 			wantArgsWin: []string{
 				`^.*\\foo\.js$`,
-				`^bar.*\\js$`,
+				`^bar.*\.js$`,
 			},
 		},
 	}

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -102,7 +102,7 @@ func TestProbePrepareCommand(t *testing.T) {
 		{
 			name:         "with_test_spec",
 			testSpec:     []string{"test_spec_1", "test_spec_2"},
-			wantCmdLine:  append(cmdLine("npx"), "^/tests/test_spec_1$", "^/tests/test_spec_2$"),
+			wantCmdLine:  append(cmdLine("npx"), "^.*/test_spec_1$", "^.*/test_spec_2$"),
 			wantEnvVars:  baseEnvVars("/playwright"),
 			wantWorkDir:  "/playwright",
 			wantEMLabels: baseWantEMLabels,
@@ -387,7 +387,7 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 			name:     "single_spec_relative",
 			testDir:  "/tests",
 			testSpec: []string{"myspec.js"},
-			wantArgs: []string{`^/tests/myspec\.js$`},
+			wantArgs: []string{`^.*/myspec\.js$`},
 		},
 		{
 			name:     "single_spec_absolute",
@@ -400,7 +400,7 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 			testDir:  "/dir",
 			testSpec: []string{"foo.js", "/bar/baz.js"},
 			wantArgs: []string{
-				`^/dir/foo\.js$`,
+				`^.*/foo\.js$`,
 				`^/bar/baz\.js$`,
 			},
 		},
@@ -417,7 +417,7 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 			filterInclude: "mytest",
 			wantArgs: []string{
 				"--grep=mytest",
-				`^/dir/foo\.js$`,
+				`^.*/foo\.js$`,
 			},
 		},
 		{
@@ -427,7 +427,7 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 			filterExclude: "skipme",
 			wantArgs: []string{
 				"--grep-invert=skipme",
-				`^/dir/foo\.js$`,
+				`^.*/foo\.js$`,
 			},
 		},
 		{
@@ -439,7 +439,7 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 			wantArgs: []string{
 				"--grep=mytest",
 				"--grep-invert=skipme",
-				`^/dir/foo\.js$`,
+				`^.*/foo\.js$`,
 			},
 		},
 		{
@@ -447,16 +447,13 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 			testDir:  "/dir",
 			testSpec: []string{"foo.js", `^bar.*\.js$`},
 			wantArgs: []string{
-				`^/dir/foo\.js$`,
+				`^.*/foo\.js$`,
 				`^bar.*\.js$`,
 			},
 		},
 	}
 
 	for _, tt := range tests {
-		if runtime.GOOS == "windows" {
-			t.Skip("Skipping test on Windows, path issues - not worth it")
-		}
 		t.Run(tt.name, func(t *testing.T) {
 			conf := &configpb.ProbeConf{}
 			if tt.testSpec != nil {

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -480,6 +480,9 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 			}
 			got := p.computeTestSpecArgs()
 			if runtime.GOOS == "windows" {
+				if tt.wantArgsWin == nil {
+					tt.wantArgsWin = tt.wantArgs
+				}
 				assert.Equal(t, tt.wantArgsWin, got)
 			} else {
 				assert.Equal(t, tt.wantArgs, got)


### PR DESCRIPTION
In some cases testDir may have symlinks to the test spec. This happens for example for k8s config maps. If you mount a config map, say at /cfg, containing a test spec say test.spec.ts, its path on the filesystem will look like the following:

```
ls -l /cfg

test.spec.ts -> ..data/test.spec.ts
```

In such cases, playwright will evaluate file path as `/cfg/..data/test.spec.ts` (note ..data itself will be a symlink so final path will be even longer). In that case, if we specify test spec as `^/cfg/test.spec.ts$` it will not match anything.

To workaround this problem, let's leave out testDir from the test spec regex. We'll use `^.*/test.spec.ts$ instead.

For posterity:
Playwright code for file matching:
https://github.com/microsoft/playwright/blob/eb5e3b37402bad85e6c2b976e1a596cca0e4f47c/packages/playwright/src/util.ts#L96
for collecting file:
https://github.com/microsoft/playwright/blob/eb5e3b37402bad85e6c2b976e1a596cca0e4f47c/packages/playwright/src/runner/projectUtils.ts#L169
