### PR TITLE
[targets.file] Set IP to target name if IP is not provided

### DIFF
--- a/internal/rds/file/file.go
+++ b/internal/rds/file/file.go
@@ -207,6 +207,8 @@ func (ls *lister) refresh() error {
 		}
 		if e.IP != nil {
 			epRes.Ip = proto.String(e.IP.String())
+		} else {
+			epRes.Ip = proto.String(e.Name)
 		}
 		if e.Port != 0 {
 			epRes.Port = proto.Int32(int32(e.Port))

--- a/internal/rds/file/testdata/testdata.go
+++ b/internal/rds/file/testdata/testdata.go
@@ -52,6 +52,7 @@ var ExpectedResources = []*rdspb.Resource{
 	},
 	{
 		Name: proto.String("web-1"),
+		Ip:   proto.String("web-1"),
 		Port: proto.Int32(80),
 		Labels: map[string]string{
 			"__cp_host__":   "cloudprober.org",

--- a/targets/file/file_test.go
+++ b/targets/file/file_test.go
@@ -15,13 +15,13 @@
 package file
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/cloudprober/cloudprober/internal/rds/file/testdata"
 	rdspb "github.com/cloudprober/cloudprober/internal/rds/proto"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
 	configpb "github.com/cloudprober/cloudprober/targets/file/proto"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -64,25 +64,14 @@ func TestListEndpointsWithFilter(t *testing.T) {
 			if len(got) != len(test.wantEndpoints) {
 				t.Fatalf("Got endpoints: %d, expected: %d", len(got), len(test.wantEndpoints))
 			}
+
 			for i := range test.wantEndpoints {
 				want := test.wantEndpoints[i]
 
-				if got[i].Name != want.Name || got[i].Port != want.Port || !reflect.DeepEqual(got[i].Labels, want.Labels) {
-					t.Errorf("ListResources: got:\n%v\nexpected:\n%v", got[i], want)
-				}
-			}
-
-			for _, ep := range got {
-				if testExpectedIP[ep.Name] != "" {
-					resolvedIP, err := ft.Resolve(ep.Name, 0)
-					if err != nil {
-						t.Errorf("unexpected error while resolving %s: %v", ep.Name, err)
-					}
-					ip := resolvedIP.String()
-					if ip != testExpectedIP[ep.Name] {
-						t.Errorf("ft.Resolve(%s): got=%s, expected=%s", ep.Name, ip, testExpectedIP[ep.Name])
-					}
-				}
+				assert.Equal(t, got[i].Name, want.Name)
+				assert.Equal(t, got[i].Port, want.Port)
+				assert.Equal(t, got[i].Labels, want.Labels)
+				assert.Equal(t, got[i].IP.String(), want.IP.String())
 			}
 		})
 	}


### PR DESCRIPTION
For file based targets, set IP to target name if IP is not provided. This is what RDS client expects. RDS client returns an error for resolve if resource IP is not set.

We do the same for other target types too:
- For example https://github.com/cloudprober/cloudprober/blob/4798dde6e4e9e3a94d8af310298f39dfbd3aef72/internal/rds/kubernetes/services.go#L163
https://github.com/cloudprober/cloudprober/blob/4798dde6e4e9e3a94d8af310298f39dfbd3aef72/internal/rds/kubernetes/ingresses.go#L127

This fixes #1099.