### PR TITLE
[metrics.payload] Sort labels when processing json metrics

### DIFF
--- a/metrics/payload/json_metrics.go
+++ b/metrics/payload/json_metrics.go
@@ -117,8 +117,8 @@ func (jm *jsonMetric) process(input any, em *metrics.EventMetrics) (*metrics.Eve
 		if !ok {
 			return nil, fmt.Errorf("labels_jq_filter didn't return a map[string]any: %T", labels)
 		}
-		for k, v := range labelsMap {
-			em.AddLabel(k, fmt.Sprintf("%v", v))
+		for _, k := range sortedKeys(labelsMap) {
+			em.AddLabel(k, fmt.Sprintf("%v", labelsMap[k]))
 		}
 	}
 

--- a/metrics/payload/json_metrics_test.go
+++ b/metrics/payload/json_metrics_test.go
@@ -97,6 +97,31 @@ func TestJSONMetrics(t *testing.T) {
 			},
 		},
 		{
+			name: "multiple labels sorting",
+			input: `{
+				"deployment": "dep1",
+				"region": "us-central1",
+				"zone": "us-central1-a",
+				"app": "cloudprober",
+				"reqs": 100
+			}`,
+			config: `
+				json_metric: [{
+					jq_filter: "{\"reqs\":.reqs}",
+					labels_jq_filter: "{\"deployment\":.deployment, \"region\":.region, \"zone\":.zone, \"app\":.app}",
+				}]
+			`,
+			wantJM: []*jsonMetric{
+				{
+					metricsJQ: testMustJQParse("{\"reqs\":.reqs}"),
+					labelsJQ:  testMustJQParse("{\"deployment\":.deployment, \"region\":.region, \"zone\":.zone, \"app\":.app}"),
+				},
+			},
+			wantEMs: []string{
+				"labels=app=cloudprober,deployment=dep1,region=us-central1,zone=us-central1-a reqs=100.000",
+			},
+		},
+		{
 			name: "bad filter",
 			config: `
 			json_metric: [{


### PR DESCRIPTION
- Ensure that labels extracted from JSON objects are always sorted alphabetically by key. 
- In Go, map iteration order is random. Without sorting, evaluating labels derived from a JSON object (like `labels_jq_filter`) leads to unpredictable output strings since the labels append in varying orders.
- Sorting the keys matches the behavior used for `metricsMap` and guarantees consistent, predictable text formatting.
- Added a new test case to [json_metrics_test.go](cci:7://file:///home/manugarg/code/cloudprober-wt/main/metrics/payload/json_metrics_test.go:0:0-0:0) to verify this behavior.

Note:
Cloudprober mostly assumes deterministic labels order – to avoid sorting them while determining caching key or exporting metrics. For native metrics like success/latency etc, it’s not problem as labels are always added by us and order remains stable. For payload based metrics, we explicitly sort line metrics. But, we were not doing any sorting for JSON based metrics.

Out of order labels can affect prometheus surfacer in a subtle way. For prometheus metrics we do caching and use labels as the caching key. Now if label order had changes, new EventMetric will become a different timeseries (instead of just updating the existing timeseries). In such a case, prometheus scraper will just accept the last scraped value for the same set of metric and labels. In such a case it's possible that the old value will continue to win.