### PR TITLE
[docs] Add Script Probe (Starlark) how-to

### DIFF
--- a/docs/assets/js/highlight.js
+++ b/docs/assets/js/highlight.js
@@ -8,6 +8,7 @@ import proto from 'highlight.js/lib/languages/protobuf';
 import ini from 'highlight.js/lib/languages/ini';
 import yaml from 'highlight.js/lib/languages/yaml';
 import markdown from 'highlight.js/lib/languages/markdown';
+import python from 'highlight.js/lib/languages/python';
 
 hljs.registerLanguage('javascript', javascript);
 hljs.registerLanguage('json', json);
@@ -21,6 +22,8 @@ hljs.registerLanguage('ini', ini);
 hljs.registerLanguage('toml', ini);
 hljs.registerLanguage('yaml', yaml);
 hljs.registerLanguage('md', markdown);
+hljs.registerLanguage('python', python);
+hljs.registerLanguage('starlark', python);
 
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('pre code').forEach((block) => {

--- a/docs/assets/scss/common/_custom.scss
+++ b/docs/assets/scss/common/_custom.scss
@@ -119,3 +119,19 @@ a.docs-link {
   font-size: $font-size-sm;
   margin-bottom: 0;
 }
+
+// Theme default is 1.25rem -- too dominant for inline callouts.
+blockquote {
+  font-size: 1.1rem;
+}
+
+// `ui-monospace` resolves to Cascadia Mono on Windows (metrics close to SF
+// Mono / Menlo). Without it, Windows falls through to Consolas, which renders
+// noticeably smaller at the same px size.
+pre,
+code,
+kbd,
+samp {
+  font-family: ui-monospace, "SF Mono", sfmono-regular, menlo, monaco, consolas,
+    "Liberation Mono", "Courier New", monospace;
+}

--- a/docs/content/docs/how-to/browser-probe/index.md
+++ b/docs/content/docs/how-to/browser-probe/index.md
@@ -3,7 +3,7 @@ menu:
   docs:
     parent: "how-to"
     name: "Browser Probe"
-    weight: 14
+    weight: 15
 title: "Browser Probe: Getting Started"
 date: 2026-02-01T17:24:32-07:00
 ---

--- a/docs/content/docs/how-to/k8s_targets.md
+++ b/docs/content/docs/how-to/k8s_targets.md
@@ -2,7 +2,7 @@
 menu:
   docs:
     parent: "how-to"
-    weight: 16
+    weight: 17
 title: "Kubernetes Targets"
 date: 2022-11-01T17:24:32-07:00
 ---

--- a/docs/content/docs/how-to/list/index.md
+++ b/docs/content/docs/how-to/list/index.md
@@ -9,6 +9,7 @@ weight: 100
 - [Alerting]({{< ref "alerting" >}})
 - [Targets]({{< ref "targets" >}})
 - [External Probe]({{< ref "external-probe" >}})
+- [Script Probe]({{< ref "starlark-probe" >}})
 - [Browser Probe]({{< ref "browser-probe" >}})
 - [Kubernetes Targets]({{< ref "k8s_targets" >}})
 - [Running on Kubernetes]({{< ref "run-on-kubernetes" >}})

--- a/docs/content/docs/how-to/run-on-kubernetes.md
+++ b/docs/content/docs/how-to/run-on-kubernetes.md
@@ -2,7 +2,7 @@
 menu:
   docs:
     parent: "how-to"
-    weight: 15
+    weight: 16
 title: "Running On Kubernetes"
 date: 2022-11-01T17:24:32-07:00
 ---

--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -3,7 +3,7 @@ menu:
   docs:
     parent: "how-to"
     name: "Script Probe"
-    weight: 15
+    weight: 14
 title: "Script Probe (Starlark)"
 date: 2026-05-10T10:00:00-07:00
 keywords: ["script probe", "starlark probe", "scripted probe", "multi-step", "api flow", "chained requests"]

--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -58,13 +58,13 @@ def probe(target):
         url = base + "/api-token-auth/",
         json = {"username": "demo", "password": "demo"},
     )
-    assert.status(r, 200)
+    assert.http_status(r, 200)
     token = r.json()["token"]
     auth = {"Authorization": "Token " + token}
 
     # 2. Accounts.
     r = http.get(url = base + "/accounts/", headers = auth)
-    assert.status(r, 200)
+    assert.http_status(r, 200)
     accounts = r.json()["results"]
     if len(accounts) == 0:
         fail("no accounts returned")
@@ -72,7 +72,7 @@ def probe(target):
     # 3. Portfolio for first account.
     account = accounts[0]["account_number"]
     r = http.get(url = base + "/portfolios/%s/" % account, headers = auth)
-    assert.status(r, 200)
+    assert.http_status(r, 200)
     print("equity for %s: %s" % (account, r.json()["equity"]))
 ```
 
@@ -92,7 +92,7 @@ probe {
 }
 ```
 
-Cloudprober calls `probe(target)` every 5 seconds. Each `assert.status` raises
+Cloudprober calls `probe(target)` every 5 seconds. Each `assert.http_status` raises
 on mismatch, ending the run as a failure -- without any extra plumbing,
 `total`, `success`, and `latency` metrics flow to your surfacers exactly like
 any other probe.
@@ -118,7 +118,7 @@ All scripts get a small, fixed set of builtins. No filesystem, network beyond
 |---|---|
 | `http.get(url, headers=None)` | HTTP GET, returns a `Response`. |
 | `http.post(url, headers=None, body=None, json=None)` | HTTP POST. Pass `json=` for an auto-encoded JSON body (sets `Content-Type`), or `body=` for a raw string/bytes. |
-| `assert.status(response, expected)` | Fails the probe if `response.status != expected`. |
+| `assert.http_status(response, expected)` | Fails the probe if `response.status != expected`. |
 | `vars.get(name, default=None)` | Read values from the probe's `vars` config map (see below). |
 | `state.get(key, default=None)` / `state.set(key, value)` | Per-target key-value store that persists across runs (see below). |
 | `log.info(msg)` / `log.warn(msg)` / `log.error(msg)` / `log.debug(msg)` | Route a message to Cloudprober's logger with the probe's `target` attribute attached. |
@@ -172,7 +172,7 @@ rate-limit countdown:
 def probe(target):
     last_id = state.get("last_id", 0)
     r = http.get(url = "http://%s/events?since=%d" % (target.name, last_id))
-    assert.status(r, 200)
+    assert.http_status(r, 200)
     events = r.json()["events"]
     if events:
         state.set("last_id", events[-1]["id"])

--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -1,0 +1,246 @@
+---
+menu:
+  docs:
+    parent: "how-to"
+    name: "Script Probe"
+    weight: 15
+title: "Script Probe (Starlark)"
+date: 2026-05-10T10:00:00-07:00
+keywords: ["script probe", "starlark probe", "scripted probe", "multi-step", "api flow", "chained requests"]
+---
+
+Cloudprober's **script probe** (proto type `STARLARK`) lets you write
+**multi-step checks as a small script**. The script is written in
+[Starlark](https://github.com/bazelbuild/starlark) -- a sandboxed, Python-like
+language with `if`/`for`/dicts/lists/string formatting -- and runs in-process,
+once per resolved target each interval. Wall time of the call becomes the
+probe's latency; a clean return is success, any unhandled error (including
+assertion failures) is failure.
+
+Think of it as **"curl + jq + assertions, in a real scripting language"**,
+without the deployment baggage of shipping a binary alongside Cloudprober. A
+typical use case is a chained API flow: get a token, list resources, fetch a
+detail page, validate the response, emit a custom latency metric for the
+critical step.
+
+> **Why Starlark?** It's the sandboxed Python-like language behind Bazel and
+> Buck. It gives you most of Python's ergonomics (string formatting, dicts,
+> comprehensions) with strong guarantees: no filesystem, no `exec`, no module
+> system, deterministic semantics, and cheap to embed -- perfect for short
+> scripts that ship inside a config file.
+
+## When to use it
+
+| If you want to... | Use |
+|---|---|
+| Probe a single URL | [HTTP probe](https://cloudprober.org/docs/config/latest/probes/#cloudprober_probes_http_ProbeConf) |
+| Run an arbitrary external binary, in any language | [External probe]({{< ref "external-probe" >}}) |
+| Drive a real browser through user flows | [Browser probe]({{< ref "browser-probe" >}}) |
+| Chain a few HTTP requests, assert on responses, emit custom metrics | **Script probe** (this page) |
+
+The script probe sits in the gap between the HTTP probe (which is one request,
+no logic) and the external probe (which is a whole binary you have to build,
+ship, and version). For most "test an API end-to-end" checks, that gap is
+exactly where you want to be.
+
+## Quick Start
+
+A small token-auth API check (full example in
+[examples/starlark/](https://github.com/cloudprober/cloudprober/tree/master/examples/starlark)):
+
+```python
+# trading_api.star
+def probe(target):
+    base = "http://%s:%d" % (target.name, target.port)
+
+    # 1. Auth.
+    r = http.post(
+        url = base + "/api-token-auth/",
+        json = {"username": "demo", "password": "demo"},
+    )
+    assert.status(r, 200)
+    token = r.json()["token"]
+    auth = {"Authorization": "Token " + token}
+
+    # 2. Accounts.
+    r = http.get(url = base + "/accounts/", headers = auth)
+    assert.status(r, 200)
+    accounts = r.json()["results"]
+    if len(accounts) == 0:
+        fail("no accounts returned")
+
+    # 3. Portfolio for first account.
+    account = accounts[0]["account_number"]
+    r = http.get(url = base + "/portfolios/%s/" % account, headers = auth)
+    assert.status(r, 200)
+    print("equity for %s: %s" % (account, r.json()["equity"]))
+```
+
+```proto
+# cloudprober.cfg
+probe {
+  name: "trading_api_flow"
+  type: STARLARK
+  targets {
+    host_names: "127.0.0.1:8080"
+  }
+  interval_msec: 5000
+  timeout_msec: 3000
+  starlark_probe {
+    source_file: "trading_api.star"
+  }
+}
+```
+
+Cloudprober calls `probe(target)` every 5 seconds. Each `assert.status` raises
+on mismatch, ending the run as a failure -- without any extra plumbing,
+`total`, `success`, and `latency` metrics flow to your surfacers exactly like
+any other probe.
+
+## The `target` argument
+
+The entry point receives a single argument exposing fields from the resolved
+target endpoint:
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `target.name` | string | Host name or IP from discovery. |
+| `target.port` | int | `0` if no port. |
+| `target.ip` | string | Resolved IP (`""` if not yet resolved). |
+| `target.labels` | dict[str,str] | Frozen; lookups via `target.labels.get("env", "prod")`. |
+
+## Available builtins
+
+All scripts get a small, fixed set of builtins. No filesystem, network beyond
+`http`, or `exec` -- the probe is sandboxed by Starlark.
+
+| Builtin | Purpose |
+|---|---|
+| `http.get(url, headers=None)` | HTTP GET, returns a `Response`. |
+| `http.post(url, headers=None, body=None, json=None)` | HTTP POST. Pass `json=` for an auto-encoded JSON body (sets `Content-Type`), or `body=` for a raw string/bytes. |
+| `assert.status(response, expected)` | Fails the probe if `response.status != expected`. |
+| `vars.get(name, default=None)` | Read values from the probe's `vars` config map (see below). |
+| `state.get(key, default=None)` / `state.set(key, value)` | Per-target key-value store that persists across runs (see below). |
+| `log.info(msg)` / `log.warn(msg)` / `log.error(msg)` / `log.debug(msg)` | Route a message to Cloudprober's logger with the probe's `target` attribute attached. |
+| `print_metric(line)` | Emit a custom metric line (see below). |
+| `print(...)` | Standard Starlark `print`; routed to the logger at INFO. |
+| `fail(msg)` | Standard Starlark; ends the run as a failure. |
+
+### Response
+
+```python
+r = http.get(url = "https://example.com/")
+r.status     # int, e.g. 200
+r.headers    # dict[str,str]; multi-valued headers are ", "-joined
+r.body       # bytes
+r.json()     # parsed JSON (raises on parse error)
+```
+
+### `vars`
+
+`vars.get` reads from the probe's static config map -- useful for passing
+non-secret config (an environment name, an API base URL, a feature flag)
+without rebuilding the script:
+
+```proto
+probe {
+  type: STARLARK
+  starlark_probe {
+    source_file: "checkout.star"
+    vars { key: "api_base" value: "https://api.staging.example.com" }
+    vars { key: "feature_flag" value: "fast_checkout" }
+  }
+}
+```
+
+```python
+def probe(target):
+    base = vars.get("api_base", "https://api.example.com")
+    ...
+```
+
+For host environment values, use Cloudprober's config-loading template layer
+(e.g. `vars { key: "api_key" value: "{{ envVar \"API_KEY\" }}" }`).
+
+### `state`
+
+`state` is a per-`(probe, target)` dictionary that survives across runs. Use
+it for things like remembering the last-seen ETag, a paging cursor, or a
+rate-limit countdown:
+
+```python
+def probe(target):
+    last_id = state.get("last_id", 0)
+    r = http.get(url = "http://%s/events?since=%d" % (target.name, last_id))
+    assert.status(r, 200)
+    events = r.json()["events"]
+    if events:
+        state.set("last_id", events[-1]["id"])
+```
+
+The bucket lives only as long as the target does: when a target disappears
+from discovery, its state is dropped. Each bucket holds up to 1024 keys.
+
+## Custom metrics with `print_metric`
+
+`print_metric(line)` accepts the same payload-format strings as the external
+probe's stdout protocol. The simplest form is `name value`:
+
+```python
+print_metric("items_in_cart 5")
+print_metric('checkout_latency_ms{flow="guest"} 234.5')
+```
+
+Configure how those lines are interpreted -- gauge vs. cumulative,
+distribution buckets, in-Cloudprober aggregation -- with
+`output_metrics_options` on the probe:
+
+```proto
+probe {
+  type: STARLARK
+  starlark_probe {
+    source_file: "checkout.star"
+    output_metrics_options {
+      aggregate_in_cloudprober: true
+      dist_metric {
+        key: "checkout_latency_ms"
+        value {
+          explicit_buckets: "10,50,100,250,500,1000,5000"
+        }
+      }
+    }
+  }
+}
+```
+
+The configuration knobs (kind, additional labels, JSON / header metrics,
+distribution buckets) are exactly those used by the [external probe
+output_metrics_options]({{< ref "external-probe#distributions" >}}); see that
+section for a worked example.
+
+Metrics are dispatched **as the line is emitted** -- if a later assertion
+fails, every `print_metric` line before it still surfaces.
+
+## Configuration reference
+
+See the [generated config reference](https://cloudprober.org/docs/config/latest/probes/#cloudprober_probes_starlark_ProbeConf)
+for the full schema. The most-used fields:
+
+| Field | Default | Description |
+|---|---|---|
+| `source` / `source_file` | -- | Exactly one of these. Inline source or path to a `.star` file. |
+| `entry_point` | `"probe"` | Function to call each run. Must take one argument (`target`). |
+| `vars` | -- | `map<string,string>` exposed to the script via `vars.get`. |
+| `output_metrics_options` | -- | How `print_metric` lines are parsed -- kind, distributions, aggregation, etc. |
+
+## Lifecycle and concurrency
+
+- Module-level code (top-level `def`, assignments, imports) runs **once** at
+  probe load. Helper functions and constants defined there are reused on every
+  call.
+- The entry-point function is called once per target per interval. Each call
+  runs on its own Starlark thread; **module globals are frozen** after load, so
+  you cannot accumulate cross-run state in a module-level dict -- use `state`
+  instead.
+- `probe_timeout` bounds each call: an in-flight `http.get` is cancelled, and
+  pure-Starlark loops are interrupted at the next call/branch.


### PR DESCRIPTION
## Summary

Adds a how-to page for the script probe (`STARLARK` type) at `docs/how-to/starlark-probe/`. Page is framed as "Script Probe (Starlark)" so users searching for "script probe" find it, while keeping the proto type name (`STARLARK`) discoverable.

Covers: when to use it vs HTTP/external/browser, quick-start with the `examples/starlark/` trading-API flow, target struct, builtins reference (`http`, `assert`, `vars`, `state`, `log`, `print_metric`), custom metrics via `output_metrics_options`, and lifecycle notes.