### PR TITLE
[probes.command] Fix zombie reaper mechanism

### DIFF
--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -421,10 +421,9 @@ func (p *Probe) prepareCommand(target endpoint.Endpoint, ts time.Time) (*command
 
 	p.l.Infof("Running command line: %v", cmdLine)
 	cmd := &command.Command{
-		CmdLine:              cmdLine,
-		WorkDir:              p.playwrightDir,
-		EnvVars:              envVars,
-		ChildProcessWaitTime: p.opts.Interval / 2,
+		CmdLine: cmdLine,
+		WorkDir: p.playwrightDir,
+		EnvVars: envVars,
 	}
 	cmd.ProcessStreamingOutput = func(line []byte) {
 		if p.payloadParser == nil {

--- a/probes/common/command/command.go
+++ b/probes/common/command/command.go
@@ -29,7 +29,6 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"time"
 
 	"github.com/cloudprober/cloudprober/logger"
 )
@@ -55,12 +54,6 @@ type Command struct {
 	EnvVars                []string
 	WorkDir                string
 	ProcessStreamingOutput func([]byte)
-
-	// We create a goroutine to wait for child processes to finish. This field
-	// dictates how long will that goroutine wait for child processes to finish
-	// before giving up. This is to avoid unbounded number of goroutines in case
-	// child processes misbehave.
-	ChildProcessWaitTime time.Duration
 }
 
 func (c *Command) setupStreaming(cmd *exec.Cmd, l *logger.Logger) error {
@@ -138,7 +131,7 @@ func (c *Command) Execute(ctx context.Context, l *logger.Logger) (string, error)
 	}
 
 	l.Debugf("Running command: %v", cmd)
-	err := runCommand(ctx, cmd, c.ChildProcessWaitTime)
+	err := runCommand(ctx, cmd)
 
 	if err != nil {
 		stdout, stderr := stdoutBuf.String(), stderrBuf.String()

--- a/probes/common/command/runcmd_nonlinux.go
+++ b/probes/common/command/runcmd_nonlinux.go
@@ -19,9 +19,8 @@ package command
 import (
 	"context"
 	"os/exec"
-	"time"
 )
 
-func runCommand(_ context.Context, cmd *exec.Cmd, _ time.Duration) error {
+func runCommand(_ context.Context, cmd *exec.Cmd) error {
 	return cmd.Run()
 }


### PR DESCRIPTION
- After a lot of research and testing, it's clear to me that my old implementation of zombie reaper doesn't really work. Reason is -- once child process exits, that child's children (cloudprober's grandchildren) will get reparented to `pid 1` immediately.
- Calling `wait4` on these grandchildren's pgid (-pgid) is not going to work whether cloudprober is `pid 1` or not. It should theoretically have worked when cloudprober's pid is 1 because orphaned process will get reparented to cloudprober (e.g. on docker, k8s), but I've confirmed that in practice it doesn't.
- I've changed my implementation to instead wait on pid `-1`, which basically will reap all children of cloudprober. We start one goroutine per cloudprober process that checks every minute for any children to be waited. I've verified that this works in docker environment. 

This should fix #1128.