### PR TITLE
[ci] Fix config docs workflow 'all' mode to pick up new release tags

### DIFF
--- a/.github/workflows/latest_config_docs.yml
+++ b/.github/workflows/latest_config_docs.yml
@@ -58,9 +58,17 @@ jobs:
       - name: Generate config docs for latest (workflow_dispatch)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.tag == 'all'
         run: |
-          for dir in docs/public/docs/config/v*.*.*
+          # Versions already published to gh-pages.
+          existing=$(for dir in docs/public/docs/config/v*.*.*; do
+            [ -d "$dir" ] && basename "$dir"
+          done | sort -V)
+          min_version=$(echo "$existing" | head -1)
+          # Union with release tags so newly-released versions are picked up,
+          # filtered to versions >= the oldest already-published one.
+          versions=$( (echo "$existing"; git tag --list 'v*.*.*') | sort -uV |
+            awk -v min="$min_version" '$0==min{seen=1} seen')
+          for version in $versions
           do
-            version=$(basename $dir)
             echo "Generating config docs for $version"
             tools/gen_config_docs.sh $version
           done


### PR DESCRIPTION
## Summary
- The `all` branch of `latest_config_docs.yml` enumerated versions from `docs/public/docs/config/v*.*.*` (the `gh-pages` worktree), so newly-released tags without an existing dir were silently skipped — recent runs regenerated v0.13.7 → v0.14.1 but didn't touch v0.14.2 or v0.14.3 ([example run](https://github.com/cloudprober/cloudprober/actions/runs/25478281396/job/74756595994)).
- Switch to the union of existing dirs and `git tag --list 'v*.*.*'`, filtered to versions ≥ the oldest already-published one. New release tags are now picked up automatically; ancient tags below the baseline stay excluded.

## Test plan
- [ ] Trigger the workflow with `tag=all` and confirm v0.14.2 and v0.14.3 are generated and pushed to `gh-pages-github-action`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)