### PR TITLE
add RunOnce interface support on more probe types

### DIFF
--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cloudprober/cloudprober/metrics"
 	"github.com/cloudprober/cloudprober/metrics/payload"
 	payload_configpb "github.com/cloudprober/cloudprober/metrics/payload/proto"
+	"github.com/cloudprober/cloudprober/metrics/singlerun"
 	"github.com/cloudprober/cloudprober/probes/browser/artifacts"
 	artifactsconfigpb "github.com/cloudprober/cloudprober/probes/browser/artifacts/proto"
 	"github.com/cloudprober/cloudprober/probes/browser/artifacts/storage"
@@ -443,7 +444,8 @@ func (p *Probe) prepareCommand(target endpoint.Endpoint, ts time.Time) (*command
 	return cmd, reportDir
 }
 
-func (p *Probe) runPWTest(ctx context.Context, target endpoint.Endpoint, result *probeRunResult, resultMu *sync.Mutex) {
+func (p *Probe) runPWTest(ctx context.Context, runReq *sched.RunProbeForTargetRequest, resultMu *sync.Mutex) {
+	target, result := runReq.Target, runReq.Result.(*probeRunResult)
 	startTime := time.Now()
 
 	cmd, reportDir := p.prepareCommand(target, startTime)
@@ -460,17 +462,21 @@ func (p *Probe) runPWTest(ctx context.Context, target endpoint.Endpoint, result 
 	// required) even after this probe run.
 	p.artifactsHandler.Handle(p.startCtx, reportDir)
 
-	if err != nil {
-		return
-	}
+	latency := time.Since(startTime)
 
 	if resultMu != nil {
 		resultMu.Lock()
 		defer resultMu.Unlock()
 	}
 
+	runReq.LastRun.Set(err == nil, latency, err)
+
+	if err != nil {
+		return
+	}
+
 	result.success.Inc()
-	result.latency.AddFloat64(time.Since(startTime).Seconds() / p.opts.LatencyUnit.Seconds())
+	result.latency.AddFloat64(latency.Seconds() / p.opts.LatencyUnit.Seconds())
 }
 
 func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetRequest) {
@@ -489,7 +495,7 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 	}
 
 	if p.c.GetRequestsPerProbe() == 1 {
-		p.runPWTest(ctx, target, result, nil)
+		p.runPWTest(ctx, runReq, nil)
 		return
 	}
 
@@ -501,12 +507,12 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 	var wg sync.WaitGroup
 	for i := 0; i < int(p.c.GetRequestsPerProbe()); i++ {
 		wg.Add(1)
-		go func(reqNum int, result *probeRunResult) {
+		go func(reqNum int) {
 			defer wg.Done()
 
 			time.Sleep(time.Duration(reqNum*int(p.c.GetRequestsIntervalMsec())) * time.Millisecond)
-			p.runPWTest(ctx, target, result, &resultMu)
-		}(i, result)
+			p.runPWTest(ctx, runReq, &resultMu)
+		}(i)
 	}
 	p.l.Debug("Waiting for Browser requests to finish")
 	wg.Wait()
@@ -533,4 +539,15 @@ func (p *Probe) Start(ctx context.Context, dataChan chan *metrics.EventMetrics) 
 		RunProbeForTarget: p.runProbe,
 	}
 	s.UpdateTargetsAndStartProbes(ctx)
+}
+
+// RunOnce runs the probe just once.
+func (p *Probe) RunOnce(ctx context.Context) []*singlerun.ProbeRunResult {
+	if p.c.GetRequestsPerProbe() > 1 {
+		p.l.Error("Run-once is not supported for requests_per_probe > 1")
+		return nil
+	}
+
+	p.l.Info("Running browser probe once.")
+	return sched.RunOnce(ctx, p.opts, p.runProbe)
 }

--- a/probes/external/external.go
+++ b/probes/external/external.go
@@ -42,7 +42,9 @@ import (
 	"github.com/cloudprober/cloudprober/metrics"
 	"github.com/cloudprober/cloudprober/metrics/payload"
 	payloadpb "github.com/cloudprober/cloudprober/metrics/payload/proto"
+	"github.com/cloudprober/cloudprober/metrics/singlerun"
 	"github.com/cloudprober/cloudprober/probes/common/command"
+	"github.com/cloudprober/cloudprober/probes/common/sched"
 	configpb "github.com/cloudprober/cloudprober/probes/external/proto"
 	"github.com/cloudprober/cloudprober/probes/options"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
@@ -57,6 +59,14 @@ type result struct {
 	total, success    int64
 	latency           metrics.LatencyValue
 	validationFailure *metrics.Map[int64]
+	payloadMetrics    []*metrics.EventMetrics
+}
+
+// Metrics converts probe result into metrics.EventMetrics object
+func (prr *result) Metrics(ts time.Time, _ int64, opts *options.Options) []*metrics.EventMetrics {
+	ems := prr.payloadMetrics
+	prr.payloadMetrics = nil
+	return ems
 }
 
 // Probe holds aggregate information about all probe runs, per-target.
@@ -239,15 +249,68 @@ func (p *Probe) processProbeResult(ps *probeStatus, target endpoint.Endpoint, re
 		defaultEM.AddMetric("validation_failure", result.validationFailure)
 	}
 
-	p.opts.RecordMetrics(target, p.withStdLabels(defaultEM, target), p.dataChan)
+	ems := []*metrics.EventMetrics{p.withStdLabels(defaultEM, target)}
 
 	// If probe is configured to use the external process output (or reply payload
 	// in case of server probe) as metrics.
 	if p.c.GetOutputAsMetrics() {
 		for _, em := range p.payloadParser.PayloadMetrics(&payload.Input{Text: []byte(ps.payload)}, target.Dst()) {
-			p.opts.RecordMetrics(target, p.withStdLabels(em, target), p.dataChan)
+			ems = append(ems, p.withStdLabels(em, target))
 		}
 	}
+
+	if p.dataChan != nil {
+		for _, em := range ems {
+			p.opts.RecordMetrics(target, em, p.dataChan)
+		}
+	} else {
+		result.payloadMetrics = append(result.payloadMetrics, ems...)
+	}
+}
+
+func (p *Probe) runProbeForTarget(ctx context.Context, runReq *sched.RunProbeForTargetRequest) {
+	if runReq.Result == nil {
+		runReq.Result = p.newResult()
+	}
+
+	target, result := runReq.Target, runReq.Result.(*result)
+
+	args := append([]string{}, p.cmdArgs...)
+	if len(p.labelKeys) != 0 {
+		for i, arg := range p.cmdArgs {
+			res, found := strtemplate.SubstituteLabels(arg, p.labels(target))
+			if !found {
+				p.l.Warningf("Substitution not found in %q", arg)
+			}
+			args[i] = res
+		}
+	}
+
+	p.l.Infof("Running external command: %s %s", p.cmdName, strings.Join(args, " "))
+	result.total++
+
+	cmd := &command.Command{
+		CmdLine: append([]string{p.cmdName}, args...),
+		EnvVars: p.envVars,
+	}
+	if p.dataChan != nil && p.c.GetOutputAsMetrics() && !p.c.GetDisableStreamingOutputMetrics() {
+		cmd.ProcessStreamingOutput = func(line []byte) {
+			for _, em := range p.payloadParser.PayloadMetrics(&payload.Input{Text: line}, target.Dst()) {
+				p.opts.RecordMetrics(target, p.withStdLabels(em, target), p.dataChan)
+			}
+		}
+	}
+
+	startTime := time.Now()
+	stdout, err := cmd.Execute(ctx, p.l)
+	latency := time.Since(startTime)
+	if err != nil {
+		p.l.Errorf("Error running external probe: %v", err)
+	}
+
+	ps := &probeStatus{success: err == nil, latency: latency, payload: stdout}
+	p.processProbeResult(ps, target, result)
+	runReq.LastRun.Set(ps.success, latency, err)
 }
 
 func (p *Probe) runOnceProbe(ctx context.Context) {
@@ -258,42 +321,35 @@ func (p *Probe) runOnceProbe(ctx context.Context) {
 		go func(target endpoint.Endpoint, result *result) {
 			defer wg.Done()
 
-			args := append([]string{}, p.cmdArgs...)
-			if len(p.labelKeys) != 0 {
-				for i, arg := range p.cmdArgs {
-					res, found := strtemplate.SubstituteLabels(arg, p.labels(target))
-					if !found {
-						p.l.Warningf("Substitution not found in %q", arg)
-					}
-					args[i] = res
-				}
+			runRequest := &sched.RunProbeForTargetRequest{
+				Target: target,
+				Result: result,
 			}
 
-			p.l.Infof("Running external command: %s %s", p.cmdName, strings.Join(args, " "))
-			result.total++
-
-			cmd := &command.Command{
-				CmdLine: append([]string{p.cmdName}, args...),
-				EnvVars: p.envVars,
-			}
-			if p.c.GetOutputAsMetrics() && !p.c.GetDisableStreamingOutputMetrics() {
-				cmd.ProcessStreamingOutput = func(line []byte) {
-					for _, em := range p.payloadParser.PayloadMetrics(&payload.Input{Text: line}, target.Dst()) {
-						p.opts.RecordMetrics(target, p.withStdLabels(em, target), p.dataChan)
-					}
-				}
-			}
-
-			startTime := time.Now()
-			stdout, err := cmd.Execute(ctx, p.l)
-			latency := time.Since(startTime)
-			if err != nil {
-				p.l.Errorf("Error running external probe: %v", err)
-			}
-			p.processProbeResult(&probeStatus{success: err == nil, latency: latency, payload: stdout}, target, result)
+			p.runProbeForTarget(ctx, runRequest)
 		}(target, p.results[target.Key()])
 	}
 	wg.Wait()
+}
+
+// RunOnce runs the probe just once.
+func (p *Probe) RunOnce(ctx context.Context) []*singlerun.ProbeRunResult {
+	p.l.Info("Running external probe once.")
+	return sched.RunOnce(ctx, p.opts, p.runProbeForTarget)
+}
+
+func (p *Probe) newResult() *result {
+	var latencyValue metrics.LatencyValue
+	if p.opts.LatencyDist != nil {
+		latencyValue = p.opts.LatencyDist.CloneDist()
+	} else {
+		latencyValue = metrics.NewFloat(0)
+	}
+
+	return &result{
+		latency:           latencyValue,
+		validationFailure: validators.ValidationFailureMap(p.opts.Validators),
+	}
 }
 
 func (p *Probe) updateTargets() {
@@ -304,17 +360,7 @@ func (p *Probe) updateTargets() {
 			continue
 		}
 
-		var latencyValue metrics.LatencyValue
-		if p.opts.LatencyDist != nil {
-			latencyValue = p.opts.LatencyDist.CloneDist()
-		} else {
-			latencyValue = metrics.NewFloat(0)
-		}
-
-		p.results[target.Key()] = &result{
-			latency:           latencyValue,
-			validationFailure: validators.ValidationFailureMap(p.opts.Validators),
-		}
+		p.results[target.Key()] = p.newResult()
 
 		for _, al := range p.opts.AdditionalLabels {
 			al.UpdateForTarget(target, "", 0)


### PR DESCRIPTION
Tested: 
- `go test ./probes/...`;
- also grpcurl with test cfg;