### PR TITLE
[ci] Pin python deps and require wheels in py_serverutils workflow

### DIFF
--- a/.github/workflows/py_serverutils.yml
+++ b/.github/workflows/py_serverutils.yml
@@ -45,8 +45,8 @@ jobs:
         run: |
           python -m venv venv
           source venv/bin/activate
-          pip install -e probes/external/serverutils/py/
-          pip install pytest
+          pip install --only-binary :all: 'protobuf==7.34.1' 'pytest==9.0.3'
+          pip install --only-binary :all: --no-deps -e probes/external/serverutils/py/
           pytest probes/external/serverutils/py/tests
           deactivate
           rm -rf venv


### PR DESCRIPTION
## Summary
- \`pip install pytest\` and \`pip install -e .../py/\` triggered two SonarCloud findings: deps weren't pinned, and \`--only-binary :all:\` was missing (so sdist setup scripts could execute at install time).
- Pin \`protobuf==7.34.1\` and \`pytest==9.0.3\` explicitly, install both with \`--only-binary :all:\`, then editable-install the local package with \`--no-deps\` so protobuf isn't re-resolved.

Note: pins are CI-only; \`pyproject.toml\` is unchanged so the published \`cloudprober-serverutils\` package keeps its current open dep on \`protobuf\`.

## Test plan
- [ ] \`test_and_build\` job passes — pytest runs against the editable install.
- [ ] SonarCloud findings on \`py_serverutils.yml\` lines 48-49 clear.