### PR TITLE
[probes.http] Support dynamic headers, starting with@uuid@ substitution

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -609,7 +609,7 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 	startSuccess := result.success
 
 	if p.c.GetRequestsPerProbe() == 1 {
-		err := p.doHTTPRequest(tgtState.req.WithContext(ctx), tgtState.clients[0], target, result, nil)
+		err := p.doHTTPRequest(requestForSend(tgtState.req, ctx), tgtState.clients[0], target, result, nil)
 		runReq.LastRun.Set(result.success > startSuccess, time.Since(start), err)
 		return
 	}
@@ -628,7 +628,7 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 
 			time.Sleep(time.Duration(numReq*int(p.c.GetRequestsIntervalMsec())) * time.Millisecond)
 			// Ignore the error returned by doHTTPRequest, as it's already logged.
-			_ = p.doHTTPRequest(req.WithContext(ctx), tgtState.clients[numReq], target, result, &resultMu)
+			_ = p.doHTTPRequest(requestForSend(req, ctx), tgtState.clients[numReq], target, result, &resultMu)
 		}(tgtState.req, numReq, target, result)
 	}
 	wg.Wait()

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -612,7 +612,7 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 	startSuccess := result.success
 
 	if p.c.GetRequestsPerProbe() == 1 {
-		err := p.doHTTPRequest(p.requestForSend(tgtState.req, ctx), tgtState.clients[0], target, result, nil)
+		err := p.doHTTPRequest(p.requestForSend(ctx, tgtState.req), tgtState.clients[0], target, result, nil)
 		runReq.LastRun.Set(result.success > startSuccess, time.Since(start), err)
 		return
 	}
@@ -631,7 +631,7 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 
 			time.Sleep(time.Duration(numReq*int(p.c.GetRequestsIntervalMsec())) * time.Millisecond)
 			// Ignore the error returned by doHTTPRequest, as it's already logged.
-			_ = p.doHTTPRequest(p.requestForSend(req, ctx), tgtState.clients[numReq], target, result, &resultMu)
+			_ = p.doHTTPRequest(p.requestForSend(ctx, req), tgtState.clients[numReq], target, result, &resultMu)
 		}(tgtState.req, numReq, target, result)
 	}
 	wg.Wait()

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -62,10 +62,11 @@ type Probe struct {
 	redirectFunc  func(req *http.Request, via []*http.Request) error
 
 	// book-keeping params
-	targets []endpoint.Endpoint
-	method  string
-	url     string
-	oauthTS oauth2.TokenSource
+	targets          []endpoint.Endpoint
+	method           string
+	url              string
+	hasDynamicHeader bool
+	oauthTS          oauth2.TokenSource
 
 	responseParser *payload.Parser
 
@@ -185,6 +186,8 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 			"requests_per_probe*requests_interval_msec + timeout (%s) > interval (%s)",
 			totalDuration, p.opts.Interval)
 	}
+
+	p.hasDynamicHeader = configHasDynamicHeader(p.c)
 
 	p.method = p.c.GetMethod().String()
 
@@ -609,7 +612,11 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 	startSuccess := result.success
 
 	if p.c.GetRequestsPerProbe() == 1 {
-		err := p.doHTTPRequest(requestForSend(tgtState.req, ctx), tgtState.clients[0], target, result, nil)
+		sendReq := tgtState.req.WithContext(ctx)
+		if p.hasDynamicHeader {
+			sendReq = substituteDynamicHeaders(tgtState.req, ctx)
+		}
+		err := p.doHTTPRequest(sendReq, tgtState.clients[0], target, result, nil)
 		runReq.LastRun.Set(result.success > startSuccess, time.Since(start), err)
 		return
 	}
@@ -627,8 +634,12 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 			defer wg.Done()
 
 			time.Sleep(time.Duration(numReq*int(p.c.GetRequestsIntervalMsec())) * time.Millisecond)
+			sendReq := req.WithContext(ctx)
+			if p.hasDynamicHeader {
+				sendReq = substituteDynamicHeaders(req, ctx)
+			}
 			// Ignore the error returned by doHTTPRequest, as it's already logged.
-			_ = p.doHTTPRequest(requestForSend(req, ctx), tgtState.clients[numReq], target, result, &resultMu)
+			_ = p.doHTTPRequest(sendReq, tgtState.clients[numReq], target, result, &resultMu)
 		}(tgtState.req, numReq, target, result)
 	}
 	wg.Wait()

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -612,11 +612,7 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 	startSuccess := result.success
 
 	if p.c.GetRequestsPerProbe() == 1 {
-		sendReq := tgtState.req.WithContext(ctx)
-		if p.hasDynamicHeader {
-			sendReq = substituteDynamicHeaders(tgtState.req, ctx)
-		}
-		err := p.doHTTPRequest(sendReq, tgtState.clients[0], target, result, nil)
+		err := p.doHTTPRequest(p.requestForSend(tgtState.req, ctx), tgtState.clients[0], target, result, nil)
 		runReq.LastRun.Set(result.success > startSuccess, time.Since(start), err)
 		return
 	}
@@ -634,12 +630,8 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 			defer wg.Done()
 
 			time.Sleep(time.Duration(numReq*int(p.c.GetRequestsIntervalMsec())) * time.Millisecond)
-			sendReq := req.WithContext(ctx)
-			if p.hasDynamicHeader {
-				sendReq = substituteDynamicHeaders(req, ctx)
-			}
 			// Ignore the error returned by doHTTPRequest, as it's already logged.
-			_ = p.doHTTPRequest(sendReq, tgtState.clients[numReq], target, result, &resultMu)
+			_ = p.doHTTPRequest(p.requestForSend(req, ctx), tgtState.clients[numReq], target, result, &resultMu)
 		}(tgtState.req, numReq, target, result)
 	}
 	wg.Wait()

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -312,8 +312,6 @@ func (p *Probe) requestTrace(result *probeResult) *httptrace.ClientTrace {
 func (p *Probe) doHTTPRequest(req *http.Request, client *http.Client, target endpoint.Endpoint, result *probeResult, resultMu *sync.Mutex) error {
 	l := p.l.WithAttributes(slog.String("target", target.Name), slog.String("url", req.URL.String()))
 
-	req = p.prepareRequest(req)
-
 	start := time.Now()
 
 	if trace := p.requestTrace(result); trace != nil {
@@ -612,7 +610,7 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 	startSuccess := result.success
 
 	if p.c.GetRequestsPerProbe() == 1 {
-		err := p.doHTTPRequest(p.requestForSend(ctx, tgtState.req), tgtState.clients[0], target, result, nil)
+		err := p.doHTTPRequest(p.prepareRequest(ctx, tgtState.req), tgtState.clients[0], target, result, nil)
 		runReq.LastRun.Set(result.success > startSuccess, time.Since(start), err)
 		return
 	}
@@ -631,7 +629,7 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 
 			time.Sleep(time.Duration(numReq*int(p.c.GetRequestsIntervalMsec())) * time.Millisecond)
 			// Ignore the error returned by doHTTPRequest, as it's already logged.
-			_ = p.doHTTPRequest(p.requestForSend(ctx, req), tgtState.clients[numReq], target, result, &resultMu)
+			_ = p.doHTTPRequest(p.prepareRequest(ctx, req), tgtState.clients[numReq], target, result, &resultMu)
 		}(tgtState.req, numReq, target, result)
 	}
 	wg.Wait()

--- a/probes/http/proto/config.pb.go
+++ b/probes/http/proto/config.pb.go
@@ -265,6 +265,11 @@ type ProbeConf struct {
 	//	  key: "Authorization"
 	//	  value: "Bearer {{env "AUTH_TOKEN"}}"
 	//	}
+	//
+	// Header values support per-request @uuid@ substitution -- each probe call
+	// gets a fresh UUIDv4. Use "@@" to emit a literal "@". Example:
+	//
+	//	header { key: "X-Request-ID" value: "@uuid@" }
 	Headers []*ProbeConf_Header `protobuf:"bytes,8,rep,name=headers" json:"headers,omitempty"`
 	Header  map[string]string   `protobuf:"bytes,20,rep,name=header" json:"header,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Request body. This field works similar to the curl's data flag. If there

--- a/probes/http/proto/config.proto
+++ b/probes/http/proto/config.proto
@@ -72,7 +72,11 @@ message ProbeConf {
   // header {
   //   key: "Authorization"
   //   value: "Bearer {{env "AUTH_TOKEN"}}"
-  // }   
+  // }
+  //
+  // Header values support per-request @uuid@ substitution -- each probe call
+  // gets a fresh UUIDv4. Use "@@" to emit a literal "@". Example:
+  //   header { key: "X-Request-ID" value: "@uuid@" }
   repeated Header headers = 8;
   map<string, string> header = 20;
   

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -15,6 +15,7 @@
 package http
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -103,47 +104,61 @@ func (p *Probe) resolveFirst(target endpoint.Endpoint) bool {
 	return target.IP != nil
 }
 
-// dynamicHeaderSubst builds the per-request substitution map applied to
-// header values via @key@. New keys must be backwards compatible: stray
-// @something@ in existing configs is left untouched by SubstituteLabels, so
-// only collisions with a key added here would change behavior.
-func dynamicHeaderSubst() map[string]string {
-	return map[string]string{
-		"uuid": uuid.NewString(),
-	}
-}
-
 // setHeaders computes setHeaders for a target. Host header is computed slightly
 // differently than other setHeaders.
 //   - If host header is set in the probe, it overrides everything else.
 //   - Otherwise we use target's host (computed elsewhere) along with port.
 //
-// Header values support @uuid@ substitution: each request gets a fresh
-// UUIDv4. Use @@ to emit a literal @.
+// Header values may contain @uuid@ tokens; those are kept verbatim here and
+// resolved per-send by requestForSend so each request gets a fresh UUIDv4.
+// Use @@ to emit a literal @.
 func (p *Probe) setHeaders(req *http.Request, host string, port int) {
 	var hostHeader string
-	subst := dynamicHeaderSubst()
-
-	set := func(k, v string) {
-		v, _ = strtemplate.SubstituteLabels(v, subst)
-		if k == "Host" {
-			hostHeader = v
-			return
-		}
-		req.Header.Set(k, v)
-	}
 
 	for _, h := range p.c.GetHeaders() {
-		set(h.GetName(), h.GetValue())
+		if h.GetName() == "Host" {
+			hostHeader = h.GetValue()
+			continue
+		}
+		req.Header.Set(h.GetName(), h.GetValue())
 	}
+
 	for k, v := range p.c.GetHeader() {
-		set(k, v)
+		if k == "Host" {
+			hostHeader = v
+			continue
+		}
+		req.Header.Set(k, v)
 	}
 
 	if hostHeader == "" {
 		hostHeader = hostWithPort(host, port)
 	}
 	req.Host = hostHeader
+}
+
+// requestForSend returns a per-call copy of req with dynamic header tokens
+// (currently just @uuid@) resolved. The cached request kept in tgtState
+// holds raw templates, so each invocation of this function -- including the
+// parallel goroutines launched when requests_per_probe > 1 -- gets its own
+// UUID without racing on the shared Header map.
+//
+// We always do the Clone, even when no header contains @, because the cost
+// is negligible compared to the network round-trip that follows.
+func requestForSend(req *http.Request, ctx context.Context) *http.Request {
+	out := req.Clone(ctx)
+	subst := map[string]string{"uuid": uuid.NewString()}
+	for k, vv := range out.Header {
+		for i, v := range vv {
+			if nv, _ := strtemplate.SubstituteLabels(v, subst); nv != v {
+				out.Header[k][i] = nv
+			}
+		}
+	}
+	if nv, _ := strtemplate.SubstituteLabels(out.Host, subst); nv != out.Host {
+		out.Host = nv
+	}
+	return out
 }
 
 func (p *Probe) urlHostAndIPLabel(target endpoint.Endpoint, host string) (string, string, error) {

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -160,20 +160,11 @@ func configHasDynamicHeader(c *configpb.ProbeConf) bool {
 	return strings.Contains(c.GetUserAgent(), "@")
 }
 
-// requestForSend prepares the cached request for a single send. When the
-// config has no dynamic header tokens (the common case), this is just the
-// original cheap WithContext shallow copy. When it does, we Clone instead
-// so each send gets its own UUID and parallel goroutines from
-// requests_per_probe > 1 don't race on the shared Header map.
-//
-// Substitution is lazy: a value without '@' skips SubstituteLabels (which
-// would otherwise strings.Split for nothing), and the UUID is only
-// generated on the first value that needs it.
-func (p *Probe) requestForSend(ctx context.Context, req *http.Request) *http.Request {
-	if !p.hasDynamicHeader {
-		return req.WithContext(ctx)
-	}
-	out := req.Clone(ctx)
+// applyDynamicHeaders substitutes @uuid@ tokens (and any future tokens) in
+// the request's header values and Host. All @uuid@ occurrences within a
+// single send resolve to the same UUID; substitution is lazy so a value
+// without '@' skips strtemplate entirely.
+func applyDynamicHeaders(req *http.Request) {
 	var subst map[string]string
 	sub := func(s string) string {
 		if !strings.Contains(s, "@") {
@@ -185,17 +176,16 @@ func (p *Probe) requestForSend(ctx context.Context, req *http.Request) *http.Req
 		nv, _ := strtemplate.SubstituteLabels(s, subst)
 		return nv
 	}
-	for _, vv := range out.Header {
+	for _, vv := range req.Header {
 		for i, v := range vv {
 			if nv := sub(v); nv != v {
 				vv[i] = nv
 			}
 		}
 	}
-	if nv := sub(out.Host); nv != out.Host {
-		out.Host = nv
+	if nv := sub(req.Host); nv != req.Host {
+		req.Host = nv
 	}
-	return out
 }
 
 func (p *Probe) urlHostAndIPLabel(target endpoint.Endpoint, host string) (string, string, error) {
@@ -266,18 +256,20 @@ func getToken(ts oauth2.TokenSource, l *logger.Logger) (string, error) {
 	return "", fmt.Errorf("got unknown token: %v", tok)
 }
 
-func (p *Probe) prepareRequest(req *http.Request) *http.Request {
-	// We clone the request for the cases where we modify the request:
-	//   -- if request has a body, each request gets its own Body
-	//      as HTTP transport reads body in a streaming fashion, and we can't
-	//      share it across multiple requests.
-	//   -- if OAuth token is used, each request gets its own Authorization
-	//      header.
-	if p.oauthTS == nil && p.requestBody.Len() == 0 {
-		return req
+// prepareRequest derives a per-send request from the cached one. Cloning is
+// the only safe way to mutate without racing parallel sends (rpp > 1), so we
+// do it once when any of the per-send mutations apply -- dynamic header
+// substitution, OAuth Authorization header, or a fresh streaming body --
+// and skip to a cheap WithContext copy otherwise.
+func (p *Probe) prepareRequest(ctx context.Context, req *http.Request) *http.Request {
+	if !p.hasDynamicHeader && p.oauthTS == nil && p.requestBody.Len() == 0 {
+		return req.WithContext(ctx)
 	}
+	req = req.Clone(ctx)
 
-	req = req.Clone(req.Context())
+	if p.hasDynamicHeader {
+		applyDynamicHeaders(req)
+	}
 
 	if p.oauthTS != nil {
 		tok, err := getToken(p.oauthTS, p.l)
@@ -291,7 +283,9 @@ func (p *Probe) prepareRequest(req *http.Request) *http.Request {
 		req.Header.Set("Authorization", fmt.Sprintf(p.c.GetOauthConfig().GetTokenTypeFormat(), tok))
 	}
 
-	req.Body = p.requestBody.Reader()
+	if p.requestBody.Len() > 0 {
+		req.Body = p.requestBody.Reader()
+	}
 
 	return req
 }

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -137,15 +137,31 @@ func (p *Probe) setHeaders(req *http.Request, host string, port int) {
 	req.Host = hostHeader
 }
 
-// requestForSend returns a per-call copy of req with dynamic header tokens
-// (currently just @uuid@) resolved. The cached request kept in tgtState
-// holds raw templates, so each invocation of this function -- including the
-// parallel goroutines launched when requests_per_probe > 1 -- gets its own
-// UUID without racing on the shared Header map.
-//
-// We always do the Clone, even when no header contains @, because the cost
-// is negligible compared to the network round-trip that follows.
-func requestForSend(req *http.Request, ctx context.Context) *http.Request {
+// configHasDynamicHeader reports whether any header value contains an '@'
+// (the substitution marker). When false, the cached request's headers are
+// stable across runs and the per-send clone+substitute can be skipped.
+// '@'-without-a-known-key is a false positive (e.g. an email in a header)
+// but harmless: substitution is a no-op for unknown keys, so the only cost
+// is the clone itself.
+func configHasDynamicHeader(c *configpb.ProbeConf) bool {
+	for _, h := range c.GetHeaders() {
+		if strings.Contains(h.GetValue(), "@") {
+			return true
+		}
+	}
+	for _, v := range c.GetHeader() {
+		if strings.Contains(v, "@") {
+			return true
+		}
+	}
+	return false
+}
+
+// substituteDynamicHeaders is called only when configHasDynamicHeader was
+// true at Init time. It resolves @uuid@ (and any future @keys@) on a freshly
+// cloned request so each send gets its own value and parallel goroutines
+// from requests_per_probe > 1 don't race on the shared Header map.
+func substituteDynamicHeaders(req *http.Request, ctx context.Context) *http.Request {
 	out := req.Clone(ctx)
 	subst := map[string]string{"uuid": uuid.NewString()}
 	for k, vv := range out.Header {

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -143,6 +143,9 @@ func (p *Probe) setHeaders(req *http.Request, host string, port int) {
 // '@'-without-a-known-key is a false positive (e.g. an email in a header)
 // but harmless: substitution is a no-op for unknown keys, so the only cost
 // is the clone itself.
+//
+// user_agent ends up as a request header too (set in httpRequestForTarget),
+// so check it here for the same reason.
 func configHasDynamicHeader(c *configpb.ProbeConf) bool {
 	for _, h := range c.GetHeaders() {
 		if strings.Contains(h.GetValue(), "@") {
@@ -154,7 +157,7 @@ func configHasDynamicHeader(c *configpb.ProbeConf) bool {
 			return true
 		}
 	}
-	return false
+	return strings.Contains(c.GetUserAgent(), "@")
 }
 
 // requestForSend prepares the cached request for a single send. When the

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -157,11 +157,15 @@ func configHasDynamicHeader(c *configpb.ProbeConf) bool {
 	return false
 }
 
-// substituteDynamicHeaders is called only when configHasDynamicHeader was
-// true at Init time. It resolves @uuid@ (and any future @keys@) on a freshly
-// cloned request so each send gets its own value and parallel goroutines
-// from requests_per_probe > 1 don't race on the shared Header map.
-func substituteDynamicHeaders(req *http.Request, ctx context.Context) *http.Request {
+// requestForSend prepares the cached request for a single send. When the
+// config has no dynamic header tokens (the common case), this is just the
+// original cheap WithContext shallow copy. When it does, we Clone instead
+// so each send gets its own UUID and parallel goroutines from
+// requests_per_probe > 1 don't race on the shared Header map.
+func (p *Probe) requestForSend(req *http.Request, ctx context.Context) *http.Request {
+	if !p.hasDynamicHeader {
+		return req.WithContext(ctx)
+	}
 	out := req.Clone(ctx)
 	subst := map[string]string{"uuid": uuid.NewString()}
 	for k, vv := range out.Header {

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -162,20 +162,34 @@ func configHasDynamicHeader(c *configpb.ProbeConf) bool {
 // original cheap WithContext shallow copy. When it does, we Clone instead
 // so each send gets its own UUID and parallel goroutines from
 // requests_per_probe > 1 don't race on the shared Header map.
-func (p *Probe) requestForSend(req *http.Request, ctx context.Context) *http.Request {
+//
+// Substitution is lazy: a value without '@' skips SubstituteLabels (which
+// would otherwise strings.Split for nothing), and the UUID is only
+// generated on the first value that needs it.
+func (p *Probe) requestForSend(ctx context.Context, req *http.Request) *http.Request {
 	if !p.hasDynamicHeader {
 		return req.WithContext(ctx)
 	}
 	out := req.Clone(ctx)
-	subst := map[string]string{"uuid": uuid.NewString()}
-	for k, vv := range out.Header {
+	var subst map[string]string
+	sub := func(s string) string {
+		if !strings.Contains(s, "@") {
+			return s
+		}
+		if subst == nil {
+			subst = map[string]string{"uuid": uuid.NewString()}
+		}
+		nv, _ := strtemplate.SubstituteLabels(s, subst)
+		return nv
+	}
+	for _, vv := range out.Header {
 		for i, v := range vv {
-			if nv, _ := strtemplate.SubstituteLabels(v, subst); nv != v {
-				out.Header[k][i] = nv
+			if nv := sub(v); nv != v {
+				vv[i] = nv
 			}
 		}
 	}
-	if nv, _ := strtemplate.SubstituteLabels(out.Host, subst); nv != out.Host {
+	if nv := sub(out.Host); nv != out.Host {
 		out.Host = nv
 	}
 	return out

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -22,10 +22,12 @@ import (
 	"strings"
 
 	"github.com/cloudprober/cloudprober/common/iputils"
+	"github.com/cloudprober/cloudprober/common/strtemplate"
 	"github.com/cloudprober/cloudprober/internal/httpreq"
 	"github.com/cloudprober/cloudprober/logger"
 	configpb "github.com/cloudprober/cloudprober/probes/http/proto"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
+	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 )
 
@@ -101,27 +103,41 @@ func (p *Probe) resolveFirst(target endpoint.Endpoint) bool {
 	return target.IP != nil
 }
 
+// dynamicHeaderSubst builds the per-request substitution map applied to
+// header values via @key@. New keys must be backwards compatible: stray
+// @something@ in existing configs is left untouched by SubstituteLabels, so
+// only collisions with a key added here would change behavior.
+func dynamicHeaderSubst() map[string]string {
+	return map[string]string{
+		"uuid": uuid.NewString(),
+	}
+}
+
 // setHeaders computes setHeaders for a target. Host header is computed slightly
 // differently than other setHeaders.
 //   - If host header is set in the probe, it overrides everything else.
 //   - Otherwise we use target's host (computed elsewhere) along with port.
+//
+// Header values support @uuid@ substitution: each request gets a fresh
+// UUIDv4. Use @@ to emit a literal @.
 func (p *Probe) setHeaders(req *http.Request, host string, port int) {
 	var hostHeader string
+	subst := dynamicHeaderSubst()
 
-	for _, h := range p.c.GetHeaders() {
-		if h.GetName() == "Host" {
-			hostHeader = h.GetValue()
-			continue
-		}
-		req.Header.Set(h.GetName(), h.GetValue())
-	}
-
-	for k, v := range p.c.GetHeader() {
+	set := func(k, v string) {
+		v, _ = strtemplate.SubstituteLabels(v, subst)
 		if k == "Host" {
 			hostHeader = v
-			continue
+			return
 		}
 		req.Header.Set(k, v)
+	}
+
+	for _, h := range p.c.GetHeaders() {
+		set(h.GetName(), h.GetValue())
+	}
+	for k, v := range p.c.GetHeader() {
+		set(k, v)
 	}
 
 	if hostHeader == "" {

--- a/probes/http/request_test.go
+++ b/probes/http/request_test.go
@@ -15,15 +15,20 @@
 package http
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/httptest"
+	neturl "net/url"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
 	oauthpb "github.com/cloudprober/cloudprober/common/oauth/proto"
 	"github.com/cloudprober/cloudprober/internal/httpreq"
+	"github.com/cloudprober/cloudprober/probes/common/sched"
 	configpb "github.com/cloudprober/cloudprober/probes/http/proto"
 	probesconfigpb "github.com/cloudprober/cloudprober/probes/proto"
 
@@ -522,11 +527,38 @@ func TestRequestHasConfiguredHeaders(t *testing.T) {
 	assert.Contains(t, val, testHeadersValue)
 }
 
+// Drives the real probe path: two runProbe calls on the same Probe must
+// land two different UUIDs on the wire. This pins the bug where the cached
+// tgtState.req baked the first UUID into its Header map and every
+// subsequent send reused it.
 func TestDynamicHeaderSubstitution(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		seen      []string
+		seenStat  string
+		seenUnk   string
+		seenEscap string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen = append(seen, r.Header.Get("X-Request-ID"))
+		seenStat = r.Header.Get("X-Static")
+		seenUnk = r.Header.Get("X-Unknown")
+		seenEscap = r.Header.Get("X-Literal-At")
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	hostURL, _ := neturl.Parse(srv.URL)
+	host, portStr, _ := net.SplitHostPort(hostURL.Host)
+	port, _ := strconv.Atoi(portStr)
+
 	p := &Probe{}
+	target := endpoint.Endpoint{Name: host, Port: port}
 	opts := &options.Options{
-		Targets:  targets.StaticTargets("test.com"),
-		Interval: 10 * time.Millisecond,
+		Targets:  targets.StaticEndpoints([]endpoint.Endpoint{target}),
+		Interval: 5 * time.Second,
+		Timeout:  2 * time.Second,
 		ProbeConf: &configpb.ProbeConf{
 			Header: map[string]string{
 				"X-Request-ID": "@uuid@",
@@ -539,26 +571,29 @@ func TestDynamicHeaderSubstitution(t *testing.T) {
 	if err := p.Init("http_test", opts); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
-	target := endpoint.Endpoint{Name: "dyn-test"}
 
-	req1, err := p.httpRequestForTarget(target)
-	assert.NoError(t, err)
-	req2, err := p.httpRequestForTarget(target)
-	assert.NoError(t, err)
+	runReq := &sched.RunProbeForTargetRequest{Target: target}
+	for i := 0; i < 3; i++ {
+		p.runProbe(context.Background(), runReq)
+	}
 
-	uuid1 := req1.Header.Get("X-Request-ID")
-	uuid2 := req2.Header.Get("X-Request-ID")
+	mu.Lock()
+	defer mu.Unlock()
 
-	_, err = uuid.Parse(uuid1)
-	assert.NoError(t, err, "X-Request-ID is not a valid UUID: %q", uuid1)
-	assert.NotEqual(t, uuid1, uuid2, "consecutive requests got the same @uuid@ value")
+	assert.Equal(t, 3, len(seen), "server should have received 3 requests")
+	for i, id := range seen {
+		_, err := uuid.Parse(id)
+		assert.NoError(t, err, "request %d X-Request-ID is not a valid UUID: %q", i, id)
+	}
+	assert.NotEqual(t, seen[0], seen[1], "consecutive requests reused the same @uuid@")
+	assert.NotEqual(t, seen[1], seen[2], "consecutive requests reused the same @uuid@")
 
-	// Static values pass through unchanged.
-	assert.Equal(t, "no-substitution-here", req1.Header.Get("X-Static"))
-	// Unknown @key@ is left untouched (backwards compatibility).
-	assert.Equal(t, "@some_other_key@", req1.Header.Get("X-Unknown"))
+	// Non-templated values pass through untouched.
+	assert.Equal(t, "no-substitution-here", seenStat)
+	// Unknown @key@ is left as-is (backwards compatibility).
+	assert.Equal(t, "@some_other_key@", seenUnk)
 	// @@ escapes to a single literal @.
-	assert.Equal(t, "left@right", req1.Header.Get("X-Literal-At"))
+	assert.Equal(t, "left@right", seenEscap)
 }
 
 func TestResolveFirst(t *testing.T) {

--- a/probes/http/request_test.go
+++ b/probes/http/request_test.go
@@ -527,10 +527,11 @@ func TestRequestHasConfiguredHeaders(t *testing.T) {
 	assert.Contains(t, val, testHeadersValue)
 }
 
-// Drives the real probe path: runProbe must put a fresh UUID on each send.
-// Each iteration captures the full header set so failure points at which
-// request misbehaved, not a last-write-wins ghost.
-func TestDynamicHeaderSubstitution(t *testing.T) {
+// Spins up a test server and returns a func that runs one full probe cycle
+// and yields the captured request headers, one entry per HTTP request the
+// server saw during that cycle.
+func dynamicHeaderTestRig(t *testing.T, conf *configpb.ProbeConf) (*Probe, func() []http.Header) {
+	t.Helper()
 	var (
 		mu   sync.Mutex
 		seen []http.Header
@@ -541,7 +542,7 @@ func TestDynamicHeaderSubstitution(t *testing.T) {
 		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 	hostURL, _ := neturl.Parse(srv.URL)
 	host, portStr, _ := net.SplitHostPort(hostURL.Host)
 	port, _ := strconv.Atoi(portStr)
@@ -549,46 +550,88 @@ func TestDynamicHeaderSubstitution(t *testing.T) {
 	p := &Probe{}
 	target := endpoint.Endpoint{Name: host, Port: port}
 	opts := &options.Options{
-		Targets:  targets.StaticEndpoints([]endpoint.Endpoint{target}),
-		Interval: 5 * time.Second,
-		Timeout:  2 * time.Second,
-		ProbeConf: &configpb.ProbeConf{
-			Header: map[string]string{
-				"X-Request-ID": "@uuid@",
-				"X-Static":     "no-substitution-here",
-				"X-Unknown":    "@some_other_key@",
-				"X-Literal-At": "left@@right",
-			},
-		},
+		Targets:   targets.StaticEndpoints([]endpoint.Endpoint{target}),
+		Interval:  5 * time.Second,
+		Timeout:   2 * time.Second,
+		ProbeConf: conf,
 	}
 	if err := p.Init("http_test", opts); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
-
 	runReq := &sched.RunProbeForTargetRequest{Target: target}
-	for i := 0; i < 3; i++ {
+	return p, func() []http.Header {
+		mu.Lock()
+		seen = seen[:0]
+		mu.Unlock()
 		p.runProbe(context.Background(), runReq)
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]http.Header, len(seen))
+		copy(out, seen)
+		return out
 	}
+}
 
-	mu.Lock()
-	defer mu.Unlock()
+// Drives the real probe path: runProbe must put a fresh UUID on each send.
+// Each iteration captures the full header set so failure points at which
+// request misbehaved, not a last-write-wins ghost.
+func TestDynamicHeaderSubstitution(t *testing.T) {
+	t.Run("sequential_runs", func(t *testing.T) {
+		p, run := dynamicHeaderTestRig(t, &configpb.ProbeConf{
+			Header: map[string]string{
+				"X-Request-ID": "@uuid@",
+				"X-Trace-Id":   "trace-@uuid@",
+				"X-Static":     "no-substitution-here",
+				"X-Unknown":    "@some_other_key@",
+				"X-Literal-At": "left@@right",
+			},
+			UserAgent: proto.String("cloudprober/@uuid@"),
+		})
+		assert.True(t, p.hasDynamicHeader, "user_agent with @uuid@ should set hasDynamicHeader")
 
-	assert.Equal(t, 3, len(seen), "server should have received 3 requests")
-	uuids := make([]string, len(seen))
-	for i, h := range seen {
-		uuids[i] = h.Get("X-Request-ID")
-		_, err := uuid.Parse(uuids[i])
-		assert.NoError(t, err, "request %d X-Request-ID is not a valid UUID: %q", i, uuids[i])
+		uuids := make([]string, 0, 3)
+		for i := 0; i < 3; i++ {
+			got := run()
+			assert.Equal(t, 1, len(got), "iteration %d: server should see one request", i)
+			h := got[0]
 
-		// Non-templated values pass through untouched.
-		assert.Equal(t, "no-substitution-here", h.Get("X-Static"))
-		// Unknown @key@ is left as-is (backwards compatibility).
-		assert.Equal(t, "@some_other_key@", h.Get("X-Unknown"))
-		// @@ escapes to a single literal @.
-		assert.Equal(t, "left@right", h.Get("X-Literal-At"))
-	}
-	assert.NotEqual(t, uuids[0], uuids[1], "consecutive requests reused the same @uuid@")
-	assert.NotEqual(t, uuids[1], uuids[2], "consecutive requests reused the same @uuid@")
+			id := h.Get("X-Request-ID")
+			_, err := uuid.Parse(id)
+			assert.NoError(t, err, "iteration %d: X-Request-ID is not a valid UUID: %q", i, id)
+			// Same @uuid@ within a single send resolves to the same value.
+			assert.Equal(t, "trace-"+id, h.Get("X-Trace-Id"), "iteration %d: @uuid@ should match within a send", i)
+			assert.Equal(t, "cloudprober/"+id, h.Get("User-Agent"), "iteration %d: user_agent should substitute too", i)
+
+			assert.Equal(t, "no-substitution-here", h.Get("X-Static"))
+			assert.Equal(t, "@some_other_key@", h.Get("X-Unknown"))
+			assert.Equal(t, "left@right", h.Get("X-Literal-At"))
+			uuids = append(uuids, id)
+		}
+		assert.NotEqual(t, uuids[0], uuids[1], "consecutive requests reused the same @uuid@")
+		assert.NotEqual(t, uuids[1], uuids[2], "consecutive requests reused the same @uuid@")
+	})
+
+	// requests_per_probe > 1 fans out to parallel goroutines that all share
+	// the cached request; each one must clone+substitute independently so
+	// (a) the UUIDs are distinct and (b) -race sees no write to a shared map.
+	t.Run("requests_per_probe_parallel", func(t *testing.T) {
+		const n = 5
+		_, run := dynamicHeaderTestRig(t, &configpb.ProbeConf{
+			RequestsPerProbe:     proto.Int32(n),
+			RequestsIntervalMsec: proto.Int32(0),
+			Header:               map[string]string{"X-Request-ID": "@uuid@"},
+		})
+		got := run()
+		assert.Equal(t, n, len(got), "server should see one request per requests_per_probe")
+		seenIDs := make(map[string]struct{}, n)
+		for i, h := range got {
+			id := h.Get("X-Request-ID")
+			_, err := uuid.Parse(id)
+			assert.NoError(t, err, "request %d X-Request-ID is not a valid UUID: %q", i, id)
+			seenIDs[id] = struct{}{}
+		}
+		assert.Equal(t, n, len(seenIDs), "parallel requests must each get a distinct UUID")
+	})
 }
 
 func TestResolveFirst(t *testing.T) {

--- a/probes/http/request_test.go
+++ b/probes/http/request_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cloudprober/cloudprober/probes/options"
 	"github.com/cloudprober/cloudprober/targets"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
 	"google.golang.org/protobuf/proto"
@@ -519,6 +520,45 @@ func TestRequestHasConfiguredHeaders(t *testing.T) {
 	val, ok = req.Header[testHeadersName]
 	assert.True(t, ok, "Configured header (via 'headers' setting) is not present in target request")
 	assert.Contains(t, val, testHeadersValue)
+}
+
+func TestDynamicHeaderSubstitution(t *testing.T) {
+	p := &Probe{}
+	opts := &options.Options{
+		Targets:  targets.StaticTargets("test.com"),
+		Interval: 10 * time.Millisecond,
+		ProbeConf: &configpb.ProbeConf{
+			Header: map[string]string{
+				"X-Request-ID": "@uuid@",
+				"X-Static":     "no-substitution-here",
+				"X-Unknown":    "@some_other_key@",
+				"X-Literal-At": "left@@right",
+			},
+		},
+	}
+	if err := p.Init("http_test", opts); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	target := endpoint.Endpoint{Name: "dyn-test"}
+
+	req1, err := p.httpRequestForTarget(target)
+	assert.NoError(t, err)
+	req2, err := p.httpRequestForTarget(target)
+	assert.NoError(t, err)
+
+	uuid1 := req1.Header.Get("X-Request-ID")
+	uuid2 := req2.Header.Get("X-Request-ID")
+
+	_, err = uuid.Parse(uuid1)
+	assert.NoError(t, err, "X-Request-ID is not a valid UUID: %q", uuid1)
+	assert.NotEqual(t, uuid1, uuid2, "consecutive requests got the same @uuid@ value")
+
+	// Static values pass through unchanged.
+	assert.Equal(t, "no-substitution-here", req1.Header.Get("X-Static"))
+	// Unknown @key@ is left untouched (backwards compatibility).
+	assert.Equal(t, "@some_other_key@", req1.Header.Get("X-Unknown"))
+	// @@ escapes to a single literal @.
+	assert.Equal(t, "left@right", req1.Header.Get("X-Literal-At"))
 }
 
 func TestResolveFirst(t *testing.T) {

--- a/probes/http/request_test.go
+++ b/probes/http/request_test.go
@@ -401,50 +401,43 @@ func TestPrepareRequest(t *testing.T) {
 		token             string
 		token_type_format string
 		data              []string
-		wantIsCloned      bool
 		wantNewBody       bool
 	}{
 		{
 			name: "No token source, no body",
 		},
 		{
-			name:         "No token source, small body",
-			data:         data[0:20],
-			wantIsCloned: true,
-			wantNewBody:  true,
+			name:        "No token source, small body",
+			data:        data[0:20],
+			wantNewBody: true,
 		},
 		{
-			name:         "No token source, large body",
-			data:         data,
-			wantIsCloned: true,
-			wantNewBody:  true,
+			name:        "No token source, large body",
+			data:        data,
+			wantNewBody: true,
 		},
 		{
-			name:         "token source, no body",
-			token:        "test-token",
-			wantIsCloned: true,
-			wantNewBody:  false, // Only request is cloned.
+			name:        "token source, no body",
+			token:       "test-token",
+			wantNewBody: false, // Only request is cloned.
 		},
 		{
 			name:              "token source, custom token format",
 			token:             "test-token",
 			token_type_format: `Snowflake Token="%s"`,
-			wantIsCloned:      true,
 			wantNewBody:       false, // Only request is cloned.
 		},
 		{
-			name:         "token source, small body",
-			data:         data[0:20],
-			token:        "test-token",
-			wantIsCloned: true,
-			wantNewBody:  true,
+			name:        "token source, small body",
+			data:        data[0:20],
+			token:       "test-token",
+			wantNewBody: true,
 		},
 		{
-			name:         "token source, large body",
-			data:         data,
-			token:        "test-token",
-			wantIsCloned: true,
-			wantNewBody:  true,
+			name:        "token source, large body",
+			data:        data,
+			token:       "test-token",
+			wantNewBody: true,
 		},
 	}
 	for _, tt := range tests {
@@ -464,11 +457,7 @@ func TestPrepareRequest(t *testing.T) {
 			}
 
 			inReq, _ := httpreq.NewRequest("GET", "http://cloudprober.org", p.requestBody)
-			got := p.prepareRequest(inReq)
-
-			if tt.wantIsCloned != (inReq != got) {
-				t.Errorf("wantIsCloned=%v, (inReq != got) is %v", tt.wantIsCloned, inReq != got)
-			}
+			got := p.prepareRequest(context.Background(), inReq)
 
 			if tt.wantNewBody != (inReq.Body != got.Body) {
 				t.Errorf("wantNewBody=%v, (inReq.Body != got.Body) is %v", tt.wantNewBody, inReq.Body != got.Body)
@@ -476,6 +465,7 @@ func TestPrepareRequest(t *testing.T) {
 
 			if tt.token != "" {
 				assert.Equal(t, fmt.Sprintf(p.c.GetOauthConfig().GetTokenTypeFormat(), tt.token), got.Header.Get("Authorization"), "Token mismatch")
+				assert.Empty(t, inReq.Header.Get("Authorization"), "Cached request must not be mutated")
 			}
 
 			if len(tt.data) != 0 {

--- a/probes/http/request_test.go
+++ b/probes/http/request_test.go
@@ -401,43 +401,50 @@ func TestPrepareRequest(t *testing.T) {
 		token             string
 		token_type_format string
 		data              []string
+		wantIsCloned      bool
 		wantNewBody       bool
 	}{
 		{
 			name: "No token source, no body",
 		},
 		{
-			name:        "No token source, small body",
-			data:        data[0:20],
-			wantNewBody: true,
+			name:         "No token source, small body",
+			data:         data[0:20],
+			wantIsCloned: true,
+			wantNewBody:  true,
 		},
 		{
-			name:        "No token source, large body",
-			data:        data,
-			wantNewBody: true,
+			name:         "No token source, large body",
+			data:         data,
+			wantIsCloned: true,
+			wantNewBody:  true,
 		},
 		{
-			name:        "token source, no body",
-			token:       "test-token",
-			wantNewBody: false, // Only request is cloned.
+			name:         "token source, no body",
+			token:        "test-token",
+			wantIsCloned: true,
+			wantNewBody:  false, // Only request is cloned.
 		},
 		{
 			name:              "token source, custom token format",
 			token:             "test-token",
 			token_type_format: `Snowflake Token="%s"`,
+			wantIsCloned:      true,
 			wantNewBody:       false, // Only request is cloned.
 		},
 		{
-			name:        "token source, small body",
-			data:        data[0:20],
-			token:       "test-token",
-			wantNewBody: true,
+			name:         "token source, small body",
+			data:         data[0:20],
+			token:        "test-token",
+			wantIsCloned: true,
+			wantNewBody:  true,
 		},
 		{
-			name:        "token source, large body",
-			data:        data,
-			token:       "test-token",
-			wantNewBody: true,
+			name:         "token source, large body",
+			data:         data,
+			token:        "test-token",
+			wantIsCloned: true,
+			wantNewBody:  true,
 		},
 	}
 	for _, tt := range tests {
@@ -459,13 +466,20 @@ func TestPrepareRequest(t *testing.T) {
 			inReq, _ := httpreq.NewRequest("GET", "http://cloudprober.org", p.requestBody)
 			got := p.prepareRequest(context.Background(), inReq)
 
+			// "Cloned" = headers are independently mutable. Writing to got
+			// should not leak into the cached inReq.
+			got.Header.Set("X-Probe-Test", "v")
+			sharedHeaders := inReq.Header.Get("X-Probe-Test") == "v"
+			if tt.wantIsCloned == sharedHeaders {
+				t.Errorf("wantIsCloned=%v, headers shared with cached request=%v", tt.wantIsCloned, sharedHeaders)
+			}
+
 			if tt.wantNewBody != (inReq.Body != got.Body) {
 				t.Errorf("wantNewBody=%v, (inReq.Body != got.Body) is %v", tt.wantNewBody, inReq.Body != got.Body)
 			}
 
 			if tt.token != "" {
 				assert.Equal(t, fmt.Sprintf(p.c.GetOauthConfig().GetTokenTypeFormat(), tt.token), got.Header.Get("Authorization"), "Token mismatch")
-				assert.Empty(t, inReq.Header.Get("Authorization"), "Cached request must not be mutated")
 			}
 
 			if len(tt.data) != 0 {

--- a/probes/http/request_test.go
+++ b/probes/http/request_test.go
@@ -527,24 +527,17 @@ func TestRequestHasConfiguredHeaders(t *testing.T) {
 	assert.Contains(t, val, testHeadersValue)
 }
 
-// Drives the real probe path: two runProbe calls on the same Probe must
-// land two different UUIDs on the wire. This pins the bug where the cached
-// tgtState.req baked the first UUID into its Header map and every
-// subsequent send reused it.
+// Drives the real probe path: runProbe must put a fresh UUID on each send.
+// Each iteration captures the full header set so failure points at which
+// request misbehaved, not a last-write-wins ghost.
 func TestDynamicHeaderSubstitution(t *testing.T) {
 	var (
-		mu        sync.Mutex
-		seen      []string
-		seenStat  string
-		seenUnk   string
-		seenEscap string
+		mu   sync.Mutex
+		seen []http.Header
 	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
-		seen = append(seen, r.Header.Get("X-Request-ID"))
-		seenStat = r.Header.Get("X-Static")
-		seenUnk = r.Header.Get("X-Unknown")
-		seenEscap = r.Header.Get("X-Literal-At")
+		seen = append(seen, r.Header.Clone())
 		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -581,19 +574,21 @@ func TestDynamicHeaderSubstitution(t *testing.T) {
 	defer mu.Unlock()
 
 	assert.Equal(t, 3, len(seen), "server should have received 3 requests")
-	for i, id := range seen {
-		_, err := uuid.Parse(id)
-		assert.NoError(t, err, "request %d X-Request-ID is not a valid UUID: %q", i, id)
-	}
-	assert.NotEqual(t, seen[0], seen[1], "consecutive requests reused the same @uuid@")
-	assert.NotEqual(t, seen[1], seen[2], "consecutive requests reused the same @uuid@")
+	uuids := make([]string, len(seen))
+	for i, h := range seen {
+		uuids[i] = h.Get("X-Request-ID")
+		_, err := uuid.Parse(uuids[i])
+		assert.NoError(t, err, "request %d X-Request-ID is not a valid UUID: %q", i, uuids[i])
 
-	// Non-templated values pass through untouched.
-	assert.Equal(t, "no-substitution-here", seenStat)
-	// Unknown @key@ is left as-is (backwards compatibility).
-	assert.Equal(t, "@some_other_key@", seenUnk)
-	// @@ escapes to a single literal @.
-	assert.Equal(t, "left@right", seenEscap)
+		// Non-templated values pass through untouched.
+		assert.Equal(t, "no-substitution-here", h.Get("X-Static"))
+		// Unknown @key@ is left as-is (backwards compatibility).
+		assert.Equal(t, "@some_other_key@", h.Get("X-Unknown"))
+		// @@ escapes to a single literal @.
+		assert.Equal(t, "left@right", h.Get("X-Literal-At"))
+	}
+	assert.NotEqual(t, uuids[0], uuids[1], "consecutive requests reused the same @uuid@")
+	assert.NotEqual(t, uuids[1], uuids[2], "consecutive requests reused the same @uuid@")
 }
 
 func TestResolveFirst(t *testing.T) {


### PR DESCRIPTION
## Summary

- Header values support `@uuid@` -- each request gets a fresh UUIDv4.
- Reuses `strtemplate.SubstituteLabels`; unknown `@keys@` pass through unchanged, so existing configs are unaffected.
- Scope is intentionally narrow: headers only (not URL/body), and only the `@uuid@` key for now.

Note: we clone HTTP request if dynamic headers are configured.

## Test plan

- [x] `go test ./probes/http/...` passes (new `TestDynamicHeaderSubstitution` covers replacement, uniqueness across requests, `@@` escape, and unknown-key passthrough)