### PR TITLE
[probes.starlark] Rename assert.status to assert.http_status

### DIFF
--- a/examples/starlark/trading_api.star
+++ b/examples/starlark/trading_api.star
@@ -13,13 +13,13 @@ def probe(target):
         url = base + "/api-token-auth/",
         json = {"username": "demo", "password": "demo"},
     )
-    assert.status(r, 200)
+    assert.http_status(r, 200)
     token = r.json()["token"]
     auth = {"Authorization": "Token " + token}
 
     # 2. Accounts.
     r = http.get(url = base + "/accounts/", headers = auth)
-    assert.status(r, 200)
+    assert.http_status(r, 200)
     accounts = r.json()["results"]
     if len(accounts) == 0:
         fail("no accounts returned")
@@ -30,13 +30,13 @@ def probe(target):
         url = base + "/portfolios/%s/" % account_number,
         headers = auth,
     )
-    assert.status(r, 200)
+    assert.http_status(r, 200)
     equity = r.json()["equity"]
     print("equity for %s: %s" % (account_number, equity))
 
     # 4. Quote for XYZ.
     r = http.get(url = base + "/quotes/?symbols=XYZ", headers = auth)
-    assert.status(r, 200)
+    assert.http_status(r, 200)
     quote = r.json()["results"][0]
     if quote["symbol"] != "XYZ":
         fail("expected XYZ, got %s" % quote["symbol"])

--- a/probes/starlark/builtins.go
+++ b/probes/starlark/builtins.go
@@ -234,15 +234,15 @@ func assertModule() *starlarkstruct.Module {
 	return &starlarkstruct.Module{
 		Name: "assert",
 		Members: starlarklib.StringDict{
-			"status": starlarklib.NewBuiltin("assert.status", assertStatus),
+			"http_status": starlarklib.NewBuiltin("assert.http_status", assertHTTPStatus),
 		},
 	}
 }
 
-func assertStatus(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
+func assertHTTPStatus(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
 	var resp starlarklib.Value
 	var expected int
-	if err := starlarklib.UnpackArgs("assert.status", args, kwargs,
+	if err := starlarklib.UnpackArgs("assert.http_status", args, kwargs,
 		"response", &resp,
 		"expected", &expected,
 	); err != nil {
@@ -250,10 +250,10 @@ func assertStatus(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starlarkli
 	}
 	r, ok := resp.(*response)
 	if !ok {
-		return nil, fmt.Errorf("assert.status: first argument must be a Response, got %s", resp.Type())
+		return nil, fmt.Errorf("assert.http_status: first argument must be a Response, got %s", resp.Type())
 	}
 	if r.status != expected {
-		return nil, fmt.Errorf("assert.status: expected %d, got %d", expected, r.status)
+		return nil, fmt.Errorf("assert.http_status: expected %d, got %d", expected, r.status)
 	}
 	return starlarklib.None, nil
 }

--- a/probes/starlark/starlark_test.go
+++ b/probes/starlark/starlark_test.go
@@ -102,14 +102,14 @@ def probe(target):
         url = base + "/login",
         json = {"user": "u", "pass": "p"},
     )
-    assert.status(r, 200)
+    assert.http_status(r, 200)
     token = r.json()["token"]
 
     r = http.get(
         url = base + "/cart",
         headers = {"Authorization": "Bearer " + token},
     )
-    assert.status(r, 200)
+    assert.http_status(r, 200)
 `
 
 // ---------------------------------------------------------------------------
@@ -165,7 +165,7 @@ func TestStarlarkProbe_OuterTimeoutCancelsInFlight(t *testing.T) {
 	source := `
 def probe(target):
     r = http.get(url = "http://%s:%d/" % (target.name, target.port))
-    assert.status(r, 200)
+    assert.http_status(r, 200)
 `
 	opts := newOpts(t, hostFromServer(t, srv), source)
 	opts.Timeout = 250 * time.Millisecond
@@ -347,7 +347,7 @@ def probe(target):
         body = "raw-body-bytes",
         headers = {"Authorization": "Bearer xyz", "Content-Type": "text/plain"},
     )
-    assert.status(r, 200)
+    assert.http_status(r, 200)
 `
 	opts := newOpts(t, hostFromServer(t, srv), source)
 	p := &Probe{}
@@ -374,7 +374,7 @@ func TestHTTP_ResponseHeadersVisible(t *testing.T) {
 	source := `
 def probe(target):
     r = http.get(url = "http://%s:%d/" % (target.name, target.port))
-    assert.status(r, 200)
+    assert.http_status(r, 200)
     if r.headers["X-Custom"] != "hello-world":
         fail("missing header, got: %s" % r.headers["X-Custom"])
 `
@@ -447,7 +447,7 @@ func TestHTTP_DistinctClientsBetweenProbes(t *testing.T) {
 	source := `
 def probe(target):
     r = http.get(url = "http://%s:%d/" % (target.name, target.port))
-    assert.status(r, 200)
+    assert.http_status(r, 200)
 `
 	mkProbe := func(name, host string) *Probe {
 		opts := newOpts(t, host, source)
@@ -470,10 +470,10 @@ def probe(target):
 // ---------------------------------------------------------------------------
 // assert builtin behavior
 
-func TestAssert_StatusWrongType(t *testing.T) {
+func TestAssert_HTTPStatusWrongType(t *testing.T) {
 	source := `
 def probe(target):
-    assert.status("not a response", 200)
+    assert.http_status("not a response", 200)
 `
 	opts := newOpts(t, "example.com", source)
 	p := &Probe{}
@@ -504,7 +504,7 @@ func TestInit_TopLevelHTTPHasRuntimeClient(t *testing.T) {
 
 	source := fmt.Sprintf(`
 r = http.get(url = "%s")
-assert.status(r, 200)
+assert.http_status(r, 200)
 
 def probe(target):
     pass
@@ -688,7 +688,7 @@ def probe(target):
         url = "http://%s:%d/" % (target.name, target.port),
         headers = {"Authorization": "Bearer " + vars.get("TOKEN")},
     )
-    assert.status(r, 200)
+    assert.http_status(r, 200)
 `
 	opts := newOpts(t, hostFromServer(t, srv), source)
 	opts.ProbeConf.(*configpb.ProbeConf).Vars = map[string]string{"TOKEN": "s3cret"}


### PR DESCRIPTION
## Summary

- `assert.status` -> `assert.http_status` in the only assert method on the Starlark probe.
- Prevents namespace collision with the planned `grpc` builtin (gRPC has its own status codes).
- No users yet; rename cost is minimal.

## Test plan

- [x] `go test ./probes/starlark/...` passes