### PR TITLE
[probes.browser] Dockerfile.pw: call playwright directly instead of npx

### DIFF
--- a/Dockerfile.pw
+++ b/Dockerfile.pw
@@ -23,7 +23,7 @@ WORKDIR /playwright
 COPY probes/browser/package*.json .
 RUN npm ci --ignore-scripts && rm -rf /root/.npm
 ENV PLAYWRIGHT_BROWSERS_PATH=0
-RUN npx -y playwright install --with-deps chromium
+RUN node_modules/.bin/playwright install --with-deps chromium
 ENV PLAYWRIGHT_DIR=/playwright
 
 # Metadata params


### PR DESCRIPTION
## Summary
- `npx -y` may fetch and install a package on demand, which can execute install scripts. Since `npm ci --ignore-scripts` already installs playwright into `node_modules/.bin`, invoke the binary directly. Resolves SonarCloud alert #39 (docker:S6505).

## Test plan
- [x] Dockerfile.pw still builds in the playwright probe workflow.
- [ ] SonarCloud alert #39 closes after the merge scan.