### PR TITLE
[security] Fix dependabot and code scanning alerts

### DIFF
--- a/Dockerfile.pw
+++ b/Dockerfile.pw
@@ -21,7 +21,7 @@ RUN chmod +x /cloudprober
 # Install playwright
 WORKDIR /playwright
 COPY probes/browser/package*.json .
-RUN npm i && rm -rf /root/.npm
+RUN npm ci --ignore-scripts && rm -rf /root/.npm
 ENV PLAYWRIGHT_BROWSERS_PATH=0
 RUN npx -y playwright install --with-deps chromium
 ENV PLAYWRIGHT_DIR=/playwright

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -944,9 +944,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.28.6",
@@ -3403,9 +3403,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Bump `@babel/plugin-transform-modules-systemjs` to 7.29.4 and `fast-uri` to 3.1.2 in `docs/package-lock.json` (GHSA-fv7c-fp4j-7gwp, GHSA-q3j6-qgpj-74h6, GHSA-v39h-62p7-jpjc).
- Use `npm ci --ignore-scripts` in `Dockerfile.pw` to lock versions to the committed lock file and skip install scripts (playwright browsers are still installed by the explicit `npx playwright install` step below).
- Two SonarCloud hotspots on `.github/workflows/py_serverutils.yml` (alerts #34, #36) were dismissed as false positives — already mitigated by commit 806617c4 which added `--only-binary :all:`; the hotspot rule does not auto-close.

## Test plan
- [ ] Dependabot alerts #78, #79, #80 close automatically after merge.
- [ ] Dockerfile.pw still builds in the playwright probe workflow.