### PR TITLE
[probes.starlark] Expose probe-level vars to scripts via vars builtin

### DIFF
--- a/probes/starlark/builtins.go
+++ b/probes/starlark/builtins.go
@@ -27,11 +27,14 @@ import (
 )
 
 // builtins returns the predeclared globals available to every script.
-// Phase 1 surface: http (get, post), assert (status).
-func builtins() starlarklib.StringDict {
+// Phase 1 surface: http (get, post), assert (status). Plus vars (get),
+// pre-baked from the probe's ProbeConf.vars map (static for the
+// runtime's lifetime, so no per-run plumbing is needed).
+func builtins(vars map[string]string) starlarklib.StringDict {
 	return starlarklib.StringDict{
 		"http":   httpModule(),
 		"assert": assertModule(),
+		"vars":   varsModule(vars),
 	}
 }
 
@@ -194,6 +197,36 @@ func (r *response) jsonMethod(_ *starlarklib.Thread, _ *starlarklib.Builtin, arg
 		return nil, fmt.Errorf("Response.json: %v", err)
 	}
 	return goToStarlark(v)
+}
+
+// ----------------------------------------------------------------------------
+// vars module
+
+// varsModule binds the ProbeConf.vars map into a Starlark module with a
+// single accessor: vars.get(name, default=None). The map is captured by
+// closure so we don't need thread-local plumbing — vars are static for
+// the runtime's lifetime.
+func varsModule(vars map[string]string) *starlarkstruct.Module {
+	get := func(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
+		var name string
+		var dflt starlarklib.Value = starlarklib.None
+		if err := starlarklib.UnpackArgs("vars.get", args, kwargs,
+			"name", &name,
+			"default?", &dflt,
+		); err != nil {
+			return nil, err
+		}
+		if v, ok := vars[name]; ok {
+			return starlarklib.String(v), nil
+		}
+		return dflt, nil
+	}
+	return &starlarkstruct.Module{
+		Name: "vars",
+		Members: starlarklib.StringDict{
+			"get": starlarklib.NewBuiltin("vars.get", get),
+		},
+	}
 }
 
 // ----------------------------------------------------------------------------

--- a/probes/starlark/builtins.go
+++ b/probes/starlark/builtins.go
@@ -27,9 +27,6 @@ import (
 )
 
 // builtins returns the predeclared globals available to every script.
-// Phase 1 surface: http (get, post), assert (status). Plus vars (get),
-// pre-baked from the probe's ProbeConf.vars map (static for the
-// runtime's lifetime, so no per-run plumbing is needed).
 func builtins(vars map[string]string) starlarklib.StringDict {
 	return starlarklib.StringDict{
 		"http":   httpModule(),
@@ -202,10 +199,6 @@ func (r *response) jsonMethod(_ *starlarklib.Thread, _ *starlarklib.Builtin, arg
 // ----------------------------------------------------------------------------
 // vars module
 
-// varsModule binds the ProbeConf.vars map into a Starlark module with a
-// single accessor: vars.get(name, default=None). The map is captured by
-// closure so we don't need thread-local plumbing — vars are static for
-// the runtime's lifetime.
 func varsModule(vars map[string]string) *starlarkstruct.Module {
 	get := func(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
 		var name string

--- a/probes/starlark/proto/config.pb.go
+++ b/probes/starlark/proto/config.pb.go
@@ -51,16 +51,12 @@ type ProbeConf struct {
 	//
 	// Defaults to "probe".
 	EntryPoint *string `protobuf:"bytes,3,opt,name=entry_point,json=entryPoint,def=probe" json:"entry_point,omitempty"`
-	// Variables exposed to the script via the `vars` builtin:
+	// Variables exposed to the script via vars.get(name, default=None).
 	//
-	//	vars.get("KEY")          -> value, or None if missing
-	//	vars.get("KEY", "fallback")
-	//
-	// Deliberately not named env_var: there's no subprocess here, so the
-	// external/browser-probe meaning ("passed to subprocess env") would
-	// mislead. If you want a host environment value, bake it in via the
-	// existing config-load template layer (e.g. {{ envVar "PASS" }}); the
-	// script just sees the resolved string.
+	// Deliberately not named env_var: external/browser probes use that name
+	// for "passed to subprocess env"; there's no subprocess here. For host
+	// environment values, bake them in via the config-load template layer
+	// (e.g. {{ envVar "PASS" }}).
 	Vars          map[string]string `protobuf:"bytes,4,rep,name=vars" json:"vars,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/probes/starlark/proto/config.pb.go
+++ b/probes/starlark/proto/config.pb.go
@@ -50,7 +50,18 @@ type ProbeConf struct {
 	//	    ...
 	//
 	// Defaults to "probe".
-	EntryPoint    *string `protobuf:"bytes,3,opt,name=entry_point,json=entryPoint,def=probe" json:"entry_point,omitempty"`
+	EntryPoint *string `protobuf:"bytes,3,opt,name=entry_point,json=entryPoint,def=probe" json:"entry_point,omitempty"`
+	// Variables exposed to the script via the `vars` builtin:
+	//
+	//	vars.get("KEY")          -> value, or None if missing
+	//	vars.get("KEY", "fallback")
+	//
+	// Deliberately not named env_var: there's no subprocess here, so the
+	// external/browser-probe meaning ("passed to subprocess env") would
+	// mislead. If you want a host environment value, bake it in via the
+	// existing config-load template layer (e.g. {{ envVar "PASS" }}); the
+	// script just sees the resolved string.
+	Vars          map[string]string `protobuf:"bytes,4,rep,name=vars" json:"vars,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -111,17 +122,28 @@ func (x *ProbeConf) GetEntryPoint() string {
 	return Default_ProbeConf_EntryPoint
 }
 
+func (x *ProbeConf) GetVars() map[string]string {
+	if x != nil {
+		return x.Vars
+	}
+	return nil
+}
+
 var File_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto protoreflect.FileDescriptor
 
 const file_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto_rawDesc = "" +
 	"\n" +
-	"Egithub.com/cloudprober/cloudprober/probes/starlark/proto/config.proto\x12\x1bcloudprober.probes.starlark\"l\n" +
+	"Egithub.com/cloudprober/cloudprober/probes/starlark/proto/config.proto\x12\x1bcloudprober.probes.starlark\"\xeb\x01\n" +
 	"\tProbeConf\x12\x16\n" +
 	"\x06source\x18\x01 \x01(\tR\x06source\x12\x1f\n" +
 	"\vsource_file\x18\x02 \x01(\tR\n" +
 	"sourceFile\x12&\n" +
 	"\ventry_point\x18\x03 \x01(\t:\x05probeR\n" +
-	"entryPointB:Z8github.com/cloudprober/cloudprober/probes/starlark/proto"
+	"entryPoint\x12D\n" +
+	"\x04vars\x18\x04 \x03(\v20.cloudprober.probes.starlark.ProbeConf.VarsEntryR\x04vars\x1a7\n" +
+	"\tVarsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B:Z8github.com/cloudprober/cloudprober/probes/starlark/proto"
 
 var (
 	file_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto_rawDescOnce sync.Once
@@ -135,16 +157,18 @@ func file_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto_
 	return file_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto_rawDescData
 }
 
-var file_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto_goTypes = []any{
 	(*ProbeConf)(nil), // 0: cloudprober.probes.starlark.ProbeConf
+	nil,               // 1: cloudprober.probes.starlark.ProbeConf.VarsEntry
 }
 var file_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto_depIdxs = []int32{
-	0, // [0:0] is the sub-list for method output_type
-	0, // [0:0] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	1, // 0: cloudprober.probes.starlark.ProbeConf.vars:type_name -> cloudprober.probes.starlark.ProbeConf.VarsEntry
+	1, // [1:1] is the sub-list for method output_type
+	1, // [1:1] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto_init() }
@@ -158,7 +182,7 @@ func file_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto_
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto_rawDesc), len(file_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   1,
+			NumMessages:   2,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/probes/starlark/proto/config.proto
+++ b/probes/starlark/proto/config.proto
@@ -30,4 +30,15 @@ message ProbeConf {
   //       ...
   // Defaults to "probe".
   optional string entry_point = 3 [default = "probe"];
+
+  // Variables exposed to the script via the `vars` builtin:
+  //   vars.get("KEY")          -> value, or None if missing
+  //   vars.get("KEY", "fallback")
+  //
+  // Deliberately not named env_var: there's no subprocess here, so the
+  // external/browser-probe meaning ("passed to subprocess env") would
+  // mislead. If you want a host environment value, bake it in via the
+  // existing config-load template layer (e.g. {{ envVar "PASS" }}); the
+  // script just sees the resolved string.
+  map<string, string> vars = 4;
 }

--- a/probes/starlark/proto/config.proto
+++ b/probes/starlark/proto/config.proto
@@ -31,14 +31,11 @@ message ProbeConf {
   // Defaults to "probe".
   optional string entry_point = 3 [default = "probe"];
 
-  // Variables exposed to the script via the `vars` builtin:
-  //   vars.get("KEY")          -> value, or None if missing
-  //   vars.get("KEY", "fallback")
+  // Variables exposed to the script via vars.get(name, default=None).
   //
-  // Deliberately not named env_var: there's no subprocess here, so the
-  // external/browser-probe meaning ("passed to subprocess env") would
-  // mislead. If you want a host environment value, bake it in via the
-  // existing config-load template layer (e.g. {{ envVar "PASS" }}); the
-  // script just sees the resolved string.
+  // Deliberately not named env_var: external/browser probes use that name
+  // for "passed to subprocess env"; there's no subprocess here. For host
+  // environment values, bake them in via the config-load template layer
+  // (e.g. {{ envVar "PASS" }}).
   map<string, string> vars = 4;
 }

--- a/probes/starlark/runtime.go
+++ b/probes/starlark/runtime.go
@@ -86,7 +86,11 @@ type Runtime struct {
 // exists with the expected arity. Module-level code runs once here and is
 // bounded by ctx; runtime calls to Run cannot mutate the resulting globals
 // (Starlark freezes them).
-func NewRuntime(ctx context.Context, name, source, entryPoint string, l *logger.Logger) (*Runtime, error) {
+//
+// vars is the ProbeConf.vars map (may be nil) exposed via the `vars` builtin.
+// It is captured by the module closure once at compile time — no per-run
+// plumbing — because vars are static for the runtime's lifetime.
+func NewRuntime(ctx context.Context, name, source, entryPoint string, vars map[string]string, l *logger.Logger) (*Runtime, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -96,7 +100,7 @@ func NewRuntime(ctx context.Context, name, source, entryPoint string, l *logger.
 		l:          l,
 		httpClient: &http.Client{},
 	}
-	rt.predeclared = builtins()
+	rt.predeclared = builtins(vars)
 
 	// One-shot thread used only to evaluate the file's top level. After
 	// ExecFile returns we discard it; the resulting globals are reused.

--- a/probes/starlark/runtime.go
+++ b/probes/starlark/runtime.go
@@ -86,10 +86,6 @@ type Runtime struct {
 // exists with the expected arity. Module-level code runs once here and is
 // bounded by ctx; runtime calls to Run cannot mutate the resulting globals
 // (Starlark freezes them).
-//
-// vars is the ProbeConf.vars map (may be nil) exposed via the `vars` builtin.
-// It is captured by the module closure once at compile time — no per-run
-// plumbing — because vars are static for the runtime's lifetime.
 func NewRuntime(ctx context.Context, name, source, entryPoint string, vars map[string]string, l *logger.Logger) (*Runtime, error) {
 	if ctx == nil {
 		ctx = context.Background()

--- a/probes/starlark/runtime_test.go
+++ b/probes/starlark/runtime_test.go
@@ -38,7 +38,7 @@ def probe(target):
 	defer cancel()
 
 	start := time.Now()
-	_, err := NewRuntime(ctx, "script-load-timeout", source, "probe", &logger.Logger{})
+	_, err := NewRuntime(ctx, "script-load-timeout", source, "probe", nil, &logger.Logger{})
 	elapsed := time.Since(start)
 
 	assert.Error(t, err)

--- a/probes/starlark/starlark.go
+++ b/probes/starlark/starlark.go
@@ -95,7 +95,7 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 	loadCtx, cancel := context.WithTimeout(context.Background(), loadTimeout)
 	defer cancel()
 
-	rt, err := NewRuntime(loadCtx, name, source, entryPoint, p.l)
+	rt, err := NewRuntime(loadCtx, name, source, entryPoint, p.c.GetVars(), p.l)
 	if err != nil {
 		return fmt.Errorf("starlark compile error: %v", err)
 	}

--- a/probes/starlark/starlark_test.go
+++ b/probes/starlark/starlark_test.go
@@ -621,9 +621,6 @@ func TestInit_WrongConfigType(t *testing.T) {
 // ---------------------------------------------------------------------------
 // vars builtin
 
-// TestVars_GetReturnsConfiguredValues exercises the happy path: configured
-// keys flow through `vars.get(name)` as strings. The script asserts the
-// expected values and fails the probe on mismatch.
 func TestVars_GetReturnsConfiguredValues(t *testing.T) {
 	source := `
 def probe(target):
@@ -650,8 +647,6 @@ def probe(target):
 	assert.True(t, results[0].Success, "err=%v", results[0].Error)
 }
 
-// TestVars_GetMissingKey covers both missing-key paths: the no-default form
-// returns None, and the explicit-default form returns the supplied value.
 func TestVars_GetMissingKey(t *testing.T) {
 	source := `
 def probe(target):
@@ -675,10 +670,6 @@ def probe(target):
 	assert.True(t, results[0].Success, "err=%v", results[0].Error)
 }
 
-// TestVars_FlowsIntoHTTPRequest verifies the realistic use case: pulling a
-// secret out of `vars` and using it in an http call. The test server
-// rejects requests without the expected Authorization header, so success
-// implies vars.get round-tripped correctly.
 func TestVars_FlowsIntoHTTPRequest(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer s3cret" {

--- a/probes/starlark/starlark_test.go
+++ b/probes/starlark/starlark_test.go
@@ -413,11 +413,11 @@ def probe(target):
 // TestHTTP_RuntimeOwnsClient verifies the review comment fix: each Runtime
 // has its own *http.Client rather than reusing http.DefaultClient.
 func TestHTTP_RuntimeOwnsClient(t *testing.T) {
-	rt1, err := NewRuntime(context.Background(), "rt1", "def probe(t): pass\n", "probe", &logger.Logger{})
+	rt1, err := NewRuntime(context.Background(), "rt1", "def probe(t): pass\n", "probe", nil, &logger.Logger{})
 	if err != nil {
 		t.Fatalf("rt1: %v", err)
 	}
-	rt2, err := NewRuntime(context.Background(), "rt2", "def probe(t): pass\n", "probe", &logger.Logger{})
+	rt2, err := NewRuntime(context.Background(), "rt2", "def probe(t): pass\n", "probe", nil, &logger.Logger{})
 	if err != nil {
 		t.Fatalf("rt2: %v", err)
 	}
@@ -616,4 +616,94 @@ func TestInit_WrongConfigType(t *testing.T) {
 	p := &Probe{}
 	err := p.Init("script-bad-conf", opts)
 	assert.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// vars builtin
+
+// TestVars_GetReturnsConfiguredValues exercises the happy path: configured
+// keys flow through `vars.get(name)` as strings. The script asserts the
+// expected values and fails the probe on mismatch.
+func TestVars_GetReturnsConfiguredValues(t *testing.T) {
+	source := `
+def probe(target):
+    if vars.get("USER") != "alice":
+        fail("USER=%s" % vars.get("USER"))
+    if vars.get("PASS") != "s3cret":
+        fail("PASS=%s" % vars.get("PASS"))
+`
+	opts := options.DefaultOptions()
+	opts.Targets = targets.StaticTargets("example.com")
+	opts.Timeout = time.Second
+	opts.Logger = &logger.Logger{}
+	opts.LatencyUnit = time.Millisecond
+	opts.ProbeConf = &configpb.ProbeConf{
+		Source: proto.String(source),
+		Vars:   map[string]string{"USER": "alice", "PASS": "s3cret"},
+	}
+
+	p := &Probe{}
+	if err := p.Init("script-vars-get", opts); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	results := p.RunOnce(context.Background())
+	assert.True(t, results[0].Success, "err=%v", results[0].Error)
+}
+
+// TestVars_GetMissingKey covers both missing-key paths: the no-default form
+// returns None, and the explicit-default form returns the supplied value.
+func TestVars_GetMissingKey(t *testing.T) {
+	source := `
+def probe(target):
+    if vars.get("MISSING") != None:
+        fail("expected None for missing key, got %r" % vars.get("MISSING"))
+    if vars.get("MISSING", "fallback") != "fallback":
+        fail("expected fallback, got %r" % vars.get("MISSING", "fallback"))
+`
+	opts := options.DefaultOptions()
+	opts.Targets = targets.StaticTargets("example.com")
+	opts.Timeout = time.Second
+	opts.Logger = &logger.Logger{}
+	opts.LatencyUnit = time.Millisecond
+	opts.ProbeConf = &configpb.ProbeConf{Source: proto.String(source)}
+
+	p := &Probe{}
+	if err := p.Init("script-vars-missing", opts); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	results := p.RunOnce(context.Background())
+	assert.True(t, results[0].Success, "err=%v", results[0].Error)
+}
+
+// TestVars_FlowsIntoHTTPRequest verifies the realistic use case: pulling a
+// secret out of `vars` and using it in an http call. The test server
+// rejects requests without the expected Authorization header, so success
+// implies vars.get round-tripped correctly.
+func TestVars_FlowsIntoHTTPRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer s3cret" {
+			http.Error(w, "no", http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	source := `
+def probe(target):
+    r = http.get(
+        url = "http://%s:%d/" % (target.name, target.port),
+        headers = {"Authorization": "Bearer " + vars.get("TOKEN")},
+    )
+    assert.status(r, 200)
+`
+	opts := newOpts(t, hostFromServer(t, srv), source)
+	opts.ProbeConf.(*configpb.ProbeConf).Vars = map[string]string{"TOKEN": "s3cret"}
+
+	p := &Probe{}
+	if err := p.Init("script-vars-http", opts); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	results := p.RunOnce(context.Background())
+	assert.True(t, results[0].Success, "err=%v", results[0].Error)
 }


### PR DESCRIPTION
## Summary

- Adds `map<string, string> vars` to `probes/starlark` `ProbeConf` and a `vars` Starlark builtin exposing `vars.get(name, default=None)`.
- Map is captured by closure at compile time — vars are static for the runtime's lifetime, so no per-run thread-local plumbing.
- Deliberately *not* named `env_var`: external/browser probes use that name for "passed to subprocess env", and reusing it here would mislead since the Starlark probe has no subprocess. Host env values, when needed, can be baked in at config-load time via the existing template layer (e.g. `{{ envVar "PASS" }}`).

This is the first item from the phase-2 roadmap noted in #1300 and unblocks any auth-protected probe.

## Example

```textproto
probe {
  name: "checkout"
  type: STARLARK
  targets { host_names: "api.example.com" }
  starlark_probe {
    source_file: "probes/checkout.star"
    vars { key: "TOKEN" value: "{{ envVar \"API_TOKEN\" }}" }
  }
}
```

```python
def probe(target):
    r = http.get(
        url = "https://%s/cart" % target.name,
        headers = {"Authorization": "Bearer " + vars.get("TOKEN")},
    )
    assert.status(r, 200)
```

## Test plan

- [x] `go test ./probes/starlark/...` passes
- [x] New tests: configured-values happy path, missing-key returns `None` and respects explicit default, end-to-end via HTTP request that requires a vars-sourced bearer token
- [x] Existing 3 `NewRuntime` callsites updated to pass `nil` vars