### PR TITLE
Continue reading upon ErrTooLong in external server probe stderr read loop

### DIFF
--- a/probes/external/external_server.go
+++ b/probes/external/external_server.go
@@ -109,8 +109,19 @@ func (p *Probe) startCmdIfNotRunning(startCtx context.Context) error {
 
 	go func() {
 		scanner := bufio.NewScanner(p.cmdStderr)
-		for scanner.Scan() {
-			p.l.WarningAttrs("process stderr", slog.String("process_stderr", scanner.Text()), slog.String("process_path", cmd.Path))
+		for {
+			if scanner.Scan() {
+				p.l.WarningAttrs("process stderr", slog.String("process_stderr", scanner.Text()), slog.String("process_path", cmd.Path))
+				continue
+			}
+			if scanner.Err() == bufio.ErrTooLong {
+				// Drop the associated log but otherwise continue reading.
+				p.l.Errorf("stderr reader: encountered ErrTooLong from %s", cmd.Path)
+				scanner = bufio.NewScanner(p.cmdStderr)
+				continue
+			}
+			p.l.Warningf("Stderr reader: encountered terminal error from %s", cmd.Path, scanner.Err())
+			break
 		}
 	}()
 

--- a/probes/external/external_server.go
+++ b/probes/external/external_server.go
@@ -120,7 +120,7 @@ func (p *Probe) startCmdIfNotRunning(startCtx context.Context) error {
 				scanner = bufio.NewScanner(p.cmdStderr)
 				continue
 			}
-			p.l.Warningf("Stderr reader: encountered terminal error from %s", cmd.Path, scanner.Err())
+			p.l.Warningf("Stderr reader: encountered terminal error from %s: %v", cmd.Path, scanner.Err())
 			break
 		}
 	}()


### PR DESCRIPTION
Currently, if an external server probe writes a large debug log to stderr exceeding `bufio.MaxScanTokenSize`, cloudprober's stderr read loop will terminate.

For `server` probes (rather than ONCE probes), this is a bad failure mode since the child process will continue attempting to log and will back up the stderr pipe. Eventually all attempts to log will block, causing prober goroutines to build up and OOM.

Approach here specifically checks for `ErrTooLong` (I wanted to make sure we *do* still terminate when we hit an EOF-like error). But, consider this a strawman, an approach that checks for all EOF-like errors might be more robust.

@manugarg 