### PR TITLE
[ci] Use npm ci to enforce package-lock.json-pinned versions

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Build pages
         run: |
           cd docs
-          npm install
+          npm ci
           npm run build
           ls public
           cd public && git status

--- a/.github/workflows/latest_config_docs.yml
+++ b/.github/workflows/latest_config_docs.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Build pages
         run: |
           cd docs
-          npm install
+          npm ci
           npm run build
           ls public
           cd public && git status


### PR DESCRIPTION
## Summary
- \`npm install\` can update \`package-lock.json\` and resolve packages outside the locked versions, which SonarCloud flags as "Dependency versions not predictable".
- Replace with \`npm ci\` in \`hugo.yml\` and \`latest_config_docs.yml\` — installs exactly what the lockfile pins and refuses to modify it.

## Test plan
- [ ] hugo build job passes.
- [ ] latest_config_docs build job passes.
- [ ] SonarCloud finding clears.