### PR TITLE
[ci] Use go mod download to enforce go.sum-pinned versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,7 +63,7 @@ jobs:
         run: echo "DISABLE_IPV6_TESTS=yes" >> $env:GITHUB_ENV
 
       - name: Get dependencies
-        run: go get -v -t -d ./...
+        run: go mod download
 
       - name: Build
         run: go build -v .

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -75,13 +75,13 @@ jobs:
       - name: Test on ubuntu
         if: matrix.os == 'ubuntu-latest'
         run: |
-          go install gotest.tools/gotestsum@latest
+          go install gotest.tools/gotestsum@v1.13.0
           gotestsum --jsonfile=report.json --rerun-fails --packages=./... -- ${{ env.EXTRA_TEST_FLAGS }} -race -covermode=atomic -coverprofile=cover.out
 
       - name: Test on non-ubuntu
         if: matrix.os != 'ubuntu-latest'
         run: |
-          go install gotest.tools/gotestsum@latest
+          go install gotest.tools/gotestsum@v1.13.0
           gotestsum --rerun-fails --packages=./... -- ${{ env.EXTRA_TEST_FLAGS }} -race -covermode=atomic
 
       - name: SonarCloud Scan

--- a/.github/workflows/go_pw.yml
+++ b/.github/workflows/go_pw.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get dependencies
         run: |
-          go get -v -t -d ./... && go build -v .
+          go mod download && go build -v .
 
       - name: Test
         run: |

--- a/.github/workflows/go_pw.yml
+++ b/.github/workflows/go_pw.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Test
         run: |
           sudo sudo sysctl -w net.ipv4.ping_group_range="0 500000"
-          go install gotest.tools/gotestsum@latest
+          go install gotest.tools/gotestsum@v1.13.0
           gotestsum --jsonfile=report.json --rerun-fails --packages=./... -- ${{ env.EXTRA_TEST_FLAGS }} -race -covermode=atomic -coverprofile=cover.out
 
       - run: make cloudprober-linux-{amd64,arm64}


### PR DESCRIPTION
## Summary
- \`go get -v -t -d ./...\` can mutate \`go.mod\` and pick versions outside what \`go.sum\` pins, which is what SonarCloud flags as "Dependency versions not predictable".
- Replace with \`go mod download\`, which fetches exactly the versions locked in \`go.sum\` and leaves \`go.mod\` untouched.

Note: this step is technically redundant — subsequent \`go build\` / \`go test\` would auto-download deps in module-aware mode — but keeping it in place avoids a larger workflow refactor.

## Test plan
- [ ] CI build-and-test job passes on all OS matrix entries.
- [ ] SonarCloud finding clears.