### PR TITLE
[logger] Stop declaring -logtostderr; strip it from os.Args instead

### DIFF
--- a/cmd/cloudprober/main.go
+++ b/cmd/cloudprober/main.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Cloudprober Authors.
+// Copyright 2017-2026 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -102,6 +102,7 @@ func setupProfiling() {
 }
 
 func main() {
+	logger.StripDeprecatedFlags()
 	flag.Parse()
 
 	// Initialize logger after parsing flags.

--- a/logger/deprecated_flags.go
+++ b/logger/deprecated_flags.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"flag"
+	"os"
+	"strings"
+)
+
+// StripDeprecatedFlags removes -logtostderr from os.Args so callers can still
+// pass it for backwards compatibility without cloudprober declaring the flag
+// (which would conflict with packages like glog that also declare it). If
+// another package has already declared -logtostderr, this is a no-op so that
+// package parses the value normally. Call before flag.Parse.
+func StripDeprecatedFlags() {
+	if flag.Lookup("logtostderr") != nil {
+		return
+	}
+	os.Args = stripLogtostderr(os.Args)
+}
+
+func stripLogtostderr(args []string) []string {
+	out := make([]string, 0, len(args))
+	for i, arg := range args {
+		if arg == "--" {
+			return append(out, args[i:]...)
+		}
+		if arg == "-logtostderr" || arg == "--logtostderr" ||
+			strings.HasPrefix(arg, "-logtostderr=") || strings.HasPrefix(arg, "--logtostderr=") {
+			continue
+		}
+		out = append(out, arg)
+	}
+	return out
+}

--- a/logger/deprecated_flags.go
+++ b/logger/deprecated_flags.go
@@ -22,10 +22,10 @@ import (
 
 // StripDeprecatedFlags removes -logtostderr from os.Args so callers can still
 // pass it for backwards compatibility without cloudprober declaring the flag
-// (which would conflict with packages like glog that also declare it). If
-// another package has already declared -logtostderr, this is a no-op so that
-// package parses the value normally. Call before flag.Parse.
+// (which would conflict with packages like glog that also declare it).
 func StripDeprecatedFlags() {
+	// If flag is already declared by another package, do nothing and let that
+	// package handle it.
 	if flag.Lookup("logtostderr") != nil {
 		return
 	}

--- a/logger/deprecated_flags_test.go
+++ b/logger/deprecated_flags_test.go
@@ -15,9 +15,31 @@
 package logger
 
 import (
+	"flag"
+	"os"
 	"reflect"
 	"testing"
 )
+
+func TestStripDeprecatedFlags_OtherPackageDeclared(t *testing.T) {
+	origArgs := os.Args
+	origCmdLine := flag.CommandLine
+	t.Cleanup(func() {
+		os.Args = origArgs
+		flag.CommandLine = origCmdLine
+	})
+
+	flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+	flag.Bool("logtostderr", false, "declared by another package")
+
+	os.Args = []string{"cmd", "-logtostderr=true", "-other"}
+	StripDeprecatedFlags()
+
+	want := []string{"cmd", "-logtostderr=true", "-other"}
+	if !reflect.DeepEqual(os.Args, want) {
+		t.Errorf("os.Args = %v, want %v (unchanged)", os.Args, want)
+	}
+}
 
 func TestStripLogtostderr(t *testing.T) {
 	tests := []struct {

--- a/logger/deprecated_flags_test.go
+++ b/logger/deprecated_flags_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStripLogtostderr(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "absent",
+			in:   []string{"cmd", "-other", "-foo=1"},
+			want: []string{"cmd", "-other", "-foo=1"},
+		},
+		{
+			name: "single dash bare",
+			in:   []string{"cmd", "-logtostderr", "-other"},
+			want: []string{"cmd", "-other"},
+		},
+		{
+			name: "double dash bare",
+			in:   []string{"cmd", "--logtostderr", "-other"},
+			want: []string{"cmd", "-other"},
+		},
+		{
+			name: "with value",
+			in:   []string{"cmd", "-logtostderr=true", "-other"},
+			want: []string{"cmd", "-other"},
+		},
+		{
+			name: "double dash with value",
+			in:   []string{"cmd", "--logtostderr=false", "-other"},
+			want: []string{"cmd", "-other"},
+		},
+		{
+			name: "does not match prefix",
+			in:   []string{"cmd", "-logtostderrx", "-other"},
+			want: []string{"cmd", "-logtostderrx", "-other"},
+		},
+		{
+			name: "preserves args after --",
+			in:   []string{"cmd", "-other", "--", "-logtostderr"},
+			want: []string{"cmd", "-other", "--", "-logtostderr"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripLogtostderr(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("stripLogtostderr(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2025 The Cloudprober Authors.
+// Copyright 2017-2026 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ import (
 
 var (
 	logFmt = flag.String("logfmt", "text", "Log format. Valid values: text, json")
-	_      = flag.Bool("logtostderr", true, "(deprecated) this option doesn't do anything anymore. All logs to stderr by default.")
 
 	minLogLevel  = flag.String("min_log_level", "INFO", "Minimum log level to log. Valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL")
 	debugLog     = flag.Bool("debug_log", false, "Whether to output debug logs or not. Deprecated: use --min_log_level=DEBUG instead.")


### PR DESCRIPTION
## Summary
- The deprecated `-logtostderr` no-op bool flag in `logger/logger.go` caused a duplicate-flag panic when a binary also imported a package that declares the same name (e.g. glog).
- Remove the declaration and add `logger.StripDeprecatedFlags()`, called from `cmd/cloudprober/main.go` before `flag.Parse()`, which silently drops `-logtostderr[=value]` from `os.Args`.
- If another package has already declared the flag, the helper is a no-op so that package parses the value normally.

## Test plan
- [x] `go test ./logger/` passes (incl. new `TestStripLogtostderr`).
- [x] `cloudprober -logtostderr=true` and `--logtostderr` exit without "flag provided but not defined".