### PR TITLE
[docs] Add docs for how to get target to the external server probe.

### DIFF
--- a/docs/content/docs/how-to/external-probe/index.md
+++ b/docs/content/docs/how-to/external-probe/index.md
@@ -146,7 +146,7 @@ The probe that we created above forks out a new `redis_probe` process for every
 probe cycle. This can get expensive if probe frequency is high and the process is big (e.g. a Java binary). Also, what if you want to keep some state across probes, for example, lets say you want to monitor performance over HTTP/2 where you keep using the same TCP connection for multiple HTTP requests. A new process
 every time makes keeping state impossible.
 
-External probe's server mode provides a way to run the external probe process in daemon mode. Cloudprober communicates with this process over stdout/stdin (connected with OS pipes), using serialized protobuf messages. Cloudprober comes with a serverutils package that makes it easy to build external probe servers in Go.
+External probe's server mode provides a way to run the external probe process in daemon mode. Cloudprober communicates with this process over stdout/stdin (connected with OS pipes), using serialized protobuf messages. Cloudprober comes with a serverutils package that makes it easy to build external probe servers in Go. To pass target info into the probe, use the @label@ notation in `external_probe.options`.
 
 ![External Probe Server](external_probe_server.svg)
 

--- a/examples/external/cloudprober_server.cfg
+++ b/examples/external/cloudprober_server.cfg
@@ -18,5 +18,12 @@ probe {
         }
       }
     }
+
+    # @target@ and friends are templated into options, which can be sent to the
+    # server probe.
+    options {
+      name: "target"
+      value: "@target@"
+    }
   }
 }


### PR DESCRIPTION
I had to go looking in the code for this - added docs to the first place I looked.

Thanks (addresses https://github.com/cloudprober/cloudprober/issues/1091) !