### PR TITLE
[probes.common.command] Reduce test flakiness on CI

### DIFF
--- a/probes/common/command/command_test.go
+++ b/probes/common/command/command_test.go
@@ -44,7 +44,7 @@ func TestShellProcessSuccess(t *testing.T) {
 	}
 	fmt.Fprintf(os.Stderr, "Running test command. Env: %s\n", strings.Join(exportEnvList, ","))
 
-	pauseTime := 10 * time.Millisecond
+	pauseTime := 50 * time.Millisecond
 	pauseSec, _ := strconv.Atoi(os.Getenv("GO_CP_TEST_PAUSE"))
 	if pauseSec != 0 {
 		pauseTime = time.Duration(pauseSec) * time.Second
@@ -139,11 +139,10 @@ func testCommandExecute(t *testing.T, disableStreaming bool) {
 
 		// Windows test environment is bad with timestamps.
 		if runtime.GOOS != "windows" {
-			// Verify that difference between first two timestamps is at least 20ms
-			// (subprocess sleeps 20ms between cmd and args output).
-			assert.True(t, outputTS[1] >= outputTS[0]+10, "gap between cmd and arg not more than 20ms")
-			// Verify that difference between second two timestamps is less than 20ms
-			assert.True(t, outputTS[2] < outputTS[1]+10, "gap between arg and env not less than 20ms")
+			// Subprocess sleeps 50ms between cmd and args; use a 25ms
+			// threshold to tolerate scheduling jitter on busy CI runners.
+			assert.True(t, outputTS[1] >= outputTS[0]+25, "gap between cmd and args is less than 25ms")
+			assert.True(t, outputTS[2] < outputTS[1]+25, "gap between args and env is not less than 25ms")
 		}
 	}
 }


### PR DESCRIPTION
Bump subprocess pause from 10ms to 50ms and the timestamp-gap assertion threshold from 10ms to 25ms. The previous 10ms margin was too tight: on busy GitHub Actions runners, goroutine scheduling jitter can delay the first timestamp capture enough that the millisecond-rounded gap between `cmd` and `args` output falls below 10ms, causing intermittent failures of `TestCommand/disable-streaming:false`.