### PR TITLE
[logger] Add in-memory log storage for probes

### DIFF
--- a/cloudprober.go
+++ b/cloudprober.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cloudprober/cloudprober/internal/servers"
 	"github.com/cloudprober/cloudprober/internal/sysvars"
 	"github.com/cloudprober/cloudprober/logger"
+	"github.com/cloudprober/cloudprober/logger/logstore"
 	"github.com/cloudprober/cloudprober/metrics/singlerun"
 	"github.com/cloudprober/cloudprober/prober"
 	"github.com/cloudprober/cloudprober/probes"
@@ -74,7 +75,9 @@ const (
 )
 
 var (
-	disableSysMetrics = flag.Bool("disable_sys_metrics", false, "Disable system metrics probe")
+	disableSysMetrics  = flag.Bool("disable_sys_metrics", false, "Disable system metrics probe")
+	logStoreMaxMemMB   = flag.Int("log_store_max_mem_mb", 50, "Max memory in MB for in-memory log store. 0 to disable.")
+	logStoreMinLevel   = flag.String("log_store_min_level", "INFO", "Minimum log level for stored logs. Valid values: DEBUG, INFO, WARNING, ERROR")
 )
 
 // Global prober.Prober instance protected by a mutex.
@@ -277,6 +280,12 @@ func initWithConfigSource(configSrc config.ConfigSource) error {
 		reflection.Register(s)
 		// register channelz service to the default grpc server port
 		service.RegisterChannelzServiceToServer(s)
+	}
+
+	// Initialize log store for in-memory log retention.
+	if *logStoreMaxMemMB > 0 {
+		ls := logstore.New(int64(*logStoreMaxMemMB)<<20, logger.ParseLogLevel(*logStoreMinLevel))
+		logger.SetDefaultLogStore(ls)
 	}
 
 	// initCtx is used to clean up in case of partial initialization failures. For

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -28,6 +28,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"flag"
@@ -35,6 +36,7 @@ import (
 	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/logging"
 	md "github.com/cloudprober/cloudprober/common/metadata"
+	"github.com/cloudprober/cloudprober/logger/logstore"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 )
@@ -103,6 +105,18 @@ const basePackage = "github.com/cloudprober/cloudprober/"
 
 var defaultWritter = io.Writer(os.Stderr)
 
+var defaultLogStore atomic.Pointer[logstore.LogStore]
+
+// SetDefaultLogStore sets the default log store that all new loggers will use.
+func SetDefaultLogStore(store *logstore.LogStore) {
+	defaultLogStore.Store(store)
+}
+
+// DefaultLogStore returns the default log store.
+func DefaultLogStore() *logstore.LogStore {
+	return defaultLogStore.Load()
+}
+
 func replaceAttrs(_ []string, a slog.Attr) slog.Attr {
 	if a.Key == slog.SourceKey {
 		source := a.Value.Any().(*slog.Source)
@@ -112,8 +126,11 @@ func replaceAttrs(_ []string, a slog.Attr) slog.Attr {
 	return a
 }
 
-func parseMinLogLevel() slog.Level {
-	switch strings.ToUpper(*minLogLevel) {
+// ParseLogLevel parses a log level string into an slog.Level.
+// Valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL.
+// Returns slog.LevelInfo for unrecognized values.
+func ParseLogLevel(s string) slog.Level {
+	switch strings.ToUpper(s) {
 	case "DEBUG":
 		return slog.LevelDebug
 	case "INFO":
@@ -125,7 +142,15 @@ func parseMinLogLevel() slog.Level {
 	case "CRITICAL":
 		return criticalLevel
 	}
-	panic("invalid log level: " + *minLogLevel)
+	return slog.LevelInfo
+}
+
+func parseMinLogLevel() slog.Level {
+	level := ParseLogLevel(*minLogLevel)
+	if level == slog.LevelInfo && strings.ToUpper(*minLogLevel) != "INFO" {
+		panic("invalid log level: " + *minLogLevel)
+	}
+	return level
 }
 
 func slogHandler(w io.Writer) slog.Handler {
@@ -197,6 +222,7 @@ type Logger struct {
 	attrs               []slog.Attr
 	systemAttr          string
 	writer              io.Writer
+	logStore            *logstore.LogStore
 }
 
 // Option can be used for adding additional metadata information in logger.
@@ -239,6 +265,10 @@ func newLogger(opts ...Option) *Logger {
 	// Initialize the traditional logger.
 	l.shandler = slogHandler(l.writer)
 
+	if l.logStore == nil {
+		l.logStore = defaultLogStore.Load()
+	}
+
 	if enableDebugLog(*debugLog, *debugLogList, l.attrs...) {
 		l.minLogLevel = slog.LevelDebug
 	}
@@ -269,6 +299,13 @@ func WithWriter(w io.Writer) Option {
 	}
 }
 
+// WithLogStore option sets the log store for in-memory log retention.
+func WithLogStore(store *logstore.LogStore) Option {
+	return func(l *Logger) {
+		l.logStore = store
+	}
+}
+
 func (l *Logger) WithAttributes(attrs ...slog.Attr) *Logger {
 	return &Logger{
 		shandler:            l.shandler,
@@ -280,6 +317,7 @@ func (l *Logger) WithAttributes(attrs ...slog.Attr) *Logger {
 		attrs:               append(l.attrs, attrs...),
 		systemAttr:          l.systemAttr,
 		writer:              l.writer,
+		logStore:            l.logStore,
 	}
 }
 
@@ -421,6 +459,10 @@ func (l *Logger) logAttrs(level slog.Level, depth int, msg string, attrs ...slog
 		l.shandler.WithAttrs(l.attrs).Handle(context.Background(), r)
 	} else {
 		slogHandler(nil).Handle(context.Background(), r)
+	}
+
+	if l != nil && l.logStore != nil {
+		l.logStore.Store(level, msg, append(l.attrs, attrs...))
 	}
 
 	if l != nil && l.gcpLogger != nil {

--- a/logger/logstore/logstore.go
+++ b/logger/logstore/logstore.go
@@ -1,0 +1,280 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package logstore provides an in-memory log store with per-probe ring buffers
+// and a configurable memory ceiling.
+package logstore
+
+import (
+	"log/slog"
+	"slices"
+	"sync"
+	"time"
+)
+
+// LogEntry is a single stored log record.
+type LogEntry struct {
+	Timestamp time.Time
+	Level     slog.Level
+	Message   string
+	Attrs     map[string]string
+	size      int // estimated memory footprint in bytes
+}
+
+// estimateSize returns the estimated memory footprint of the entry.
+func estimateSize(msg string, attrs map[string]string) int {
+	// Base overhead for the struct itself.
+	size := 128
+
+	size += len(msg)
+	for k, v := range attrs {
+		size += len(k) + len(v) + 16 // 16 bytes map entry overhead
+	}
+	return size
+}
+
+// ringBuffer is a dynamically growing circular buffer capped by the LogStore's
+// memory ceiling.
+type ringBuffer struct {
+	entries  []LogEntry
+	writeIdx int
+	count    int
+	memUsed  int64
+}
+
+func (rb *ringBuffer) write(entry LogEntry) (evictedSize int64) {
+	if rb.count < len(rb.entries) {
+		// Still have room in the allocated slice.
+		rb.entries[rb.writeIdx] = entry
+		rb.writeIdx = (rb.writeIdx + 1) % len(rb.entries)
+		rb.count++
+		rb.memUsed += int64(entry.size)
+		return 0
+	}
+
+	// Buffer is full — overwrite oldest entry.
+	evicted := rb.entries[rb.writeIdx]
+	evictedSize = int64(evicted.size)
+	rb.entries[rb.writeIdx] = entry
+	rb.writeIdx = (rb.writeIdx + 1) % len(rb.entries)
+	rb.memUsed += int64(entry.size) - evictedSize
+	return evictedSize
+}
+
+// read returns entries in chronological order.
+func (rb *ringBuffer) read() []LogEntry {
+	if rb.count == 0 {
+		return nil
+	}
+	result := make([]LogEntry, rb.count)
+	if rb.count < len(rb.entries) {
+		copy(result, rb.entries[:rb.count])
+		return result
+	}
+	// Full buffer: oldest is at writeIdx.
+	n := copy(result, rb.entries[rb.writeIdx:])
+	copy(result[n:], rb.entries[:rb.writeIdx])
+	return result
+}
+
+// evictOldest removes the oldest entry and returns its size. Returns 0 if empty.
+func (rb *ringBuffer) evictOldest() int64 {
+	if rb.count == 0 {
+		return 0
+	}
+	oldestIdx := rb.writeIdx - rb.count
+	if oldestIdx < 0 {
+		oldestIdx += len(rb.entries)
+	}
+	evicted := rb.entries[oldestIdx]
+	rb.entries[oldestIdx] = LogEntry{} // release references
+	rb.count--
+	rb.memUsed -= int64(evicted.size)
+	return int64(evicted.size)
+}
+
+const defaultRingSize = 1024
+
+// LogStore holds per-probe ring buffers with a total memory ceiling.
+type LogStore struct {
+	mu            sync.RWMutex
+	probeBuffers  map[string]*ringBuffer
+	globalBuffer  *ringBuffer
+	maxMemBytes   int64
+	curMemBytes   int64
+	minStoreLevel slog.Level
+}
+
+// New creates a new LogStore with the given memory ceiling and minimum log level.
+func New(maxMemBytes int64, minLevel slog.Level) *LogStore {
+	return &LogStore{
+		probeBuffers:  make(map[string]*ringBuffer),
+		globalBuffer:  &ringBuffer{entries: make([]LogEntry, defaultRingSize)},
+		maxMemBytes:   maxMemBytes,
+		minStoreLevel: minLevel,
+	}
+}
+
+// Store adds a log entry to the store. It extracts the probe name from attrs.
+func (ls *LogStore) Store(level slog.Level, msg string, attrs []slog.Attr) {
+	if level < ls.minStoreLevel {
+		return
+	}
+
+	flatAttrs := make(map[string]string, len(attrs))
+	probeName := ""
+	for _, a := range attrs {
+		flatAttrs[a.Key] = a.Value.String()
+		if a.Key == "probe" {
+			probeName = a.Value.String()
+		}
+	}
+
+	entry := LogEntry{
+		Timestamp: time.Now(),
+		Level:     level,
+		Message:   msg,
+		Attrs:     flatAttrs,
+	}
+	entry.size = estimateSize(msg, flatAttrs)
+
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+
+	rb := ls.getOrCreateBuffer(probeName)
+	evictedSize := rb.write(entry)
+
+	ls.curMemBytes += int64(entry.size)
+	if evictedSize > 0 {
+		// The ring buffer itself evicted an entry (buffer was full).
+		ls.curMemBytes -= evictedSize
+	}
+
+	// Evict oldest entries across all buffers until under memory ceiling.
+	ls.evictUntilUnderLimit()
+}
+
+func (ls *LogStore) getOrCreateBuffer(probeName string) *ringBuffer {
+	if probeName == "" {
+		return ls.globalBuffer
+	}
+	rb, ok := ls.probeBuffers[probeName]
+	if !ok {
+		rb = &ringBuffer{entries: make([]LogEntry, defaultRingSize)}
+		ls.probeBuffers[probeName] = rb
+	}
+	return rb
+}
+
+// evictUntilUnderLimit evicts oldest entries from the buffer with the most
+// memory usage until total memory is under the ceiling. Must be called with
+// ls.mu held.
+func (ls *LogStore) evictUntilUnderLimit() {
+	for ls.curMemBytes > ls.maxMemBytes {
+		// Find the buffer using the most memory.
+		var maxBuf *ringBuffer
+		var maxMem int64
+
+		if ls.globalBuffer.memUsed > maxMem && ls.globalBuffer.count > 0 {
+			maxBuf = ls.globalBuffer
+			maxMem = ls.globalBuffer.memUsed
+		}
+		for _, rb := range ls.probeBuffers {
+			if rb.memUsed > maxMem && rb.count > 0 {
+				maxBuf = rb
+				maxMem = rb.memUsed
+			}
+		}
+		if maxBuf == nil {
+			break // nothing to evict
+		}
+		freed := maxBuf.evictOldest()
+		ls.curMemBytes -= freed
+	}
+}
+
+// QueryOpts specifies filters for querying log entries.
+type QueryOpts struct {
+	ProbeName string
+	MinLevel  slog.Level
+	Since     time.Time
+	Until     time.Time
+	Limit     int
+}
+
+// Query returns log entries matching the given filters, in chronological order.
+func (ls *LogStore) Query(opts QueryOpts) []LogEntry {
+	ls.mu.RLock()
+	defer ls.mu.RUnlock()
+
+	var allEntries []LogEntry
+
+	if opts.ProbeName != "" {
+		rb, ok := ls.probeBuffers[opts.ProbeName]
+		if ok {
+			allEntries = rb.read()
+		}
+	} else {
+		// Collect from all buffers.
+		for _, rb := range ls.probeBuffers {
+			allEntries = append(allEntries, rb.read()...)
+		}
+		allEntries = append(allEntries, ls.globalBuffer.read()...)
+	}
+
+	// Filter.
+	var filtered []LogEntry
+	for _, e := range allEntries {
+		if e.Level < opts.MinLevel {
+			continue
+		}
+		if !opts.Since.IsZero() && e.Timestamp.Before(opts.Since) {
+			continue
+		}
+		if !opts.Until.IsZero() && e.Timestamp.After(opts.Until) {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+
+	// Sort by timestamp (entries from different buffers may interleave).
+	if opts.ProbeName == "" && len(filtered) > 1 {
+		sortByTimestamp(filtered)
+	}
+
+	if opts.Limit > 0 && len(filtered) > opts.Limit {
+		// Return the most recent entries.
+		filtered = filtered[len(filtered)-opts.Limit:]
+	}
+
+	return filtered
+}
+
+// ProbeNames returns the names of all probes that have log entries.
+func (ls *LogStore) ProbeNames() []string {
+	ls.mu.RLock()
+	defer ls.mu.RUnlock()
+
+	names := make([]string, 0, len(ls.probeBuffers))
+	for name := range ls.probeBuffers {
+		names = append(names, name)
+	}
+	return names
+}
+
+func sortByTimestamp(entries []LogEntry) {
+	slices.SortFunc(entries, func(a, b LogEntry) int {
+		return a.Timestamp.Compare(b.Timestamp)
+	})
+}

--- a/logger/logstore/logstore.go
+++ b/logger/logstore/logstore.go
@@ -126,19 +126,31 @@ func New(maxMemBytes int64, minLevel slog.Level) *LogStore {
 	}
 }
 
-// Store adds a log entry to the store. It extracts the probe name from attrs.
+// sourceFromAttrs returns the source identifier for a log entry.
+// It prefers "probe", then falls back to "component", then "system".
+func sourceFromAttrs(attrs map[string]string) string {
+	if v := attrs["probe"]; v != "" {
+		return v
+	}
+	if v := attrs["component"]; v != "" {
+		return v
+	}
+	if v := attrs["system"]; v != "" {
+		return v
+	}
+	return ""
+}
+
+// Store adds a log entry to the store. It extracts the source (probe name,
+// component, or system) from attrs to determine which buffer to use.
 func (ls *LogStore) Store(level slog.Level, msg string, attrs []slog.Attr) {
 	if level < ls.minStoreLevel {
 		return
 	}
 
 	flatAttrs := make(map[string]string, len(attrs))
-	probeName := ""
 	for _, a := range attrs {
 		flatAttrs[a.Key] = a.Value.String()
-		if a.Key == "probe" {
-			probeName = a.Value.String()
-		}
 	}
 
 	entry := LogEntry{
@@ -149,10 +161,12 @@ func (ls *LogStore) Store(level slog.Level, msg string, attrs []slog.Attr) {
 	}
 	entry.size = estimateSize(msg, flatAttrs)
 
+	source := sourceFromAttrs(flatAttrs)
+
 	ls.mu.Lock()
 	defer ls.mu.Unlock()
 
-	rb := ls.getOrCreateBuffer(probeName)
+	rb := ls.getOrCreateBuffer(source)
 	evictedSize := rb.write(entry)
 
 	ls.curMemBytes += int64(entry.size)
@@ -165,14 +179,14 @@ func (ls *LogStore) Store(level slog.Level, msg string, attrs []slog.Attr) {
 	ls.evictUntilUnderLimit()
 }
 
-func (ls *LogStore) getOrCreateBuffer(probeName string) *ringBuffer {
-	if probeName == "" {
+func (ls *LogStore) getOrCreateBuffer(source string) *ringBuffer {
+	if source == "" {
 		return ls.globalBuffer
 	}
-	rb, ok := ls.probeBuffers[probeName]
+	rb, ok := ls.probeBuffers[source]
 	if !ok {
 		rb = &ringBuffer{entries: make([]LogEntry, defaultRingSize)}
-		ls.probeBuffers[probeName] = rb
+		ls.probeBuffers[source] = rb
 	}
 	return rb
 }
@@ -206,11 +220,11 @@ func (ls *LogStore) evictUntilUnderLimit() {
 
 // QueryOpts specifies filters for querying log entries.
 type QueryOpts struct {
-	ProbeName string
-	MinLevel  slog.Level
-	Since     time.Time
-	Until     time.Time
-	Limit     int
+	Source   string // probe name, component name, or empty for all
+	MinLevel slog.Level
+	Since    time.Time
+	Until    time.Time
+	Limit    int
 }
 
 // Query returns log entries matching the given filters, in chronological order.
@@ -220,8 +234,8 @@ func (ls *LogStore) Query(opts QueryOpts) []LogEntry {
 
 	var allEntries []LogEntry
 
-	if opts.ProbeName != "" {
-		rb, ok := ls.probeBuffers[opts.ProbeName]
+	if opts.Source != "" {
+		rb, ok := ls.probeBuffers[opts.Source]
 		if ok {
 			allEntries = rb.read()
 		}
@@ -249,7 +263,7 @@ func (ls *LogStore) Query(opts QueryOpts) []LogEntry {
 	}
 
 	// Sort by timestamp (entries from different buffers may interleave).
-	if opts.ProbeName == "" && len(filtered) > 1 {
+	if opts.Source == "" && len(filtered) > 1 {
 		sortByTimestamp(filtered)
 	}
 
@@ -261,8 +275,9 @@ func (ls *LogStore) Query(opts QueryOpts) []LogEntry {
 	return filtered
 }
 
-// ProbeNames returns the names of all probes that have log entries.
-func (ls *LogStore) ProbeNames() []string {
+// SourceNames returns the names of all sources (probes, components) that
+// have log entries.
+func (ls *LogStore) SourceNames() []string {
 	ls.mu.RLock()
 	defer ls.mu.RUnlock()
 

--- a/logger/logstore/logstore_test.go
+++ b/logger/logstore/logstore_test.go
@@ -36,7 +36,7 @@ func TestStoreAndQuery(t *testing.T) {
 	}
 
 	// Query by probe.
-	entries = ls.Query(QueryOpts{ProbeName: "p1"})
+	entries = ls.Query(QueryOpts{Source: "p1"})
 	if len(entries) != 2 {
 		t.Fatalf("expected 2 entries for p1, got %d", len(entries))
 	}
@@ -71,7 +71,7 @@ func TestRingBufferEviction(t *testing.T) {
 		ls.Store(slog.LevelInfo, fmt.Sprintf("msg %d", i), []slog.Attr{slog.String("probe", "p1")})
 	}
 
-	entries := ls.Query(QueryOpts{ProbeName: "p1"})
+	entries := ls.Query(QueryOpts{Source: "p1"})
 	if len(entries) != defaultRingSize {
 		t.Fatalf("expected %d entries (ring buffer size), got %d", defaultRingSize, len(entries))
 	}
@@ -98,7 +98,7 @@ func TestMemoryCeiling(t *testing.T) {
 		t.Errorf("memory usage %d exceeds ceiling 2000", mem)
 	}
 
-	entries := ls.Query(QueryOpts{ProbeName: "p1"})
+	entries := ls.Query(QueryOpts{Source: "p1"})
 	if len(entries) == 0 {
 		t.Error("expected at least some entries")
 	}
@@ -157,13 +157,13 @@ func TestGlobalBuffer(t *testing.T) {
 	}
 }
 
-func TestProbeNames(t *testing.T) {
+func TestSourceNames(t *testing.T) {
 	ls := New(1<<20, slog.LevelInfo)
 
 	ls.Store(slog.LevelInfo, "a", []slog.Attr{slog.String("probe", "p1")})
 	ls.Store(slog.LevelInfo, "b", []slog.Attr{slog.String("probe", "p2")})
 
-	names := ls.ProbeNames()
+	names := ls.SourceNames()
 	if len(names) != 2 {
 		t.Fatalf("expected 2 probe names, got %d", len(names))
 	}

--- a/logger/logstore/logstore_test.go
+++ b/logger/logstore/logstore_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logstore
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStoreAndQuery(t *testing.T) {
+	ls := New(1<<20, slog.LevelInfo) // 1MB ceiling
+
+	ls.Store(slog.LevelInfo, "probe1 msg1", []slog.Attr{slog.String("probe", "p1")})
+	ls.Store(slog.LevelInfo, "probe2 msg1", []slog.Attr{slog.String("probe", "p2")})
+	ls.Store(slog.LevelError, "probe1 err", []slog.Attr{slog.String("probe", "p1")})
+
+	// Query all.
+	entries := ls.Query(QueryOpts{})
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	// Query by probe.
+	entries = ls.Query(QueryOpts{ProbeName: "p1"})
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries for p1, got %d", len(entries))
+	}
+
+	// Query by level.
+	entries = ls.Query(QueryOpts{MinLevel: slog.LevelError})
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 error entry, got %d", len(entries))
+	}
+	if entries[0].Message != "probe1 err" {
+		t.Errorf("expected 'probe1 err', got %q", entries[0].Message)
+	}
+}
+
+func TestMinStoreLevel(t *testing.T) {
+	ls := New(1<<20, slog.LevelWarn)
+
+	ls.Store(slog.LevelInfo, "info msg", []slog.Attr{slog.String("probe", "p1")})
+	ls.Store(slog.LevelWarn, "warn msg", []slog.Attr{slog.String("probe", "p1")})
+
+	entries := ls.Query(QueryOpts{})
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry (info filtered at store level), got %d", len(entries))
+	}
+}
+
+func TestRingBufferEviction(t *testing.T) {
+	ls := New(1<<20, slog.LevelInfo)
+
+	// Write more than defaultRingSize entries to one probe.
+	for i := 0; i < defaultRingSize+100; i++ {
+		ls.Store(slog.LevelInfo, fmt.Sprintf("msg %d", i), []slog.Attr{slog.String("probe", "p1")})
+	}
+
+	entries := ls.Query(QueryOpts{ProbeName: "p1"})
+	if len(entries) != defaultRingSize {
+		t.Fatalf("expected %d entries (ring buffer size), got %d", defaultRingSize, len(entries))
+	}
+
+	// Oldest entries should have been evicted — first entry should be msg 100.
+	if entries[0].Message != "msg 100" {
+		t.Errorf("expected oldest entry 'msg 100', got %q", entries[0].Message)
+	}
+}
+
+func TestMemoryCeiling(t *testing.T) {
+	// Set a very small memory ceiling.
+	ls := New(2000, slog.LevelInfo)
+
+	for i := 0; i < 100; i++ {
+		ls.Store(slog.LevelInfo, fmt.Sprintf("msg %d", i), []slog.Attr{slog.String("probe", "p1")})
+	}
+
+	ls.mu.RLock()
+	mem := ls.curMemBytes
+	ls.mu.RUnlock()
+
+	if mem > 2000 {
+		t.Errorf("memory usage %d exceeds ceiling 2000", mem)
+	}
+
+	entries := ls.Query(QueryOpts{ProbeName: "p1"})
+	if len(entries) == 0 {
+		t.Error("expected at least some entries")
+	}
+	if len(entries) >= 100 {
+		t.Error("expected some entries to have been evicted due to memory ceiling")
+	}
+}
+
+func TestQueryLimit(t *testing.T) {
+	ls := New(1<<20, slog.LevelInfo)
+
+	for i := 0; i < 50; i++ {
+		ls.Store(slog.LevelInfo, fmt.Sprintf("msg %d", i), []slog.Attr{slog.String("probe", "p1")})
+	}
+
+	entries := ls.Query(QueryOpts{Limit: 10})
+	if len(entries) != 10 {
+		t.Fatalf("expected 10 entries with limit, got %d", len(entries))
+	}
+	// Should return the most recent 10.
+	if entries[0].Message != "msg 40" {
+		t.Errorf("expected 'msg 40', got %q", entries[0].Message)
+	}
+}
+
+func TestQueryTimeRange(t *testing.T) {
+	ls := New(1<<20, slog.LevelInfo)
+
+	now := time.Now()
+
+	ls.Store(slog.LevelInfo, "old", []slog.Attr{slog.String("probe", "p1")})
+	// Entries get time.Now() timestamp, so we filter using Since.
+	entries := ls.Query(QueryOpts{Since: now.Add(-time.Second)})
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	entries = ls.Query(QueryOpts{Since: now.Add(time.Hour)})
+	if len(entries) != 0 {
+		t.Fatalf("expected 0 entries for future Since, got %d", len(entries))
+	}
+}
+
+func TestGlobalBuffer(t *testing.T) {
+	ls := New(1<<20, slog.LevelInfo)
+
+	// Store without probe attr.
+	ls.Store(slog.LevelInfo, "global msg", []slog.Attr{slog.String("component", "main")})
+
+	entries := ls.Query(QueryOpts{})
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 global entry, got %d", len(entries))
+	}
+	if entries[0].Attrs["component"] != "main" {
+		t.Errorf("expected component=main, got %v", entries[0].Attrs)
+	}
+}
+
+func TestProbeNames(t *testing.T) {
+	ls := New(1<<20, slog.LevelInfo)
+
+	ls.Store(slog.LevelInfo, "a", []slog.Attr{slog.String("probe", "p1")})
+	ls.Store(slog.LevelInfo, "b", []slog.Attr{slog.String("probe", "p2")})
+
+	names := ls.ProbeNames()
+	if len(names) != 2 {
+		t.Fatalf("expected 2 probe names, got %d", len(names))
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	ls := New(1<<20, slog.LevelInfo)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(probe string) {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				ls.Store(slog.LevelInfo, fmt.Sprintf("msg %d", j), []slog.Attr{slog.String("probe", probe)})
+			}
+		}(fmt.Sprintf("p%d", i))
+	}
+
+	// Concurrent reads.
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				ls.Query(QueryOpts{})
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	entries := ls.Query(QueryOpts{})
+	if len(entries) == 0 {
+		t.Error("expected entries after concurrent writes")
+	}
+}

--- a/prober/proto/service.pb.go
+++ b/prober/proto/service.pb.go
@@ -665,7 +665,11 @@ type GetProbeStatusRequest struct {
 	TimeWindowMinutes *int32 `protobuf:"varint,2,opt,name=time_window_minutes,json=timeWindowMinutes,def=10" json:"time_window_minutes,omitempty"`
 	// Unix epoch timestamp in seconds for the end of the window.
 	// If not provided, it defaults to the current time.
-	EndTimeSec    *int64 `protobuf:"varint,3,opt,name=end_time_sec,json=endTimeSec" json:"end_time_sec,omitempty"`
+	EndTimeSec *int64 `protobuf:"varint,3,opt,name=end_time_sec,json=endTimeSec" json:"end_time_sec,omitempty"`
+	// If true, include recent logs in the response.
+	IncludeLogs *bool `protobuf:"varint,4,opt,name=include_logs,json=includeLogs" json:"include_logs,omitempty"`
+	// Max log entries per probe. Default: 100.
+	LogLimit      *int32 `protobuf:"varint,5,opt,name=log_limit,json=logLimit,def=100" json:"log_limit,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -673,6 +677,7 @@ type GetProbeStatusRequest struct {
 // Default values for GetProbeStatusRequest fields.
 const (
 	Default_GetProbeStatusRequest_TimeWindowMinutes = int32(10)
+	Default_GetProbeStatusRequest_LogLimit          = int32(100)
 )
 
 func (x *GetProbeStatusRequest) Reset() {
@@ -726,6 +731,20 @@ func (x *GetProbeStatusRequest) GetEndTimeSec() int64 {
 	return 0
 }
 
+func (x *GetProbeStatusRequest) GetIncludeLogs() bool {
+	if x != nil && x.IncludeLogs != nil {
+		return *x.IncludeLogs
+	}
+	return false
+}
+
+func (x *GetProbeStatusRequest) GetLogLimit() int32 {
+	if x != nil && x.LogLimit != nil {
+		return *x.LogLimit
+	}
+	return Default_GetProbeStatusRequest_LogLimit
+}
+
 type GetProbeStatusResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ProbeStatus   []*ProbeStatus         `protobuf:"bytes,1,rep,name=probe_status,json=probeStatus" json:"probe_status,omitempty"`
@@ -770,17 +789,94 @@ func (x *GetProbeStatusResponse) GetProbeStatus() []*ProbeStatus {
 	return nil
 }
 
+type LogEntry struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	TimestampSec  *int64                 `protobuf:"varint,1,opt,name=timestamp_sec,json=timestampSec" json:"timestamp_sec,omitempty"`
+	TimestampNsec *int32                 `protobuf:"varint,2,opt,name=timestamp_nsec,json=timestampNsec" json:"timestamp_nsec,omitempty"`
+	Level         *string                `protobuf:"bytes,3,opt,name=level" json:"level,omitempty"`
+	Message       *string                `protobuf:"bytes,4,opt,name=message" json:"message,omitempty"`
+	Attributes    map[string]string      `protobuf:"bytes,5,rep,name=attributes" json:"attributes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LogEntry) Reset() {
+	*x = LogEntry{}
+	mi := &file_github_com_cloudprober_cloudprober_prober_proto_service_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LogEntry) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LogEntry) ProtoMessage() {}
+
+func (x *LogEntry) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_cloudprober_cloudprober_prober_proto_service_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LogEntry.ProtoReflect.Descriptor instead.
+func (*LogEntry) Descriptor() ([]byte, []int) {
+	return file_github_com_cloudprober_cloudprober_prober_proto_service_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *LogEntry) GetTimestampSec() int64 {
+	if x != nil && x.TimestampSec != nil {
+		return *x.TimestampSec
+	}
+	return 0
+}
+
+func (x *LogEntry) GetTimestampNsec() int32 {
+	if x != nil && x.TimestampNsec != nil {
+		return *x.TimestampNsec
+	}
+	return 0
+}
+
+func (x *LogEntry) GetLevel() string {
+	if x != nil && x.Level != nil {
+		return *x.Level
+	}
+	return ""
+}
+
+func (x *LogEntry) GetMessage() string {
+	if x != nil && x.Message != nil {
+		return *x.Message
+	}
+	return ""
+}
+
+func (x *LogEntry) GetAttributes() map[string]string {
+	if x != nil {
+		return x.Attributes
+	}
+	return nil
+}
+
 type ProbeStatus struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          *string                `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
 	TargetStatus  []*TargetStatus        `protobuf:"bytes,2,rep,name=target_status,json=targetStatus" json:"target_status,omitempty"`
+	Logs          []*LogEntry            `protobuf:"bytes,3,rep,name=logs" json:"logs,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ProbeStatus) Reset() {
 	*x = ProbeStatus{}
-	mi := &file_github_com_cloudprober_cloudprober_prober_proto_service_proto_msgTypes[16]
+	mi := &file_github_com_cloudprober_cloudprober_prober_proto_service_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -792,7 +888,7 @@ func (x *ProbeStatus) String() string {
 func (*ProbeStatus) ProtoMessage() {}
 
 func (x *ProbeStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_cloudprober_cloudprober_prober_proto_service_proto_msgTypes[16]
+	mi := &file_github_com_cloudprober_cloudprober_prober_proto_service_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -805,7 +901,7 @@ func (x *ProbeStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProbeStatus.ProtoReflect.Descriptor instead.
 func (*ProbeStatus) Descriptor() ([]byte, []int) {
-	return file_github_com_cloudprober_cloudprober_prober_proto_service_proto_rawDescGZIP(), []int{16}
+	return file_github_com_cloudprober_cloudprober_prober_proto_service_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ProbeStatus) GetName() string {
@@ -822,6 +918,13 @@ func (x *ProbeStatus) GetTargetStatus() []*TargetStatus {
 	return nil
 }
 
+func (x *ProbeStatus) GetLogs() []*LogEntry {
+	if x != nil {
+		return x.Logs
+	}
+	return nil
+}
+
 type TargetStatus struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	TargetName    *string                `protobuf:"bytes,1,opt,name=target_name,json=targetName" json:"target_name,omitempty"`
@@ -833,7 +936,7 @@ type TargetStatus struct {
 
 func (x *TargetStatus) Reset() {
 	*x = TargetStatus{}
-	mi := &file_github_com_cloudprober_cloudprober_prober_proto_service_proto_msgTypes[17]
+	mi := &file_github_com_cloudprober_cloudprober_prober_proto_service_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -845,7 +948,7 @@ func (x *TargetStatus) String() string {
 func (*TargetStatus) ProtoMessage() {}
 
 func (x *TargetStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_cloudprober_cloudprober_prober_proto_service_proto_msgTypes[17]
+	mi := &file_github_com_cloudprober_cloudprober_prober_proto_service_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -858,7 +961,7 @@ func (x *TargetStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TargetStatus.ProtoReflect.Descriptor instead.
 func (*TargetStatus) Descriptor() ([]byte, []int) {
-	return file_github_com_cloudprober_cloudprober_prober_proto_service_proto_rawDescGZIP(), []int{17}
+	return file_github_com_cloudprober_cloudprober_prober_proto_service_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *TargetStatus) GetTargetName() string {
@@ -921,18 +1024,32 @@ const file_github_com_cloudprober_cloudprober_prober_proto_service_proto_rawDesc
 	"\x17SaveProbesConfigRequest\x12\x1b\n" +
 	"\tfile_path\x18\x01 \x01(\tR\bfilePath\"7\n" +
 	"\x18SaveProbesConfigResponse\x12\x1b\n" +
-	"\tfile_path\x18\x01 \x01(\tR\bfilePath\"\x8c\x01\n" +
+	"\tfile_path\x18\x01 \x01(\tR\bfilePath\"\xd1\x01\n" +
 	"\x15GetProbeStatusRequest\x12\x1d\n" +
 	"\n" +
 	"probe_name\x18\x01 \x03(\tR\tprobeName\x122\n" +
 	"\x13time_window_minutes\x18\x02 \x01(\x05:\x0210R\x11timeWindowMinutes\x12 \n" +
 	"\fend_time_sec\x18\x03 \x01(\x03R\n" +
-	"endTimeSec\"U\n" +
+	"endTimeSec\x12!\n" +
+	"\finclude_logs\x18\x04 \x01(\bR\vincludeLogs\x12 \n" +
+	"\tlog_limit\x18\x05 \x01(\x05:\x03100R\blogLimit\"U\n" +
 	"\x16GetProbeStatusResponse\x12;\n" +
-	"\fprobe_status\x18\x01 \x03(\v2\x18.cloudprober.ProbeStatusR\vprobeStatus\"a\n" +
+	"\fprobe_status\x18\x01 \x03(\v2\x18.cloudprober.ProbeStatusR\vprobeStatus\"\x8c\x02\n" +
+	"\bLogEntry\x12#\n" +
+	"\rtimestamp_sec\x18\x01 \x01(\x03R\ftimestampSec\x12%\n" +
+	"\x0etimestamp_nsec\x18\x02 \x01(\x05R\rtimestampNsec\x12\x14\n" +
+	"\x05level\x18\x03 \x01(\tR\x05level\x12\x18\n" +
+	"\amessage\x18\x04 \x01(\tR\amessage\x12E\n" +
+	"\n" +
+	"attributes\x18\x05 \x03(\v2%.cloudprober.LogEntry.AttributesEntryR\n" +
+	"attributes\x1a=\n" +
+	"\x0fAttributesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x8c\x01\n" +
 	"\vProbeStatus\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12>\n" +
-	"\rtarget_status\x18\x02 \x03(\v2\x19.cloudprober.TargetStatusR\ftargetStatus\"_\n" +
+	"\rtarget_status\x18\x02 \x03(\v2\x19.cloudprober.TargetStatusR\ftargetStatus\x12)\n" +
+	"\x04logs\x18\x03 \x03(\v2\x15.cloudprober.LogEntryR\x04logs\"_\n" +
 	"\fTargetStatus\x12\x1f\n" +
 	"\vtarget_name\x18\x01 \x01(\tR\n" +
 	"targetName\x12\x14\n" +
@@ -959,7 +1076,7 @@ func file_github_com_cloudprober_cloudprober_prober_proto_service_proto_rawDescG
 	return file_github_com_cloudprober_cloudprober_prober_proto_service_proto_rawDescData
 }
 
-var file_github_com_cloudprober_cloudprober_prober_proto_service_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
+var file_github_com_cloudprober_cloudprober_prober_proto_service_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_github_com_cloudprober_cloudprober_prober_proto_service_proto_goTypes = []any{
 	(*AddProbeRequest)(nil),          // 0: cloudprober.AddProbeRequest
 	(*AddProbeResponse)(nil),         // 1: cloudprober.AddProbeResponse
@@ -977,40 +1094,44 @@ var file_github_com_cloudprober_cloudprober_prober_proto_service_proto_goTypes =
 	(*SaveProbesConfigResponse)(nil), // 13: cloudprober.SaveProbesConfigResponse
 	(*GetProbeStatusRequest)(nil),    // 14: cloudprober.GetProbeStatusRequest
 	(*GetProbeStatusResponse)(nil),   // 15: cloudprober.GetProbeStatusResponse
-	(*ProbeStatus)(nil),              // 16: cloudprober.ProbeStatus
-	(*TargetStatus)(nil),             // 17: cloudprober.TargetStatus
-	nil,                              // 18: cloudprober.RunProbeResponse.ResultsEntry
-	(*proto.ProbeDef)(nil),           // 19: cloudprober.probes.ProbeDef
-	(*proto1.Endpoint)(nil),          // 20: cloudprober.targets.Endpoint
+	(*LogEntry)(nil),                 // 16: cloudprober.LogEntry
+	(*ProbeStatus)(nil),              // 17: cloudprober.ProbeStatus
+	(*TargetStatus)(nil),             // 18: cloudprober.TargetStatus
+	nil,                              // 19: cloudprober.RunProbeResponse.ResultsEntry
+	nil,                              // 20: cloudprober.LogEntry.AttributesEntry
+	(*proto.ProbeDef)(nil),           // 21: cloudprober.probes.ProbeDef
+	(*proto1.Endpoint)(nil),          // 22: cloudprober.targets.Endpoint
 }
 var file_github_com_cloudprober_cloudprober_prober_proto_service_proto_depIdxs = []int32{
-	19, // 0: cloudprober.AddProbeRequest.probe_config:type_name -> cloudprober.probes.ProbeDef
-	20, // 1: cloudprober.ProbeRunResult.target:type_name -> cloudprober.targets.Endpoint
+	21, // 0: cloudprober.AddProbeRequest.probe_config:type_name -> cloudprober.probes.ProbeDef
+	22, // 1: cloudprober.ProbeRunResult.target:type_name -> cloudprober.targets.Endpoint
 	5,  // 2: cloudprober.ProbeRunResult.result_metrics:type_name -> cloudprober.ResultMetric
 	6,  // 3: cloudprober.ProbeResults.run_result:type_name -> cloudprober.ProbeRunResult
-	18, // 4: cloudprober.RunProbeResponse.results:type_name -> cloudprober.RunProbeResponse.ResultsEntry
-	19, // 5: cloudprober.Probe.config:type_name -> cloudprober.probes.ProbeDef
+	19, // 4: cloudprober.RunProbeResponse.results:type_name -> cloudprober.RunProbeResponse.ResultsEntry
+	21, // 5: cloudprober.Probe.config:type_name -> cloudprober.probes.ProbeDef
 	10, // 6: cloudprober.ListProbesResponse.probe:type_name -> cloudprober.Probe
-	16, // 7: cloudprober.GetProbeStatusResponse.probe_status:type_name -> cloudprober.ProbeStatus
-	17, // 8: cloudprober.ProbeStatus.target_status:type_name -> cloudprober.TargetStatus
-	7,  // 9: cloudprober.RunProbeResponse.ResultsEntry.value:type_name -> cloudprober.ProbeResults
-	0,  // 10: cloudprober.Cloudprober.AddProbe:input_type -> cloudprober.AddProbeRequest
-	2,  // 11: cloudprober.Cloudprober.RemoveProbe:input_type -> cloudprober.RemoveProbeRequest
-	4,  // 12: cloudprober.Cloudprober.RunProbe:input_type -> cloudprober.RunProbeRequest
-	9,  // 13: cloudprober.Cloudprober.ListProbes:input_type -> cloudprober.ListProbesRequest
-	12, // 14: cloudprober.Cloudprober.SaveProbesConfig:input_type -> cloudprober.SaveProbesConfigRequest
-	14, // 15: cloudprober.Cloudprober.GetProbeStatus:input_type -> cloudprober.GetProbeStatusRequest
-	1,  // 16: cloudprober.Cloudprober.AddProbe:output_type -> cloudprober.AddProbeResponse
-	3,  // 17: cloudprober.Cloudprober.RemoveProbe:output_type -> cloudprober.RemoveProbeResponse
-	8,  // 18: cloudprober.Cloudprober.RunProbe:output_type -> cloudprober.RunProbeResponse
-	11, // 19: cloudprober.Cloudprober.ListProbes:output_type -> cloudprober.ListProbesResponse
-	13, // 20: cloudprober.Cloudprober.SaveProbesConfig:output_type -> cloudprober.SaveProbesConfigResponse
-	15, // 21: cloudprober.Cloudprober.GetProbeStatus:output_type -> cloudprober.GetProbeStatusResponse
-	16, // [16:22] is the sub-list for method output_type
-	10, // [10:16] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	17, // 7: cloudprober.GetProbeStatusResponse.probe_status:type_name -> cloudprober.ProbeStatus
+	20, // 8: cloudprober.LogEntry.attributes:type_name -> cloudprober.LogEntry.AttributesEntry
+	18, // 9: cloudprober.ProbeStatus.target_status:type_name -> cloudprober.TargetStatus
+	16, // 10: cloudprober.ProbeStatus.logs:type_name -> cloudprober.LogEntry
+	7,  // 11: cloudprober.RunProbeResponse.ResultsEntry.value:type_name -> cloudprober.ProbeResults
+	0,  // 12: cloudprober.Cloudprober.AddProbe:input_type -> cloudprober.AddProbeRequest
+	2,  // 13: cloudprober.Cloudprober.RemoveProbe:input_type -> cloudprober.RemoveProbeRequest
+	4,  // 14: cloudprober.Cloudprober.RunProbe:input_type -> cloudprober.RunProbeRequest
+	9,  // 15: cloudprober.Cloudprober.ListProbes:input_type -> cloudprober.ListProbesRequest
+	12, // 16: cloudprober.Cloudprober.SaveProbesConfig:input_type -> cloudprober.SaveProbesConfigRequest
+	14, // 17: cloudprober.Cloudprober.GetProbeStatus:input_type -> cloudprober.GetProbeStatusRequest
+	1,  // 18: cloudprober.Cloudprober.AddProbe:output_type -> cloudprober.AddProbeResponse
+	3,  // 19: cloudprober.Cloudprober.RemoveProbe:output_type -> cloudprober.RemoveProbeResponse
+	8,  // 20: cloudprober.Cloudprober.RunProbe:output_type -> cloudprober.RunProbeResponse
+	11, // 21: cloudprober.Cloudprober.ListProbes:output_type -> cloudprober.ListProbesResponse
+	13, // 22: cloudprober.Cloudprober.SaveProbesConfig:output_type -> cloudprober.SaveProbesConfigResponse
+	15, // 23: cloudprober.Cloudprober.GetProbeStatus:output_type -> cloudprober.GetProbeStatusResponse
+	18, // [18:24] is the sub-list for method output_type
+	12, // [12:18] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_github_com_cloudprober_cloudprober_prober_proto_service_proto_init() }
@@ -1024,7 +1145,7 @@ func file_github_com_cloudprober_cloudprober_prober_proto_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_cloudprober_cloudprober_prober_proto_service_proto_rawDesc), len(file_github_com_cloudprober_cloudprober_prober_proto_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   19,
+			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/prober/proto/service.proto
+++ b/prober/proto/service.proto
@@ -110,15 +110,30 @@ message GetProbeStatusRequest {
   // Unix epoch timestamp in seconds for the end of the window.
   // If not provided, it defaults to the current time.
   optional int64 end_time_sec = 3;
+
+  // If true, include recent logs in the response.
+  optional bool include_logs = 4;
+
+  // Max log entries per probe. Default: 100.
+  optional int32 log_limit = 5 [default = 100];
 }
 
 message GetProbeStatusResponse {
   repeated ProbeStatus probe_status = 1;
 }
 
+message LogEntry {
+  optional int64 timestamp_sec = 1;
+  optional int32 timestamp_nsec = 2;
+  optional string level = 3;
+  optional string message = 4;
+  map<string, string> attributes = 5;
+}
+
 message ProbeStatus {
   optional string name = 1;
   repeated TargetStatus target_status = 2;
+  repeated LogEntry logs = 3;
 }
 
 message TargetStatus {

--- a/prober/serviceimpl.go
+++ b/prober/serviceimpl.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	configpb "github.com/cloudprober/cloudprober/config/proto"
+	"github.com/cloudprober/cloudprober/logger"
+	"github.com/cloudprober/cloudprober/logger/logstore"
 	"github.com/cloudprober/cloudprober/metrics/singlerun"
 	pb "github.com/cloudprober/cloudprober/prober/proto"
 	probes_configpb "github.com/cloudprober/cloudprober/probes/proto"
@@ -176,6 +178,25 @@ func (pr *Prober) GetProbeStatus(ctx context.Context, req *pb.GetProbeStatusRequ
 			}
 			probeStatus.TargetStatus = append(probeStatus.TargetStatus, targetStatus)
 		}
+
+		if req.GetIncludeLogs() {
+			if ls := logger.DefaultLogStore(); ls != nil {
+				logEntries := ls.Query(logstore.QueryOpts{
+					ProbeName: psd.Name,
+					Limit:     int(req.GetLogLimit()),
+				})
+				for _, le := range logEntries {
+					probeStatus.Logs = append(probeStatus.Logs, &pb.LogEntry{
+						TimestampSec:  proto.Int64(le.Timestamp.Unix()),
+						TimestampNsec: proto.Int32(int32(le.Timestamp.Nanosecond())),
+						Level:         proto.String(le.Level.String()),
+						Message:       proto.String(le.Message),
+						Attributes:    le.Attrs,
+					})
+				}
+			}
+		}
+
 		resp.ProbeStatus = append(resp.ProbeStatus, probeStatus)
 	}
 	return resp, nil

--- a/prober/serviceimpl.go
+++ b/prober/serviceimpl.go
@@ -182,8 +182,8 @@ func (pr *Prober) GetProbeStatus(ctx context.Context, req *pb.GetProbeStatusRequ
 		if req.GetIncludeLogs() {
 			if ls := logger.DefaultLogStore(); ls != nil {
 				logEntries := ls.Query(logstore.QueryOpts{
-					ProbeName: psd.Name,
-					Limit:     int(req.GetLogLimit()),
+					Source: psd.Name,
+					Limit:  int(req.GetLogLimit()),
 				})
 				for _, le := range logEntries {
 					probeStatus.Logs = append(probeStatus.Logs, &pb.LogEntry{

--- a/web/logs.go
+++ b/web/logs.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"html/template"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -28,20 +29,32 @@ import (
 )
 
 var logsTmpl = template.Must(template.New("logs").Parse(`
-<h3>Probe Logs</h3>
+<h3>Logs</h3>
 
-<form method="get" action="/logs" style="margin-bottom: 1em;">
-  <label>Probe: <input type="text" name="probe" value="{{.Probe}}" placeholder="all"></label>
+<form id="logsForm" method="get" action="/logs" style="margin-bottom: 1em;">
+  <label>Source:
+    <select name="source" onchange="this.form.submit()">
+      <option value="">All</option>
+      {{range .Sources}}
+      <option value="{{.}}" {{if eq . $.Source}}selected{{end}}>{{.}}</option>
+      {{end}}
+    </select>
+  </label>
   <label>Level:
-    <select name="level">
+    <select name="level" onchange="this.form.submit()">
       <option value="DEBUG" {{if eq .Level "DEBUG"}}selected{{end}}>DEBUG</option>
       <option value="INFO" {{if eq .Level "INFO"}}selected{{end}}>INFO</option>
       <option value="WARNING" {{if eq .Level "WARNING"}}selected{{end}}>WARNING</option>
       <option value="ERROR" {{if eq .Level "ERROR"}}selected{{end}}>ERROR</option>
     </select>
   </label>
-  <label>Limit: <input type="number" name="limit" value="{{.Limit}}" style="width:60px"></label>
-  <button type="submit">Filter</button>
+  <label>Limit:
+    <select name="limit" onchange="this.form.submit()">
+      {{range .LimitOptions}}
+      <option value="{{.}}" {{if eq . $.Limit}}selected{{end}}>{{.}}</option>
+      {{end}}
+    </select>
+  </label>
 </form>
 
 {{if .Entries}}
@@ -49,7 +62,7 @@ var logsTmpl = template.Must(template.New("logs").Parse(`
 <tr>
   <th>Time</th>
   <th>Level</th>
-  <th>Probe</th>
+  <th>Source</th>
   <th>Message</th>
   <th>Attributes</th>
 </tr>
@@ -57,7 +70,7 @@ var logsTmpl = template.Must(template.New("logs").Parse(`
 <tr>
   <td style="white-space:nowrap">{{.Time}}</td>
   <td>{{.Level}}</td>
-  <td>{{.Probe}}</td>
+  <td>{{.Source}}</td>
   <td>{{.Message}}</td>
   <td style="font-size:0.8em">{{.Attrs}}</td>
 </tr>
@@ -69,16 +82,18 @@ var logsTmpl = template.Must(template.New("logs").Parse(`
 `))
 
 type logsPageData struct {
-	Probe   string
-	Level   string
-	Limit   int
-	Entries []logEntryView
+	Source       string
+	Sources      []string
+	Level        string
+	Limit        int
+	LimitOptions []int
+	Entries      []logEntryView
 }
 
 type logEntryView struct {
 	Time    string
 	Level   string
-	Probe   string
+	Source  string
 	Message string
 	Attrs   string
 }
@@ -90,6 +105,19 @@ type logEntryJSON struct {
 	Attrs     map[string]string `json:"attrs"`
 }
 
+// sourceLabel returns the display label for a log entry's source.
+func sourceLabel(attrs map[string]string) string {
+	if v := attrs["probe"]; v != "" {
+		return v
+	}
+	if v := attrs["component"]; v != "" {
+		return v
+	}
+	if v := attrs["system"]; v != "" {
+		return v
+	}
+	return ""
+}
 
 func logsHandler(w http.ResponseWriter, r *http.Request) {
 	ls := logger.DefaultLogStore()
@@ -98,7 +126,7 @@ func logsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	probe := r.URL.Query().Get("probe")
+	source := r.URL.Query().Get("source")
 	levelStr := r.URL.Query().Get("level")
 	if levelStr == "" {
 		levelStr = "INFO"
@@ -119,10 +147,10 @@ func logsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	entries := ls.Query(logstore.QueryOpts{
-		ProbeName: probe,
-		MinLevel:  logger.ParseLogLevel(levelStr),
-		Since:     since,
-		Limit:     limit,
+		Source:   source,
+		MinLevel: logger.ParseLogLevel(levelStr),
+		Since:    since,
+		Limit:    limit,
 	})
 
 	if r.URL.Query().Get("format") == "json" {
@@ -140,32 +168,38 @@ func logsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Build source dropdown options.
+	sourceNames := ls.SourceNames()
+	sort.Strings(sourceNames)
+
 	views := make([]logEntryView, len(entries))
 	for i, e := range entries {
-		probeName := e.Attrs["probe"]
-		// Build a compact attrs string excluding probe.
+		// Build a compact attrs string excluding source-related keys.
 		var attrParts []string
 		for k, v := range e.Attrs {
-			if k == "probe" || k == "system" {
+			if k == "probe" || k == "system" || k == "component" {
 				continue
 			}
 			attrParts = append(attrParts, k+"="+v)
 		}
+		sort.Strings(attrParts)
 
 		views[i] = logEntryView{
 			Time:    e.Timestamp.Format("15:04:05.000"),
 			Level:   e.Level.String(),
-			Probe:   probeName,
+			Source:  sourceLabel(e.Attrs),
 			Message: e.Message,
 			Attrs:   strings.Join(attrParts, ", "),
 		}
 	}
 
 	data := logsPageData{
-		Probe:   probe,
-		Level:   strings.ToUpper(levelStr),
-		Limit:   limit,
-		Entries: views,
+		Source:       source,
+		Sources:      sourceNames,
+		Level:        strings.ToUpper(levelStr),
+		Limit:        limit,
+		LimitOptions: []int{50, 100, 200, 500, 1000},
+		Entries:      views,
 	}
 
 	body := resources.ExecTmpl(logsTmpl, data)

--- a/web/logs.go
+++ b/web/logs.go
@@ -76,9 +76,9 @@ var logsTmpl = template.Must(template.New("logs").Parse(`
   .logs-table .time { white-space: nowrap; color: #666; }
   .logs-table .level-ERROR, .logs-table .level-WARN { color: #c00; font-weight: bold; }
   .logs-table .level-DEBUG { color: #999; }
-  .logs-table .source { color: #0066cc; }
-  .logs-table .msg { width: 60%; }
-  .logs-table .attrs { width: 15%; }
+  .logs-table .source { color: #0066cc; white-space: nowrap; }
+  .logs-table .msg { width: 55%; }
+  .logs-table .attrs { width: 20%; }
   .logs-empty { color: #999; margin-top: 20px; }
 </style>
 

--- a/web/logs.go
+++ b/web/logs.go
@@ -77,7 +77,7 @@ var logsTmpl = template.Must(template.New("logs").Parse(`
   .logs-table .level-ERROR, .logs-table .level-WARN { color: #c00; font-weight: bold; }
   .logs-table .level-DEBUG { color: #999; }
   .logs-table .source { color: #0066cc; }
-  .logs-table .attrs { color: #888; font-size: 12px; }
+  .logs-table .attrs { }
   .logs-empty { color: #999; margin-top: 20px; }
 </style>
 

--- a/web/logs.go
+++ b/web/logs.go
@@ -77,7 +77,8 @@ var logsTmpl = template.Must(template.New("logs").Parse(`
   .logs-table .level-ERROR, .logs-table .level-WARN { color: #c00; font-weight: bold; }
   .logs-table .level-DEBUG { color: #999; }
   .logs-table .source { color: #0066cc; }
-  .logs-table .attrs { }
+  .logs-table .msg { width: 60%; }
+  .logs-table .attrs { width: 15%; }
   .logs-empty { color: #999; margin-top: 20px; }
 </style>
 
@@ -128,7 +129,7 @@ var logsTmpl = template.Must(template.New("logs").Parse(`
   <td class="time">{{.Time}}</td>
   <td class="level-{{.Level}}">{{.Level}}</td>
   <td class="source">{{.Source}}</td>
-  <td>{{.Message}}</td>
+  <td class="msg">{{.Message}}</td>
   <td class="attrs">{{.Attrs}}</td>
 </tr>
 {{end}}

--- a/web/logs.go
+++ b/web/logs.go
@@ -1,0 +1,173 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package web
+
+import (
+	"encoding/json"
+	"html/template"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cloudprober/cloudprober/logger"
+	"github.com/cloudprober/cloudprober/logger/logstore"
+	"github.com/cloudprober/cloudprober/web/resources"
+)
+
+var logsTmpl = template.Must(template.New("logs").Parse(`
+<h3>Probe Logs</h3>
+
+<form method="get" action="/logs" style="margin-bottom: 1em;">
+  <label>Probe: <input type="text" name="probe" value="{{.Probe}}" placeholder="all"></label>
+  <label>Level:
+    <select name="level">
+      <option value="DEBUG" {{if eq .Level "DEBUG"}}selected{{end}}>DEBUG</option>
+      <option value="INFO" {{if eq .Level "INFO"}}selected{{end}}>INFO</option>
+      <option value="WARNING" {{if eq .Level "WARNING"}}selected{{end}}>WARNING</option>
+      <option value="ERROR" {{if eq .Level "ERROR"}}selected{{end}}>ERROR</option>
+    </select>
+  </label>
+  <label>Limit: <input type="number" name="limit" value="{{.Limit}}" style="width:60px"></label>
+  <button type="submit">Filter</button>
+</form>
+
+{{if .Entries}}
+<table border="1" cellpadding="4" cellspacing="0" style="border-collapse:collapse; font-size:0.9em;">
+<tr>
+  <th>Time</th>
+  <th>Level</th>
+  <th>Probe</th>
+  <th>Message</th>
+  <th>Attributes</th>
+</tr>
+{{range .Entries}}
+<tr>
+  <td style="white-space:nowrap">{{.Time}}</td>
+  <td>{{.Level}}</td>
+  <td>{{.Probe}}</td>
+  <td>{{.Message}}</td>
+  <td style="font-size:0.8em">{{.Attrs}}</td>
+</tr>
+{{end}}
+</table>
+{{else}}
+<p>No log entries found.</p>
+{{end}}
+`))
+
+type logsPageData struct {
+	Probe   string
+	Level   string
+	Limit   int
+	Entries []logEntryView
+}
+
+type logEntryView struct {
+	Time    string
+	Level   string
+	Probe   string
+	Message string
+	Attrs   string
+}
+
+type logEntryJSON struct {
+	Timestamp string            `json:"timestamp"`
+	Level     string            `json:"level"`
+	Message   string            `json:"message"`
+	Attrs     map[string]string `json:"attrs"`
+}
+
+
+func logsHandler(w http.ResponseWriter, r *http.Request) {
+	ls := logger.DefaultLogStore()
+	if ls == nil {
+		http.Error(w, "log store is not enabled", http.StatusServiceUnavailable)
+		return
+	}
+
+	probe := r.URL.Query().Get("probe")
+	levelStr := r.URL.Query().Get("level")
+	if levelStr == "" {
+		levelStr = "INFO"
+	}
+	limitStr := r.URL.Query().Get("limit")
+	limit := 200
+	if limitStr != "" {
+		if v, err := strconv.Atoi(limitStr); err == nil && v > 0 {
+			limit = v
+		}
+	}
+	sinceStr := r.URL.Query().Get("since")
+	var since time.Time
+	if sinceStr != "" {
+		if v, err := strconv.ParseInt(sinceStr, 10, 64); err == nil {
+			since = time.Unix(v, 0)
+		}
+	}
+
+	entries := ls.Query(logstore.QueryOpts{
+		ProbeName: probe,
+		MinLevel:  logger.ParseLogLevel(levelStr),
+		Since:     since,
+		Limit:     limit,
+	})
+
+	if r.URL.Query().Get("format") == "json" {
+		w.Header().Set("Content-Type", "application/json")
+		jsonEntries := make([]logEntryJSON, len(entries))
+		for i, e := range entries {
+			jsonEntries[i] = logEntryJSON{
+				Timestamp: e.Timestamp.Format(time.RFC3339Nano),
+				Level:     e.Level.String(),
+				Message:   e.Message,
+				Attrs:     e.Attrs,
+			}
+		}
+		json.NewEncoder(w).Encode(jsonEntries)
+		return
+	}
+
+	views := make([]logEntryView, len(entries))
+	for i, e := range entries {
+		probeName := e.Attrs["probe"]
+		// Build a compact attrs string excluding probe.
+		var attrParts []string
+		for k, v := range e.Attrs {
+			if k == "probe" || k == "system" {
+				continue
+			}
+			attrParts = append(attrParts, k+"="+v)
+		}
+
+		views[i] = logEntryView{
+			Time:    e.Timestamp.Format("15:04:05.000"),
+			Level:   e.Level.String(),
+			Probe:   probeName,
+			Message: e.Message,
+			Attrs:   strings.Join(attrParts, ", "),
+		}
+	}
+
+	data := logsPageData{
+		Probe:   probe,
+		Level:   strings.ToUpper(levelStr),
+		Limit:   limit,
+		Entries: views,
+	}
+
+	body := resources.ExecTmpl(logsTmpl, data)
+	w.Write([]byte(resources.RenderPage("/logs", body)))
+}

--- a/web/logs.go
+++ b/web/logs.go
@@ -29,36 +29,91 @@ import (
 )
 
 var logsTmpl = template.Must(template.New("logs").Parse(`
+<style>
+  .logs-filters {
+    background: #E1F6FF;
+    padding: 8px 12px;
+    border-radius: 4px;
+    margin-bottom: 12px;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+  .logs-filters label {
+    font-weight: bold;
+    font-size: 13px;
+  }
+  .logs-filters select {
+    padding: 4px 8px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    font-size: 13px;
+    background: white;
+  }
+  .logs-table {
+    border-collapse: collapse;
+    border-spacing: 0;
+    width: 100%;
+    font-family: monospace;
+    font-size: 13px;
+  }
+  .logs-table th {
+    background: #f0f0f0;
+    text-align: left;
+    padding: 6px 10px;
+    border: 1px solid #ddd;
+    white-space: nowrap;
+  }
+  .logs-table td {
+    padding: 4px 10px;
+    border: 1px solid #eee;
+    max-width: 600px;
+    word-wrap: break-word;
+    vertical-align: top;
+  }
+  .logs-table tr:hover { background: #f8f8f8; }
+  .logs-table .time { white-space: nowrap; color: #666; }
+  .logs-table .level-ERROR, .logs-table .level-WARN { color: #c00; font-weight: bold; }
+  .logs-table .level-DEBUG { color: #999; }
+  .logs-table .source { color: #0066cc; }
+  .logs-table .attrs { color: #888; font-size: 12px; }
+  .logs-empty { color: #999; margin-top: 20px; }
+</style>
+
 <h3>Logs</h3>
 
-<form id="logsForm" method="get" action="/logs" style="margin-bottom: 1em;">
-  <label>Source:
-    <select name="source" onchange="this.form.submit()">
-      <option value="">All</option>
-      {{range .Sources}}
-      <option value="{{.}}" {{if eq . $.Source}}selected{{end}}>{{.}}</option>
-      {{end}}
-    </select>
-  </label>
-  <label>Level:
-    <select name="level" onchange="this.form.submit()">
-      <option value="DEBUG" {{if eq .Level "DEBUG"}}selected{{end}}>DEBUG</option>
-      <option value="INFO" {{if eq .Level "INFO"}}selected{{end}}>INFO</option>
-      <option value="WARNING" {{if eq .Level "WARNING"}}selected{{end}}>WARNING</option>
-      <option value="ERROR" {{if eq .Level "ERROR"}}selected{{end}}>ERROR</option>
-    </select>
-  </label>
-  <label>Limit:
-    <select name="limit" onchange="this.form.submit()">
-      {{range .LimitOptions}}
-      <option value="{{.}}" {{if eq . $.Limit}}selected{{end}}>{{.}}</option>
-      {{end}}
-    </select>
-  </label>
+<form id="logsForm" method="get" action="/logs">
+  <div class="logs-filters">
+    <label>Source:
+      <select name="source" onchange="this.form.submit()">
+        <option value="">All</option>
+        {{range .Sources}}
+        <option value="{{.}}" {{if eq . $.Source}}selected{{end}}>{{.}}</option>
+        {{end}}
+      </select>
+    </label>
+    <label>Level:
+      <select name="level" onchange="this.form.submit()">
+        <option value="DEBUG" {{if eq .Level "DEBUG"}}selected{{end}}>DEBUG</option>
+        <option value="INFO" {{if eq .Level "INFO"}}selected{{end}}>INFO</option>
+        <option value="WARNING" {{if eq .Level "WARNING"}}selected{{end}}>WARNING</option>
+        <option value="ERROR" {{if eq .Level "ERROR"}}selected{{end}}>ERROR</option>
+      </select>
+    </label>
+    <label>Limit:
+      <select name="limit" onchange="this.form.submit()">
+        {{range .LimitOptions}}
+        <option value="{{.}}" {{if eq . $.Limit}}selected{{end}}>{{.}}</option>
+        {{end}}
+      </select>
+    </label>
+  </div>
 </form>
 
 {{if .Entries}}
-<table border="1" cellpadding="4" cellspacing="0" style="border-collapse:collapse; font-size:0.9em;">
+<table class="logs-table">
+<thead>
 <tr>
   <th>Time</th>
   <th>Level</th>
@@ -66,18 +121,21 @@ var logsTmpl = template.Must(template.New("logs").Parse(`
   <th>Message</th>
   <th>Attributes</th>
 </tr>
+</thead>
+<tbody>
 {{range .Entries}}
 <tr>
-  <td style="white-space:nowrap">{{.Time}}</td>
-  <td>{{.Level}}</td>
-  <td>{{.Source}}</td>
+  <td class="time">{{.Time}}</td>
+  <td class="level-{{.Level}}">{{.Level}}</td>
+  <td class="source">{{.Source}}</td>
   <td>{{.Message}}</td>
-  <td style="font-size:0.8em">{{.Attrs}}</td>
+  <td class="attrs">{{.Attrs}}</td>
 </tr>
 {{end}}
+</tbody>
 </table>
 {{else}}
-<p>No log entries found.</p>
+<p class="logs-empty">No log entries found.</p>
 {{end}}
 `))
 

--- a/web/web.go
+++ b/web/web.go
@@ -182,5 +182,9 @@ func InitWithDataFuncs(fn DataFuncs) error {
 		}
 	}
 
+	if err := state.AddWebHandler("/logs", logsHandler); err != nil {
+		return err
+	}
+
 	return state.AddWebHandler("/static/", http.FileServer(http.FS(content)).ServeHTTP)
 }


### PR DESCRIPTION
## Summary
- Add per-probe in-memory log storage with configurable memory ceiling (`--log_store_max_mem_mb`, default 50MB)
- Integrate with existing logger package — all probe logs captured automatically, zero probe code changes
- Expose logs via web UI (`/logs`), JSON API (`/logs?format=json`), and gRPC (`GetProbeStatus` with `include_logs=true`)

## Details

**New package `logger/logstore`**: Per-probe ring buffers backed by a total memory ceiling. When the ceiling is hit, oldest entries are evicted from the buffer using the most memory. Thread-safe via `sync.RWMutex`.

**Logger integration**: Added `logStore` field to `Logger`, auto-attached via `atomic.Pointer`-based global default. `logAttrs()` writes to the store after stderr output. `WithAttributes()` propagates the store to sub-loggers.

**gRPC**: Extended `GetProbeStatusRequest` with `include_logs` (bool) and `log_limit` (int32, default 100). Added `LogEntry` message and `repeated LogEntry logs` to `ProbeStatus`.

**Web UI**: `/logs` endpoint with HTML table view (filterable by probe, level, limit) and JSON output (`?format=json`).

**Flags**:
- `--log_store_max_mem_mb` (default 50, 0 to disable)
- `--log_store_min_level` (default INFO)

## Test plan
- [x] `go test ./logger/logstore/...` — ring buffer, memory ceiling, concurrent access, query filtering
- [x] `go test ./logger/...` — logger integration
- [x] `go test ./web/...` — web handler
- [x] `go build ./...` — full build passes
- [ ] Manual: run cloudprober, visit `/logs`, verify logs appear
- [ ] Manual: `grpcurl` call `GetProbeStatus` with `include_logs=true`