### PR TITLE
Annotate that file_path target files can be remotely fetched

### DIFF
--- a/examples/targets/file/cloudprober.cfg
+++ b/examples/targets/file/cloudprober.cfg
@@ -15,6 +15,13 @@
 # total{ptype="http",probe="dc-aa-endpoints",dst="web-aa-01"} 20
 # total{ptype="http",probe="dc-aa-endpoints",dst="web-aa-02"} 20
 
+
+# file_path have any of the following prefixes:
+//  - /tmp/resources.textpb , for local files
+//  - gs://my-bucket/resources.json , for GCS Storage Bucket
+//  - s3://my-bucket/resources.json , for an S3 (compatible) Bucket
+//  - https://my-public-bucket.s3.amazonaws.com/resources.json , for a HTTP(s) endpoint
+
 probe {
     name: "all-endpoints"
     type: HTTP


### PR DESCRIPTION
Annotate `examples/targets/file/cloudprober.cfg` that file based targets can be remote paths, enabling HTTP(S), GCS and S3 storage systems

Interestingly, this is a little known feature that is currently only discoverable if you read the source code of either:
`internal/rds/file/proto/config.proto` or `internal/file/file.go`. The only brief mention of it under https://cloudprober.org/docs/config/ is buried deep  at https://cloudprober.org/docs/config/latest/rds/#cloudprober_rds_file_ProviderConfig