### PR TITLE
[common.oauth] Allow customization of 'Authorization' header token type format

### DIFF
--- a/common/oauth/oauth.go
+++ b/common/oauth/oauth.go
@@ -20,6 +20,7 @@ package oauth
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	configpb "github.com/cloudprober/cloudprober/common/oauth/proto"
@@ -42,6 +43,13 @@ func TokenSourceFromConfig(c *configpb.Config, l *logger.Logger) (oauth2.TokenSo
 	refreshExpiryBuffer := time.Minute
 	if c.RefreshExpiryBufferSec != nil {
 		refreshExpiryBuffer = time.Duration(c.GetRefreshExpiryBufferSec()) * time.Second
+	}
+
+	if c.GetTokenTypeFormat() != configpb.Default_Config_TokenTypeFormat {
+		fmtStr := c.GetTokenTypeFormat()
+		if strings.Count(fmtStr, "%") != 1 || strings.Count(fmtStr, "%s") != 1 {
+			return nil, fmt.Errorf("oauth: invalid token_type_format (%s). It should have exactly one %%s placeholder for the token", fmtStr)
+		}
 	}
 
 	switch c.Source.(type) {

--- a/common/oauth/proto/config.pb.go
+++ b/common/oauth/proto/config.pb.go
@@ -49,14 +49,18 @@ type Config struct {
 	// In most cases, Cloudprober does the right thing based on the retrieved
 	// token and you don't need to set this field.
 	RefreshIntervalSec *float32 `protobuf:"fixed32,21,opt,name=refresh_interval_sec,json=refreshIntervalSec,def=30" json:"refresh_interval_sec,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// Token type to be used in the "Authorization" header.
+	// If set, can have exact only one '%s' placeholder for the token.
+	TokenTypeFormat *string `protobuf:"bytes,6,opt,name=token_type_format,json=tokenTypeFormat,def=Bearer %s" json:"token_type_format,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 // Default values for Config fields.
 const (
 	Default_Config_RefreshExpiryBufferSec = int32(60)
 	Default_Config_RefreshIntervalSec     = float32(30)
+	Default_Config_TokenTypeFormat        = string("Bearer %s")
 )
 
 func (x *Config) Reset() {
@@ -171,6 +175,13 @@ func (x *Config) GetRefreshIntervalSec() float32 {
 		return *x.RefreshIntervalSec
 	}
 	return Default_Config_RefreshIntervalSec
+}
+
+func (x *Config) GetTokenTypeFormat() string {
+	if x != nil && x.TokenTypeFormat != nil {
+		return *x.TokenTypeFormat
+	}
+	return Default_Config_TokenTypeFormat
 }
 
 type isConfig_Source interface {
@@ -521,7 +532,7 @@ var File_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto prot
 
 const file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_rawDesc = "" +
 	"\n" +
-	"Bgithub.com/cloudprober/cloudprober/common/oauth/proto/config.proto\x12\x11cloudprober.oauth\"\xee\x03\n" +
+	"Bgithub.com/cloudprober/cloudprober/common/oauth/proto/config.proto\x12\x11cloudprober.oauth\"\xa5\x04\n" +
 	"\x06Config\x12\x14\n" +
 	"\x04file\x18\x01 \x01(\tH\x00R\x04file\x12C\n" +
 	"\fhttp_request\x18\x02 \x01(\v2\x1e.cloudprober.oauth.HTTPRequestH\x00R\vhttpRequest\x12\x12\n" +
@@ -531,7 +542,8 @@ const file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_ra
 	"\x12google_credentials\x18\b \x01(\v2$.cloudprober.oauth.GoogleCredentialsH\x00R\x11googleCredentials\x12C\n" +
 	"\fbearer_token\x18\a \x01(\v2\x1e.cloudprober.oauth.BearerTokenH\x00R\vbearerToken\x12=\n" +
 	"\x19refresh_expiry_buffer_sec\x18\x14 \x01(\x05:\x0260R\x16refreshExpiryBufferSec\x124\n" +
-	"\x14refresh_interval_sec\x18\x15 \x01(\x02:\x0230R\x12refreshIntervalSecB\b\n" +
+	"\x14refresh_interval_sec\x18\x15 \x01(\x02:\x0230R\x12refreshIntervalSec\x125\n" +
+	"\x11token_type_format\x18\x06 \x01(\t:\tBearer %sR\x0ftokenTypeFormatB\b\n" +
 	"\x06source\"\xd5\x01\n" +
 	"\vHTTPRequest\x12\x1b\n" +
 	"\ttoken_url\x18\x01 \x02(\tR\btokenUrl\x12\x16\n" +

--- a/common/oauth/proto/config.proto
+++ b/common/oauth/proto/config.proto
@@ -50,6 +50,10 @@ message Config {
   // In most cases, Cloudprober does the right thing based on the retrieved
   // token and you don't need to set this field.
   optional float refresh_interval_sec = 21 [default = 30];
+
+  // Token type to be used in the "Authorization" header.
+  // If set, can have exact only one '%s' placeholder for the token.
+  optional string token_type_format = 6 [default = "Bearer %s"];
 }
 
 message HTTPRequest {

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -220,7 +220,7 @@ func (p *Probe) prepareRequest(req *http.Request) *http.Request {
 			p.l.Error("Error getting OAuth token: ", err.Error())
 			tok = "<token-missing>"
 		}
-		req.Header.Set("Authorization", "Bearer "+tok)
+		req.Header.Set("Authorization", fmt.Sprintf(p.c.GetOauthConfig().GetTokenTypeFormat(), tok))
 	}
 
 	req.Body = p.requestBody.Reader()


### PR DESCRIPTION
The most common OAuth 'Authorization' header format is simply: `Bearer <...token>`, but there are other custom token type allowed.  

For example, per https://docs.snowflake.com/en/developer-guide/snowflake-ml/model-registry/container#calling-the-service:

"With a Programmatic Access Token (PAT), authentication based on a token you generate on Snowflake. For information on setting up a PAT for use with Snowflake services, see [Using programmatic access tokens for authentication](https://docs.snowflake.com/en/user-guide/programmatic-access-tokens). To use a PAT when calling a service, include the token in your Authorization request header:

`Authorization: Snowflake Token="<your_token>"`

For example, with a PAT stored in the environment variable SNOWFLAKE_SERVICE_PAT and the predict(INTEGER, VARCHAR, TIMESTAMP) function signature used in previous examples, you could make a request to the endpoint random-id.myaccount.snowflakecomputing.app/predict with the following curl command:

```
curl \
 -X POST \
 -H "Content-Type: application/json" \
 -H "Authorization: Snowflake Token=\"$SNOWFLAKE_SERVICE_PAT\"" \
 -d '{
       "data": [
                   [0, 10, "Alex", "2014-01-01 16:00:00"],
                   [1, 20, "Steve", "2015-01-01 16:00:00"],
                   [2, 30, "Alice", "2016-01-01 16:00:00"],
                   [3, 40, "Adrian", "2017-01-01 16:00:00"]
               ]
   }' \
 random-id.myaccount.snowflakecomputing.app/predict/predict
``` 
"