### PR TITLE
[docs] Sort config version dropdown newest-first

### DIFF
--- a/docs/layouts/shortcodes/config-docs-nav.html
+++ b/docs/layouts/shortcodes/config-docs-nav.html
@@ -48,9 +48,13 @@
 <select id="config-version-selector">
     <option selected value="latest">latest</option>
     <option value="main">main</option>
+{{ $versions := slice }}
 {{ range os.ReadDir "public/docs/config/" -}}
-    {{ if and (findRE `v[0-9]+\.[0-9]+\.[0-9]+` .Name) .IsDir }}<option value="{{ .Name }}">{{ .Name }}</option> {{ end }}
+    {{ if and (findRE `v[0-9]+\.[0-9]+\.[0-9]+` .Name) .IsDir }}{{ $versions = $versions | append .Name }}{{ end }}
 {{- end }}
+{{ range sort $versions "value" "desc" -}}
+    <option value="{{ . }}">{{ . }}</option>
+{{ end }}
 </select> |
 {{- end }}
 Language: <button id="set-lang-yaml" class="set-lang">YAML</button>|<button id="set-lang-textpb" class="set-lang">TextPB</button>


### PR DESCRIPTION
## Summary
- The version selector on the config reference page lists versions in `os.ReadDir` order, which is ascending alphabetical — so `v0.13.7` shows at the top instead of the latest release.
- Collect the version dir names into a slice and `sort … "desc"` so the newest release appears first in the dropdown.

Note: lexical sort works fine for current single-digit patch versions; once a `v0.X.10`-style tag ships we'll need a numeric-aware sort.

## Test plan
- [ ] After deploy, open any config reference page (e.g. `/docs/config/probes/`) and confirm the Version dropdown lists newest-to-oldest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)