### PR TITLE
[probes.http] Update target labels even if target resolution fails

### DIFF
--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -156,12 +156,12 @@ func (p *Probe) httpRequestForTarget(target endpoint.Endpoint) (*http.Request, e
 	host := hostForTarget(target)
 
 	urlHost, ipForLabel, err := p.urlHostAndIPLabel(target, host)
-	if err != nil {
-		return nil, err
-	}
-
+	// Make sure we update additional labels even if there is an error.
 	for _, al := range p.opts.AdditionalLabels {
 		al.UpdateForTarget(target, ipForLabel, port)
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	url := fmt.Sprintf("%s://%s%s", p.schemeForTarget(target), hostWithPort(urlHost, port), pathForTarget(target, p.url))


### PR DESCRIPTION
- Add a test that verifies that labels are added regardless of failures.