### PR TITLE
[metrics.payload] Fix initialization of json and header metrics

### DIFF
--- a/metrics/payload/header_metrics.go
+++ b/metrics/payload/header_metrics.go
@@ -18,14 +18,13 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/cloudprober/cloudprober/metrics"
 	configpb "github.com/cloudprober/cloudprober/metrics/payload/proto"
 )
 
 func (p *Parser) processHeaderMetrics(resp interface{}) *metrics.EventMetrics {
-	em := metrics.NewEventMetrics(time.Now())
+	em := p.newEM(nil)
 
 	httpResp, ok := resp.(*http.Response)
 	if !ok {

--- a/metrics/payload/header_metrics_test.go
+++ b/metrics/payload/header_metrics_test.go
@@ -88,7 +88,10 @@ func TestParserProcessHeaderMetrics(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &Parser{opts: opts}
+			p, err := NewParser(opts, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 			em := p.processHeaderMetrics(tt.resp)
 			if em == nil {
 				if !tt.wantNilEM {

--- a/metrics/payload/json_metrics.go
+++ b/metrics/payload/json_metrics.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"time"
 
 	"github.com/cloudprober/cloudprober/metrics"
 	configpb "github.com/cloudprober/cloudprober/metrics/payload/proto"
@@ -91,9 +90,7 @@ func jqValToMetricValue(v any) (metrics.Value, error) {
 	}
 }
 
-func (jm *jsonMetric) process(input any) (*metrics.EventMetrics, error) {
-	em := metrics.NewEventMetrics(time.Now())
-
+func (jm *jsonMetric) process(input any, em *metrics.EventMetrics) (*metrics.EventMetrics, error) {
 	metrics, err := runJQFilter(jm.metricsJQ, input)
 	if err != nil {
 		return nil, err
@@ -139,7 +136,7 @@ func (p *Parser) processJSONMetric(text []byte) []*metrics.EventMetrics {
 	var ems []*metrics.EventMetrics
 
 	for _, jm := range p.jsonMetrics {
-		em, err := jm.process(input)
+		em, err := jm.process(input, p.newEM(nil))
 		if err != nil {
 			p.l.Warning(err.Error())
 			continue


### PR DESCRIPTION
Currently eventmetrics generated by json and header metrics processing don't get metrics kind and additional labels from the payload parser config.

Fixes: #1101