### PR TITLE
[docker] Install ca-certificates in Dockerfile.pw

### DIFF
--- a/Dockerfile.pw
+++ b/Dockerfile.pw
@@ -15,6 +15,10 @@ RUN rm -f cloudprober-linux-*
 
 FROM node:24-bookworm-slim
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY --from=temp /cloudprober /cloudprober
 RUN chmod +x /cloudprober
 


### PR DESCRIPTION
## Summary
- `node:24-bookworm-slim` (base for `cloudprober/cloudprober:*-pw`) doesn't include `ca-certificates`, so HTTPS probes from the playwright image fail with `x509: certificate signed by unknown authority`.

## Test plan
- [ ] Build `Dockerfile.pw` locally and run an HTTPS probe against a public CA-signed host