### PR TITLE
fix: validate trimmed surfacer additional labels

### DIFF
--- a/surfacers/options/options.go
+++ b/surfacers/options/options.go
@@ -159,12 +159,12 @@ func processAdditionalLabels(envVar string, l *logger.Logger) [][2]string {
 	}
 	var labels [][2]string
 	for _, label := range strings.Split(labelsStr, ",") {
-		kv := strings.Split(label, "=")
-		if len(kv) != 2 || kv[0] == "" || kv[1] == "" {
+		key, val, ok := strings.Cut(label, "=")
+		key, val = strings.TrimSpace(key), strings.TrimSpace(val)
+		if !ok || key == "" || val == "" {
 			l.Warningf("Invalid additional label format: %s", label)
 			continue
 		}
-		key, val := strings.TrimSpace(kv[0]), strings.TrimSpace(kv[1])
 		labels = append(labels, [2]string{key, val})
 	}
 	return labels

--- a/surfacers/options/options_test.go
+++ b/surfacers/options/options_test.go
@@ -346,6 +346,14 @@ func TestProcessAdditionalLabels(t *testing.T) {
 			},
 		},
 		{
+			name:        "label_value_with_equal",
+			envVar:      "CLOUDPROBER_ADDITIONAL_LABELS",
+			envVarValue: "token=a=b",
+			want: [][2]string{
+				{"token", "a=b"},
+			},
+		},
+		{
 			name:        "invalid_label1",
 			envVar:      "CLOUDPROBER_ADDITIONAL_LABELS",
 			envVarValue: "env=prod,=identity",
@@ -359,6 +367,22 @@ func TestProcessAdditionalLabels(t *testing.T) {
 			envVarValue: "env=,app=identity",
 			want: [][2]string{
 				{"app", "identity"},
+			},
+		},
+		{
+			name:        "invalid_label_key_after_trim",
+			envVar:      "CLOUDPROBER_ADDITIONAL_LABELS",
+			envVarValue: "env=prod, =identity",
+			want: [][2]string{
+				{"env", "prod"},
+			},
+		},
+		{
+			name:        "invalid_label_value_after_trim",
+			envVar:      "CLOUDPROBER_ADDITIONAL_LABELS",
+			envVarValue: "env=prod,app= ",
+			want: [][2]string{
+				{"env", "prod"},
 			},
 		},
 	}


### PR DESCRIPTION
Fixes a tiny papercut in `CLOUDPROBER_ADDITIONAL_LABELS` parsing.

On `main`, `env=prod, =identity` gets accepted as `[[env prod] [ identity]]`, because the empty-key check runs before trimming. That can leak a blank-ish label key into exported metrics from a normal env var typo.

This change does two things:
- trims key/value before validating, so whitespace-only keys or values are rejected
- splits only on the first `=`, so values like `token=a=b` are preserved correctly

Repro:
```
go test ./surfacers/options -run TestProcessAdditionalLabels
```

Tests:
```
go test ./surfacers/options
go test ./surfacers
```

`go test ./...` hits local ICMP socket permission failures in ping/prober tests here, unrelated to this change.
