### PR TITLE
[probes.browser] Simplify web server root logic

### DIFF
--- a/probes/browser/artifacts/artifacts_test.go
+++ b/probes/browser/artifacts/artifacts_test.go
@@ -59,12 +59,9 @@ func TestPathPrefix(t *testing.T) {
 }
 
 func TestWebServerRoot(t *testing.T) {
-	outputDir := "/output/dir"
-
 	tests := []struct {
 		name             string
 		artifactsOpts    *configpb.ArtifactsOptions
-		outputDir        string
 		localStorageDirs []string
 		expectedRoot     string
 		expectError      bool
@@ -72,22 +69,12 @@ func TestWebServerRoot(t *testing.T) {
 		{
 			name:          "no local storage",
 			artifactsOpts: &configpb.ArtifactsOptions{},
-			outputDir:     outputDir,
-			expectedRoot:  outputDir,
-			expectError:   false,
-		},
-		{
-			name:          "no local storage, no default",
-			artifactsOpts: &configpb.ArtifactsOptions{},
-			outputDir:     "",
-			expectedRoot:  "",
 			expectError:   true,
 		},
 		{
 			name:             "only one local storage",
 			artifactsOpts:    &configpb.ArtifactsOptions{},
 			localStorageDirs: []string{"/local/storage/dir"},
-			outputDir:        outputDir,
 			expectedRoot:     "/local/storage/dir",
 			expectError:      false,
 		},
@@ -96,7 +83,6 @@ func TestWebServerRoot(t *testing.T) {
 			artifactsOpts: &configpb.ArtifactsOptions{
 				WebServerRoot: proto.String("/local/storage/dir"),
 			},
-			outputDir:        outputDir,
 			localStorageDirs: []string{"/local/storage/dir"},
 			expectedRoot:     "/local/storage/dir",
 			expectError:      false,
@@ -107,8 +93,6 @@ func TestWebServerRoot(t *testing.T) {
 				WebServerRoot: proto.String("/invalid/storage/dir"),
 			},
 			localStorageDirs: []string{"/local/storage/dir"},
-			outputDir:        outputDir,
-			expectedRoot:     "",
 			expectError:      true,
 		},
 	}
@@ -124,7 +108,7 @@ func TestWebServerRoot(t *testing.T) {
 					},
 				})
 			}
-			root, err := webServerRoot(tt.artifactsOpts, tt.outputDir)
+			root, err := webServerRoot(tt.artifactsOpts)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {

--- a/probes/browser/artifacts/proto/config.pb.go
+++ b/probes/browser/artifacts/proto/config.pb.go
@@ -437,16 +437,15 @@ func (*Storage_Abs) isStorage_Storage() {}
 type ArtifactsOptions struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Serve test artifacts on Cloudprober's default webserver. This is
-	// disabled by default for security reasons.
+	// disabled by default for security reasons. If it's set to true and no
+	// local storage is configured, we return an error.
 	ServeOnWeb *bool `protobuf:"varint,1,opt,name=serve_on_web,json=serveOnWeb" json:"serve_on_web,omitempty"`
 	// Specify web server path to serve test artifacts on.
 	// Default is "/artifacts/<probename>".
 	WebServerPath *string `protobuf:"bytes,2,opt,name=web_server_path,json=webServerPath" json:"web_server_path,omitempty"`
 	// Web server root directory. If not provided (recommended), we just use
 	// the first local storage directory if configured, and if provided, we
-	// verify that it is one of the local storages directories. If no local
-	// storage is configured, we return an error for global options and use
-	// <workdir>/output for probe level artifacts options.
+	// verify that it is one of the local storages directories.
 	WebServerRoot *string `protobuf:"bytes,4,opt,name=web_server_root,json=webServerRoot" json:"web_server_root,omitempty"`
 	// Storage for test artifacts. Note that test artifacts are always
 	// written to the workdir first, and uploaded to the storage backend in a

--- a/probes/browser/artifacts/proto/config.proto
+++ b/probes/browser/artifacts/proto/config.proto
@@ -74,7 +74,8 @@ message Storage {
 
 message ArtifactsOptions {
     // Serve test artifacts on Cloudprober's default webserver. This is
-    // disabled by default for security reasons.
+    // disabled by default for security reasons. If it's set to true and no
+    // local storage is configured, we return an error.
     optional bool serve_on_web = 1;
 
     // Specify web server path to serve test artifacts on.
@@ -83,9 +84,7 @@ message ArtifactsOptions {
 
     // Web server root directory. If not provided (recommended), we just use
     // the first local storage directory if configured, and if provided, we
-    // verify that it is one of the local storages directories. If no local
-    // storage is configured, we return an error for global options and use
-    // <workdir>/output for probe level artifacts options.
+    // verify that it is one of the local storages directories.
     optional string web_server_root = 4;
 
     // Storage for test artifacts. Note that test artifacts are always

--- a/probes/browser/proto/config.pb.go
+++ b/probes/browser/proto/config.pb.go
@@ -243,12 +243,14 @@ type ProbeConf struct {
 	//	  exclude: "@draft"  // exclude tests with @draft tag
 	//	}
 	TestSpecFilter *TestSpecFilter `protobuf:"bytes,3,opt,name=test_spec_filter,json=testSpecFilter" json:"test_spec_filter,omitempty"`
-	// Workdir is path to the working directory. It should be writable. If not
-	// specified, we try to create a temporary directory. All the output files
-	// and reports are stored under <workdir>/output/.
-	// If you need to be able access the output files, you should set this
-	// field to a persistent location, e.g. a persistent volume, or configure
-	// artifact options.
+	// Path to the working directory for this probe. It has no impact on the
+	// test execution except for the fact that this directory should be
+	// writable. If left unset (recommended), we try to create a temporary
+	// directory.
+	//
+	// If you need to be able access the output files, you should set this field
+	// to a persistent location, e.g. a persistent volume, or configure artifact
+	// options.
 	Workdir *string `protobuf:"bytes,4,opt,name=workdir" json:"workdir,omitempty"`
 	// Path to the playwright installation. We execute tests from this location.
 	// If not specified, we'll use the value of environment variable

--- a/probes/browser/proto/config.proto
+++ b/probes/browser/proto/config.proto
@@ -70,12 +70,14 @@ message ProbeConf {
     //   }
     optional TestSpecFilter test_spec_filter = 3;
 
-    // Workdir is path to the working directory. It should be writable. If not
-    // specified, we try to create a temporary directory. All the output files
-    // and reports are stored under <workdir>/output/.
-    // If you need to be able access the output files, you should set this 
-    // field to a persistent location, e.g. a persistent volume, or configure
-    // artifact options.
+    // Path to the working directory for this probe. It has no impact on the
+    // test execution except for the fact that this directory should be
+    // writable. If left unset (recommended), we try to create a temporary
+    // directory.
+    //
+    // If you need to be able access the output files, you should set this field
+    // to a persistent location, e.g. a persistent volume, or configure artifact
+    // options.
     optional string workdir = 4;
 
     // Path to the playwright installation. We execute tests from this location.


### PR DESCRIPTION
- Don't run web server on workdir.
- Discourage from setting workdir. This option can be confusing.