### PR TITLE
[examples.percentiles] Annotate and Improve Findability of How to Configure Percentiles

### DIFF
--- a/docs/content/docs/how-to/percentiles/index.md
+++ b/docs/content/docs/how-to/percentiles/index.md
@@ -33,6 +33,7 @@ probe {
     host_names: "..."
   }
 
+  # Local and Intra-regional latencies
   latency_unit: "ms"
   latency_distribution {
     explicit_buckets: "0.01,0.1,0.15,0.2,0.25,0.35,0.5,0.75,1.0,1.5,2.0,3.0,4.0,5.0,10.0,15.0,20.0"

--- a/examples/percentiles/http_regional_latency.cfg
+++ b/examples/percentiles/http_regional_latency.cfg
@@ -1,0 +1,13 @@
+probe {
+  name: "..."
+  type: HTTP
+  targets {
+    host_names: "..."
+  }
+
+  # Local and Intra-regional latencies
+  latency_unit: "ms"
+  latency_distribution {
+    explicit_buckets: "0.01,0.1,0.15,0.2,0.25,0.35,0.5,0.75,1.0,1.5,2.0,3.0,4.0,5.0,10.0,15.0,20.0"
+  }
+}


### PR DESCRIPTION
* Annotate the scope of the percentiles example in https://cloudprober.org/docs/how-to/percentiles/ , as a reminder for 
  readers to not blindly C&P the example

* Create an explicit example config under `examples/percentiles/`

