### PR TITLE
Add an example config for a HTTP TLS probe

### DIFF
--- a/examples/tls/cloudprober.cfg
+++ b/examples/tls/cloudprober.cfg
@@ -1,0 +1,22 @@
+# This config demonstrates the use of configuring TLS.
+#
+# cloudprober --config_file=cloudprober.cfg
+#
+
+probe {
+  name: "tls-example"
+  type: HTTP
+
+  http_probe {
+    protocol: HTTPS
+
+    tls_config {
+      # If using the helm chart, use `extraSecretMounts` to map a kubetnetes secret to the same path
+      ca_cert_file: "path/to/tls/ca.crt"
+    }
+  }
+
+  targets {
+      # Configure targets here...
+  }
+}


### PR DESCRIPTION
* Include a tip for helm chart users to use`extraSecretMounts` to  acess cert from [kubenetes secrets](https://k8s.io/docs/concepts/configuration/secret/)

This implements https://github.com/cloudprober/cloudprober/issues/1079 and is a clean branch recreation of https://github.com/cloudprober/cloudprober/pull/1080