### PR TITLE
[probes.browser] Skip target subdirectory in artifacts for single-target probes

### DIFF
--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -385,7 +385,7 @@ func targetEnvVars(target endpoint.Endpoint) []string {
 
 func (p *Probe) outputDirPath(target endpoint.Endpoint, ts time.Time) string {
 	outputDirPath := []string{p.outputDir, ts.Format("2006-01-02"), strconv.FormatInt(ts.UnixMilli(), 10)}
-	if target.Name != "" {
+	if target.Name != "" && len(p.targets) > 1 {
 		outputDirPath = append(outputDirPath, target.Name)
 	}
 	return filepath.Join(outputDirPath...)

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -164,11 +164,12 @@ func TestProbePrepareCommand(t *testing.T) {
 
 func TestProbeOutputDirPath(t *testing.T) {
 	tests := []struct {
-		name      string
-		outputDir string
-		target    endpoint.Endpoint
-		ts        time.Time
-		want      string
+		name       string
+		outputDir  string
+		target     endpoint.Endpoint
+		targets    []endpoint.Endpoint
+		ts         time.Time
+		want       string
 	}{
 		{
 			name:      "default",
@@ -177,16 +178,25 @@ func TestProbeOutputDirPath(t *testing.T) {
 			want:      "/tmp/output/2024-01-01/1704067200000",
 		},
 		{
-			name:      "with_target",
+			name:      "single_target",
 			outputDir: "/tmp/output",
 			target:    endpoint.Endpoint{Name: "test_target"},
+			targets:   []endpoint.Endpoint{{Name: "test_target"}},
+			ts:        time.Date(2024, time.February, 2, 12, 30, 45, 0, time.UTC),
+			want:      "/tmp/output/2024-02-02/1706877045000",
+		},
+		{
+			name:      "multiple_targets",
+			outputDir: "/tmp/output",
+			target:    endpoint.Endpoint{Name: "test_target"},
+			targets:   []endpoint.Endpoint{{Name: "test_target"}, {Name: "test_target_2"}},
 			ts:        time.Date(2024, time.February, 2, 12, 30, 45, 0, time.UTC),
 			want:      "/tmp/output/2024-02-02/1706877045000/test_target",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := &Probe{outputDir: tt.outputDir}
+			p := &Probe{outputDir: tt.outputDir, targets: tt.targets}
 			assert.Equal(t, filepath.FromSlash(tt.want), p.outputDirPath(tt.target, tt.ts))
 		})
 	}


### PR DESCRIPTION
## Summary
- When a browser probe has only one target (the common case), skip creating the target-name subdirectory under the artifacts timestamp directory.
- This simplifies the artifact directory structure from `{date}/{timestamp}/{target_name}/` to `{date}/{timestamp}/` for single-target probes.
- Multi-target probes continue to use per-target subdirectories as before.

## Test plan
- [x] Updated `TestProbeOutputDirPath` with cases for single and multiple targets
- [ ] Verify artifact directory structure with a single-target browser probe
- [ ] Verify artifact directory structure with a multi-target browser probe