### PR TITLE
[docs] Add config tester link to the Config menu.

### DIFF
--- a/docs/config/_default/menus/menus.toml
+++ b/docs/config/_default/menus/menus.toml
@@ -42,6 +42,13 @@
   url = "/docs/config/latest/overview"
 
 [[main]]
+  name = "🛠 Config Tester"
+  weight = 43
+  identifier = "config-tester"
+  parent = "config"
+  url = "https://configtester.cloudprober.org/"
+
+[[main]]
   name = "How-To"
   weight = 60
   identifier = "how-to"


### PR DESCRIPTION
Add a link to the configtester tool: https://configtester.cloudprober.org.