### PR TITLE
Use net.JoinHostPort to combine host and port

### DIFF
--- a/cloudprober.go
+++ b/cloudprober.go
@@ -121,7 +121,7 @@ func initDefaultServer(c *configpb.ProberConfig, l *logger.Logger) (net.Listener
 		return nil, err
 	}
 
-	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", serverHost, serverPort))
+	ln, err := net.Listen("tcp", net.JoinHostPort(serverHost, strconv.Itoa(serverPort)))
 	if err != nil {
 		return nil, fmt.Errorf("error while creating listener for default HTTP server: %v", err)
 	}
@@ -198,7 +198,7 @@ func initWithConfigSource(configSrc config.ConfigSource) error {
 	if cfg.GetGrpcPort() != 0 {
 		serverHost := getServerHost(cfg)
 
-		grpcLn, err = net.Listen("tcp", fmt.Sprintf("%s:%d", serverHost, cfg.GetGrpcPort()))
+		grpcLn, err = net.Listen("tcp", net.JoinHostPort(serverHost, strconv.Itoa(int(cfg.GetGrpcPort()))))
 		if err != nil {
 			return fmt.Errorf("error while creating listener for default gRPC server: %v", err)
 		}


### PR DESCRIPTION
When the host is an IPv6 address like `::1`, simple `fmt.Sprintf()` doesn't surrround the host with brackets, while `net.JoinHostPort` produces correct result like `[::1]:80`.