### PR TITLE
[probes.browser] Run cleanup cycle early to opportunistically free up disk space

### DIFF
--- a/probes/browser/artifacts/cleanup.go
+++ b/probes/browser/artifacts/cleanup.go
@@ -54,6 +54,10 @@ func NewCleanupHandler(dir string, opts *configpb.CleanupOptions, l *logger.Logg
 		ch.interval = ch.maxAge
 	}
 
+	// Opportunistically do an initial cleanup to release some space.
+	ch.l.Debugf("cleanupHandler: doing initial cleanup for %s", ch.dir)
+	ch.cleanupCycle()
+
 	return ch, nil
 }
 

--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -337,12 +337,7 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 	// We strip unnecessary /_playwright_report/ subdirectory from the path.
 	destPathFn := storage.RemovePathSegmentFn(p.outputDir, playwrightReportDir)
 
-	ah, err := artifacts.InitArtifactsHandler(context.Background(), p.c.GetArtifactsOptions(), p.outputDir, p.opts, destPathFn, p.l)
-	if err != nil {
-		return fmt.Errorf("failed to initialize artifacts handler: %v", err)
-	}
-	p.artifactsHandler = ah
-
+	// Setup cleanup handler first, so we can opportunistically release some space.
 	workdirCleanupOpts := p.c.GetWorkdirCleanupOptions()
 	if workdirCleanupOpts == nil {
 		workdirCleanupOpts = &artifactsconfigpb.CleanupOptions{
@@ -354,6 +349,12 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 		return fmt.Errorf("failed to initialize cleanup handler: %v", err)
 	}
 	p.workdirCleanup = ch
+
+	ah, err := artifacts.InitArtifactsHandler(context.Background(), p.c.GetArtifactsOptions(), p.outputDir, p.opts, destPathFn, p.l)
+	if err != nil {
+		return fmt.Errorf("failed to initialize artifacts handler: %v", err)
+	}
+	p.artifactsHandler = ah
 
 	return nil
 }


### PR DESCRIPTION
Run a cleanup cycle early to possibly make space for new artifacts. Sometimes we may not even get a chance to cleanup if disk is full and prober will just keep crashing.

- Run cleanup during cleanup handler creation.
- Create work dir cleanup handler before creating new artifacts handlers.