### PR TITLE
[probes.external] In server, log probe options on timeout

### DIFF
--- a/probes/external/serverutils/serverutils.go
+++ b/probes/external/serverutils/serverutils.go
@@ -144,7 +144,18 @@ func serve(ctx context.Context, probeFunc func(*serverpb.ProbeRequest, *serverpb
 				repliesChan <- reply
 			case <-timeout:
 				// drop the request on the floor.
-				fmt.Fprintf(stderr, "Timeout for request %v\n", *reply.RequestId)
+				if len(request.GetOptions()) > 0 {
+					var sb strings.Builder
+
+					for _, option := range request.Options {
+						sb.WriteString(fmt.Sprintf("%s: %s,", *option.Name, *option.Value))
+					}
+
+					fmt.Fprintf(stderr, "Timeout for request %v (%s)\n", *reply.RequestId, sb.String())
+				} else {
+					fmt.Fprintf(stderr, "Timeout for request %v\n", *reply.RequestId)
+				}
+
 			}
 		}()
 	}


### PR DESCRIPTION
- Modify severutils to log probe options on timeout.
- Makes it possible to tell which instance of a probe timed out. The probeId is totally internal, so you can't map it to which probe failed without this. 