### PR TITLE
[probes.command] Revert dedicated zombie reaper solutions

### DIFF
--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -421,9 +421,10 @@ func (p *Probe) prepareCommand(target endpoint.Endpoint, ts time.Time) (*command
 
 	p.l.Infof("Running command line: %v", cmdLine)
 	cmd := &command.Command{
-		CmdLine: cmdLine,
-		WorkDir: p.playwrightDir,
-		EnvVars: envVars,
+		CmdLine:              cmdLine,
+		WorkDir:              p.playwrightDir,
+		EnvVars:              envVars,
+		ChildProcessWaitTime: p.opts.Interval / 2,
 	}
 	cmd.ProcessStreamingOutput = func(line []byte) {
 		if p.payloadParser == nil {

--- a/probes/common/command/command.go
+++ b/probes/common/command/command.go
@@ -29,6 +29,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/cloudprober/cloudprober/logger"
 )
@@ -54,6 +55,12 @@ type Command struct {
 	EnvVars                []string
 	WorkDir                string
 	ProcessStreamingOutput func([]byte)
+
+	// We create a goroutine to wait for child processes to finish. This field
+	// dictates how long will that goroutine wait for child processes to finish
+	// before giving up. This is to avoid unbounded number of goroutines in case
+	// child processes misbehave.
+	ChildProcessWaitTime time.Duration
 }
 
 func (c *Command) setupStreaming(cmd *exec.Cmd, l *logger.Logger) error {
@@ -131,7 +138,7 @@ func (c *Command) Execute(ctx context.Context, l *logger.Logger) (string, error)
 	}
 
 	l.Debugf("Running command: %v", cmd)
-	err := runCommand(ctx, cmd)
+	err := runCommand(ctx, cmd, c.ChildProcessWaitTime)
 
 	if err != nil {
 		stdout, stderr := stdoutBuf.String(), stderrBuf.String()

--- a/probes/common/command/runcmd_nonlinux.go
+++ b/probes/common/command/runcmd_nonlinux.go
@@ -19,8 +19,9 @@ package command
 import (
 	"context"
 	"os/exec"
+	"time"
 )
 
-func runCommand(_ context.Context, cmd *exec.Cmd) error {
+func runCommand(_ context.Context, cmd *exec.Cmd, _ time.Duration) error {
 	return cmd.Run()
 }


### PR DESCRIPTION
This reverts #1130, #1131.

Unfortunately my last attempt at zombie cleanup also doesn't work. This time problem is with the mutex -- when zombieReaper is waiting on the write lock it will block even the read lock acquisition, thus blocking further runCommand executions. I thought of other alternatives but I think trying to manage this out is not worth it.

For the zombie leak problem in docker/k8s environments, where one of the descendants creates another process group thus making those processes out of reach through earlier `pgid`[1], there is not much we can do in Cloudprober itself. For k8s we'll recommend `shareProcessNamespace: true` for pod spec and for docker simply `--init` flag.

[1] - This happens with browser probe where playwright creates some chrome task, which in turn creates some chrome tasks and put them in a different process group.