### PR TITLE
[tools] Use [[ ... ]] instead of [ ... ] in shell scripts

### DIFF
--- a/tools/add-shortlink.sh
+++ b/tools/add-shortlink.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 GOTO_DIR="$(cd "$(dirname "$0")/../docs/content/goto" && pwd)"
 
-if [ $# -ne 2 ]; then
+if [[ $# -ne 2 ]]; then
   echo "Usage: $0 <keyword> <destination-url>" >&2
   exit 1
 fi
@@ -19,7 +19,7 @@ KEYWORD="$1"
 DEST="$2"
 FILE="${GOTO_DIR}/${KEYWORD}.md"
 
-if [ -f "$FILE" ]; then
+if [[ -f "$FILE" ]]; then
   echo "Error: shortlink '${KEYWORD}' already exists at ${FILE}" >&2
   exit 1
 fi

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -22,7 +22,7 @@ PROJECT="github.com/cloudprober/cloudprober"
 
 GOPATH=$(go env GOPATH)
 
-if [ -z "$GOPATH" ]; then
+if [[ -z "$GOPATH" ]]; then
   echo "Go environment is not setup correctly. Please look at"
   echo "https://golang.org/doc/code.html to set up Go environment."
   exit 1
@@ -31,7 +31,7 @@ fi
 # Change directory to the project workspace in GOPATH
 project_dir="${GOPATH}/src/${PROJECT}"
 
-if [ ! -d "${project_dir}" ];then
+if [[ ! -d "${project_dir}" ]];then
   echo "${PROJECT} not found under Go workspace: ${GOPATH}/src. Please download"
   echo " cloudprober source code from github.com/cloudprober/cloudprober and set it "
   echo "such that it's available at ${project_dir}."

--- a/tools/cloudprober_startup.sh
+++ b/tools/cloudprober_startup.sh
@@ -26,13 +26,13 @@ done
 
 shift $(($OPTIND - 1))
 cmd=$1
-if [ "$cmd" != "start" ]; then
+if [[ "$cmd" != "start" ]]; then
   # First execution by cloud-init. Make the script accessible to all.
   chmod a+rx "$0"
   exit
 fi
 
-if [ -z "${JOB}" ]; then
+if [[ -z "${JOB}" ]]; then
   echo "-j <job_name> is a required parameter"
   exit 1
 fi

--- a/tools/gen_config_docs.sh
+++ b/tools/gen_config_docs.sh
@@ -9,10 +9,10 @@
 DOCS_VERSION=$1
 RELEASE=$1
 
-if [ -z "${DOCS_VERSION}" ]; then
+if [[ -z "${DOCS_VERSION}" ]]; then
     DOCS_VERSION=$(git describe --exact-match --exclude tip --tags HEAD 2>/dev/null || /bin/true)
 
-    if [ -z "${DOCS_VERSION}" ]; then
+    if [[ -z "${DOCS_VERSION}" ]]; then
         DOCS_VERSION=$(git rev-parse --abbrev-ref HEAD)
     fi
 fi
@@ -21,11 +21,11 @@ DOCS_VERSION=${DOCS_VERSION//\//_}
 
 ORIGINAL_DIR=$(pwd)
 
-if [ "${RELEASE}" == "latest" ]; then
+if [[ "${RELEASE}" == "latest" ]]; then
   RELEASE=$(curl -s https://api.github.com/repos/cloudprober/cloudprober/releases/latest | grep 'tag_name' | cut -d '"' -f4)
 fi
 
-if [ ! -z "${RELEASE}" ]; then
+if [[ ! -z "${RELEASE}" ]]; then
   TEMPDIR=$(mktemp -d) && cd $TEMPDIR
   wget https://github.com/cloudprober/cloudprober/archive/refs/tags/${RELEASE}.tar.gz
   tar -xzf ${RELEASE}.tar.gz
@@ -51,7 +51,7 @@ MENU_HDR="menu:
 "
 TITLE_VERSION=""
 
-if [ "${DOCS_VERSION}" != "latest" ]; then
+if [[ "${DOCS_VERSION}" != "latest" ]]; then
   MENU_HDR=""
   TITLE_VERSION=" (${DOCS_VERSION})"
 fi
@@ -61,7 +61,7 @@ generate_config_files() {
   local menu_hdr="$2"
   for dir in ${ORIGINAL_DIR}/docs/_config_docs/${DOCS_VERSION}/textpb/*; do
     baseName=$(basename $dir)
-    if [ ! -d $dir ]; then
+    if [[ ! -d $dir ]]; then
       continue
     fi
     cat > ${base_path}/${baseName}.md <<EOF
@@ -84,7 +84,7 @@ cp ${ORIGINAL_DIR}/docs/content/docs/config/_index.md ${BASE_PATH}/
 
 # Copy latest configs to non-versioned path as well to make sure
 # we don't break existing links.
-if [ "${DOCS_VERSION}" == "latest" ]; then
+if [[ "${DOCS_VERSION}" == "latest" ]]; then
   echo "Copying latest configs to non-versioned path as well."
   NON_VERSIONED_BASE_PATH=${ORIGINAL_DIR}/docs/content/docs/config
   mkdir -p ${NON_VERSIONED_BASE_PATH}

--- a/tools/gen_pb_go.sh
+++ b/tools/gen_pb_go.sh
@@ -20,14 +20,14 @@ PROTOC_VERSION="33.5"
 
 GOPATH=$(go env GOPATH)
 
-if [ -z "$GOPATH" ]; then
+if [[ -z "$GOPATH" ]]; then
   echo "Go environment is not setup correctly. Please look at"
   echo "https://golang.org/doc/code.html to set up Go environment."
   exit 1
 fi
 echo GOPATH=${GOPATH}
 
-if [ -z ${PROJECTROOT+x} ]; then
+if [[ -z ${PROJECTROOT+x} ]]; then
   # If PROJECTROOT is not set, try to determine it from script's location
   SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
   if [[ $SCRIPTDIR == *"/tools"* ]]; then
@@ -45,9 +45,9 @@ echo "Install protoc from the internet."
 echo "============================================"
 sleep 1
 
-if [ "$(uname -s)" == "Darwin" ]; then
+if [[ "$(uname -s)" == "Darwin" ]]; then
   os="osx"
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+elif [[ "$(expr substr $(uname -s) 1 5)" == "Linux" ]]; then
   os="linux"
 else
   echo "OS unsupported by this this build script. Please install protoc manually."
@@ -56,7 +56,7 @@ fi
 arch=$(uname -m)
 
 # On Apple arm64, protoc is called aarch64.
-if [ "${os}" == "osx" ] && [ "${arch}" == "arm64" ]; then
+if [[ "${os}" == "osx" && "${arch}" == "arm64" ]]; then
   arch="aarch_64"
 fi
 


### PR DESCRIPTION
## Summary
- Convert single-bracket conditionals to double-bracket across all bash scripts in `tools/`. Resolves SonarCloud "Use '[[' instead of '[' for conditional tests" warnings.

## Test plan
- [x] `bash -n` syntax check passes for every script.