### PR TITLE
[probes.browser] Wait longer for child processes cleanup

### DIFF
--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -421,9 +421,10 @@ func (p *Probe) prepareCommand(target endpoint.Endpoint, ts time.Time) (*command
 
 	p.l.Infof("Running command line: %v", cmdLine)
 	cmd := &command.Command{
-		CmdLine: cmdLine,
-		WorkDir: p.playwrightDir,
-		EnvVars: envVars,
+		CmdLine:              cmdLine,
+		WorkDir:              p.playwrightDir,
+		EnvVars:              envVars,
+		ChildProcessWaitTime: p.opts.Interval / 2,
 	}
 	cmd.ProcessStreamingOutput = func(line []byte) {
 		if p.payloadParser == nil {

--- a/probes/common/command/command.go
+++ b/probes/common/command/command.go
@@ -29,6 +29,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/cloudprober/cloudprober/logger"
 )
@@ -54,6 +55,12 @@ type Command struct {
 	EnvVars                []string
 	WorkDir                string
 	ProcessStreamingOutput func([]byte)
+
+	// We create a goroutine to wait for child processes to finish. This field
+	// dictates how long will that goroutine wait for child processes to finish
+	// before giving up. This is to avoid unbounded number of goroutines in case
+	// child processes misbehave.
+	ChildProcessWaitTime time.Duration
 }
 
 func (c *Command) setupStreaming(cmd *exec.Cmd, l *logger.Logger) error {
@@ -131,7 +138,7 @@ func (c *Command) Execute(ctx context.Context, l *logger.Logger) (string, error)
 	}
 
 	l.Debugf("Running command: %v", cmd)
-	err := runCommand(ctx, cmd)
+	err := runCommand(ctx, cmd, c.ChildProcessWaitTime)
 
 	if err != nil {
 		stdout, stderr := stdoutBuf.String(), stderrBuf.String()

--- a/probes/common/command/runcmd_linux.go
+++ b/probes/common/command/runcmd_linux.go
@@ -29,7 +29,13 @@ import (
 	"time"
 )
 
-func runCommand(ctx context.Context, cmd *exec.Cmd) error {
+var defaultChildProcessWaitTime = 10 * time.Second
+
+func runCommand(ctx context.Context, cmd *exec.Cmd, childProcessWaitTime time.Duration) error {
+	if childProcessWaitTime == 0 {
+		childProcessWaitTime = defaultChildProcessWaitTime
+	}
+
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if err := cmd.Start(); err != nil {
@@ -57,7 +63,7 @@ func runCommand(ctx context.Context, cmd *exec.Cmd) error {
 	go func() {
 		var err error
 
-		timeout := time.NewTimer(10 * time.Second)
+		timeout := time.NewTimer(childProcessWaitTime)
 		defer timeout.Stop()
 		for err == nil {
 			select {

--- a/probes/common/command/runcmd_nonlinux.go
+++ b/probes/common/command/runcmd_nonlinux.go
@@ -19,8 +19,9 @@ package command
 import (
 	"context"
 	"os/exec"
+	"time"
 )
 
-func runCommand(_ context.Context, cmd *exec.Cmd) error {
+func runCommand(_ context.Context, cmd *exec.Cmd, _ time.Duration) error {
 	return cmd.Run()
 }


### PR DESCRIPTION
- Child processes (forked by the external process) may take long to die even after SIGKILL to the session id. This is specially true in case of browser probe where playwright forks off browser processes which take longer to clean up.
- By default wait for 10s (instead of 1s) for child process cleanup
- In case of browser probes, wait for half the interval since browser probes take longer to clean up.

See https://github.com/cloudprober/cloudprober/issues/1128 for more context.