### PR TITLE
[probes.http] Log dynamic headers on probe errors; drop Host substitution

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -62,11 +62,16 @@ type Probe struct {
 	redirectFunc  func(req *http.Request, via []*http.Request) error
 
 	// book-keeping params
-	targets          []endpoint.Endpoint
-	method           string
-	url              string
-	hasDynamicHeader bool
-	oauthTS          oauth2.TokenSource
+	targets []endpoint.Endpoint
+	method  string
+	url     string
+	// dynamicHeaderNames lists canonicalized header names whose configured
+	// values contain a substitution token (e.g. @uuid@). Recorded at init so
+	// error logs can pull the resolved value from req.Header on the fly.
+	// Substitution is intentionally limited to req.Header; Host is not dynamic.
+	dynamicHeaderNames []string
+	hasDynamicHeader   bool
+	oauthTS            oauth2.TokenSource
 
 	responseParser *payload.Parser
 
@@ -187,7 +192,7 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 			totalDuration, p.opts.Interval)
 	}
 
-	p.hasDynamicHeader = configHasDynamicHeader(p.c)
+	p.initDynamicHeaders()
 
 	p.method = p.c.GetMethod().String()
 
@@ -337,7 +342,7 @@ func (p *Probe) doHTTPRequest(req *http.Request, client *http.Client, target end
 			result.success++
 			return nil
 		}
-		l.Warning(err.Error())
+		l.WithAttributes(p.dynamicHeaderAttrs(req)...).Warning(err.Error())
 		return err
 	}
 
@@ -349,7 +354,7 @@ func (p *Probe) doHTTPRequest(req *http.Request, client *http.Client, target end
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		l.Warning(err.Error())
+		l.WithAttributes(p.dynamicHeaderAttrs(req)...).Warning(err.Error())
 		return err
 	}
 
@@ -379,7 +384,7 @@ func (p *Probe) doHTTPRequest(req *http.Request, client *http.Client, target end
 		// counters unchanged.
 		if len(failedValidations) > 0 {
 			msg := fmt.Sprintf("failed validations: %s", strings.Join(failedValidations, ","))
-			l.Error(msg)
+			l.WithAttributes(p.dynamicHeaderAttrs(req)...).Error(msg)
 			return errors.New(msg)
 		}
 	}

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -67,10 +67,10 @@ type Probe struct {
 	url     string
 	// dynamicHeaderNames lists canonicalized header names whose configured
 	// values contain a substitution token (e.g. @uuid@). Recorded at init so
-	// error logs can pull the resolved value from req.Header on the fly.
+	// error logs can pull the resolved value from req.Header on the fly, and
+	// so prepareRequest knows whether the per-send clone is needed.
 	// Substitution is intentionally limited to req.Header; Host is not dynamic.
 	dynamicHeaderNames []string
-	hasDynamicHeader   bool
 	oauthTS            oauth2.TokenSource
 
 	responseParser *payload.Parser

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -65,11 +65,9 @@ type Probe struct {
 	targets []endpoint.Endpoint
 	method  string
 	url     string
-	// dynamicHeaderNames lists canonicalized header names whose configured
-	// values contain a substitution token (e.g. @uuid@). Recorded at init so
-	// error logs can pull the resolved value from req.Header on the fly, and
-	// so prepareRequest knows whether the per-send clone is needed.
-	// Substitution is intentionally limited to req.Header; Host is not dynamic.
+	// Canonical names of headers whose values carry a substitution token
+	// (e.g. @uuid@). Empty when no header is dynamic; len() also gates the
+	// per-send clone in prepareRequest.
 	dynamicHeaderNames []string
 	oauthTS            oauth2.TokenSource
 

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -138,18 +138,9 @@ func (p *Probe) setHeaders(req *http.Request, host string, port int) {
 	req.Host = hostHeader
 }
 
-// initDynamicHeaders scans the config once and records canonical names of
-// headers whose values contain an '@' substitution marker. The list drives
-// both the per-send clone gate (hasDynamicHeader) and the error-log path,
-// which pulls the resolved value back out of req.Header by name.
-//
-// Host is intentionally excluded: req.Host is not substituted, so a literal
-// '@uuid@' in a Host config flows through unchanged. We warn so the user
-// isn't surprised. user_agent feeds the User-Agent header in
-// httpRequestForTarget, so it's tracked under that canonical name.
-//
-// '@'-without-a-known-key (e.g. an email in a header) is a false positive
-// but harmless: applyDynamicHeaders is a no-op for unknown keys.
+// initDynamicHeaders records canonical names of headers whose values carry
+// a substitution token. Host is excluded: req.Host is not substituted, so
+// a literal '@' there is warned about and sent verbatim.
 func (p *Probe) initDynamicHeaders() {
 	seen := map[string]bool{}
 	add := func(name, val string) {
@@ -175,13 +166,13 @@ func (p *Probe) initDynamicHeaders() {
 	add("User-Agent", p.c.GetUserAgent())
 }
 
-// applyDynamicHeaders substitutes @uuid@ tokens (and any future tokens) in
-// the request's header values. All @uuid@ occurrences within a single send
-// resolve to the same UUID; substitution is lazy so a value without '@'
-// skips strtemplate entirely. req.Host is intentionally left alone.
-func applyDynamicHeaders(req *http.Request) {
+// applyDynamicHeaders substitutes @uuid@ (and future tokens) in tracked
+// header values. All @uuid@ occurrences within a single send resolve to
+// the same UUID. req.Host is intentionally left alone.
+func (p *Probe) applyDynamicHeaders(req *http.Request) {
 	var subst map[string]string
-	for _, vv := range req.Header {
+	for _, name := range p.dynamicHeaderNames {
+		vv := req.Header[name]
 		for i, v := range vv {
 			if !strings.Contains(v, "@") {
 				continue
@@ -189,18 +180,15 @@ func applyDynamicHeaders(req *http.Request) {
 			if subst == nil {
 				subst = map[string]string{"uuid": uuid.NewString()}
 			}
-			nv, _ := strtemplate.SubstituteLabels(v, subst)
-			if nv != v {
+			if nv, _ := strtemplate.SubstituteLabels(v, subst); nv != v {
 				vv[i] = nv
 			}
 		}
 	}
 }
 
-// dynamicHeaderAttrs returns slog attributes for each tracked dynamic header
-// holding its resolved per-send value. Returns nil when no dynamic headers
-// are configured so callers can no-op without branching. Used by error-log
-// paths in doHTTPRequest to make per-request UUIDs recoverable from logs.
+// dynamicHeaderAttrs returns the resolved per-send values for tracked
+// dynamic headers, for use in error-log attributes.
 func (p *Probe) dynamicHeaderAttrs(req *http.Request) []slog.Attr {
 	if len(p.dynamicHeaderNames) == 0 {
 		return nil
@@ -294,7 +282,7 @@ func (p *Probe) prepareRequest(ctx context.Context, req *http.Request) *http.Req
 	req = req.Clone(ctx)
 
 	if len(p.dynamicHeaderNames) > 0 {
-		applyDynamicHeaders(req)
+		p.applyDynamicHeaders(req)
 	}
 
 	if p.oauthTS != nil {

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -17,6 +17,7 @@ package http
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"strconv"
@@ -137,55 +138,81 @@ func (p *Probe) setHeaders(req *http.Request, host string, port int) {
 	req.Host = hostHeader
 }
 
-// configHasDynamicHeader reports whether any header value contains an '@'
-// (the substitution marker). When false, the cached request's headers are
-// stable across runs and the per-send clone+substitute can be skipped.
-// '@'-without-a-known-key is a false positive (e.g. an email in a header)
-// but harmless: substitution is a no-op for unknown keys, so the only cost
-// is the clone itself.
+// initDynamicHeaders scans the config once and records canonical names of
+// headers whose values contain an '@' substitution marker. The list drives
+// both the per-send clone gate (hasDynamicHeader) and the error-log path,
+// which pulls the resolved value back out of req.Header by name.
 //
-// user_agent ends up as a request header too (set in httpRequestForTarget),
-// so check it here for the same reason.
-func configHasDynamicHeader(c *configpb.ProbeConf) bool {
-	for _, h := range c.GetHeaders() {
-		if strings.Contains(h.GetValue(), "@") {
-			return true
+// Host is intentionally excluded: req.Host is not substituted, so a literal
+// '@uuid@' in a Host config flows through unchanged. We warn so the user
+// isn't surprised. user_agent feeds the User-Agent header in
+// httpRequestForTarget, so it's tracked under that canonical name.
+//
+// '@'-without-a-known-key (e.g. an email in a header) is a false positive
+// but harmless: applyDynamicHeaders is a no-op for unknown keys.
+func (p *Probe) initDynamicHeaders() {
+	seen := map[string]bool{}
+	add := func(name, val string) {
+		if !strings.Contains(val, "@") {
+			return
+		}
+		if name == "Host" {
+			p.l.Warningf("http probe %q: Host header value %q contains '@' but Host substitution is not supported; value will be sent verbatim", p.name, val)
+			return
+		}
+		canon := http.CanonicalHeaderKey(name)
+		if !seen[canon] {
+			seen[canon] = true
+			p.dynamicHeaderNames = append(p.dynamicHeaderNames, canon)
 		}
 	}
-	for _, v := range c.GetHeader() {
-		if strings.Contains(v, "@") {
-			return true
-		}
+	for _, h := range p.c.GetHeaders() {
+		add(h.GetName(), h.GetValue())
 	}
-	return strings.Contains(c.GetUserAgent(), "@")
+	for k, v := range p.c.GetHeader() {
+		add(k, v)
+	}
+	add("User-Agent", p.c.GetUserAgent())
+	p.hasDynamicHeader = len(p.dynamicHeaderNames) > 0
 }
 
 // applyDynamicHeaders substitutes @uuid@ tokens (and any future tokens) in
-// the request's header values and Host. All @uuid@ occurrences within a
-// single send resolve to the same UUID; substitution is lazy so a value
-// without '@' skips strtemplate entirely.
+// the request's header values. All @uuid@ occurrences within a single send
+// resolve to the same UUID; substitution is lazy so a value without '@'
+// skips strtemplate entirely. req.Host is intentionally left alone.
 func applyDynamicHeaders(req *http.Request) {
 	var subst map[string]string
-	sub := func(s string) string {
-		if !strings.Contains(s, "@") {
-			return s
-		}
-		if subst == nil {
-			subst = map[string]string{"uuid": uuid.NewString()}
-		}
-		nv, _ := strtemplate.SubstituteLabels(s, subst)
-		return nv
-	}
 	for _, vv := range req.Header {
 		for i, v := range vv {
-			if nv := sub(v); nv != v {
+			if !strings.Contains(v, "@") {
+				continue
+			}
+			if subst == nil {
+				subst = map[string]string{"uuid": uuid.NewString()}
+			}
+			nv, _ := strtemplate.SubstituteLabels(v, subst)
+			if nv != v {
 				vv[i] = nv
 			}
 		}
 	}
-	if nv := sub(req.Host); nv != req.Host {
-		req.Host = nv
+}
+
+// dynamicHeaderAttrs returns slog attributes for each tracked dynamic header
+// holding its resolved per-send value. Returns nil when no dynamic headers
+// are configured so callers can no-op without branching. Used by error-log
+// paths in doHTTPRequest to make per-request UUIDs recoverable from logs.
+func (p *Probe) dynamicHeaderAttrs(req *http.Request) []slog.Attr {
+	if !p.hasDynamicHeader {
+		return nil
 	}
+	attrs := make([]slog.Attr, 0, len(p.dynamicHeaderNames))
+	for _, name := range p.dynamicHeaderNames {
+		if v := req.Header.Get(name); v != "" {
+			attrs = append(attrs, slog.String(name, v))
+		}
+	}
+	return attrs
 }
 
 func (p *Probe) urlHostAndIPLabel(target endpoint.Endpoint, host string) (string, string, error) {

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -173,7 +173,6 @@ func (p *Probe) initDynamicHeaders() {
 		add(k, v)
 	}
 	add("User-Agent", p.c.GetUserAgent())
-	p.hasDynamicHeader = len(p.dynamicHeaderNames) > 0
 }
 
 // applyDynamicHeaders substitutes @uuid@ tokens (and any future tokens) in
@@ -203,7 +202,7 @@ func applyDynamicHeaders(req *http.Request) {
 // are configured so callers can no-op without branching. Used by error-log
 // paths in doHTTPRequest to make per-request UUIDs recoverable from logs.
 func (p *Probe) dynamicHeaderAttrs(req *http.Request) []slog.Attr {
-	if !p.hasDynamicHeader {
+	if len(p.dynamicHeaderNames) == 0 {
 		return nil
 	}
 	attrs := make([]slog.Attr, 0, len(p.dynamicHeaderNames))
@@ -289,12 +288,12 @@ func getToken(ts oauth2.TokenSource, l *logger.Logger) (string, error) {
 // substitution, OAuth Authorization header, or a fresh streaming body --
 // and skip to a cheap WithContext copy otherwise.
 func (p *Probe) prepareRequest(ctx context.Context, req *http.Request) *http.Request {
-	if !p.hasDynamicHeader && p.oauthTS == nil && p.requestBody.Len() == 0 {
+	if len(p.dynamicHeaderNames) == 0 && p.oauthTS == nil && p.requestBody.Len() == 0 {
 		return req.WithContext(ctx)
 	}
 	req = req.Clone(ctx)
 
-	if p.hasDynamicHeader {
+	if len(p.dynamicHeaderNames) > 0 {
 		applyDynamicHeaders(req)
 	}
 

--- a/probes/http/request_test.go
+++ b/probes/http/request_test.go
@@ -636,6 +636,72 @@ func TestDynamicHeaderSubstitution(t *testing.T) {
 		}
 		assert.Equal(t, n, len(seenIDs), "parallel requests must each get a distinct UUID")
 	})
+
+	// Host substitution is intentionally unsupported: a Host config containing
+	// '@' should not be tracked, and applyDynamicHeaders must leave req.Host
+	// alone. Sibling dynamic headers must still resolve.
+	t.Run("host_not_substituted", func(t *testing.T) {
+		hostName, hostVal := "Host", "api-@uuid@.example.com"
+		p, run := dynamicHeaderTestRig(t, &configpb.ProbeConf{
+			Headers: []*configpb.ProbeConf_Header{{Name: &hostName, Value: &hostVal}},
+			Header:  map[string]string{"X-Request-ID": "@uuid@"},
+		})
+		for _, n := range p.dynamicHeaderNames {
+			assert.NotEqual(t, "Host", n, "Host must not be tracked as a dynamic header")
+		}
+		got := run()
+		assert.Equal(t, 1, len(got))
+		if len(got) == 1 {
+			_, err := uuid.Parse(got[0].Get("X-Request-ID"))
+			assert.NoError(t, err, "sibling dynamic header should still resolve")
+		}
+	})
+}
+
+// dynamicHeaderAttrs is what doHTTPRequest's error paths use to attach
+// resolved per-send values (e.g. UUIDs) to error logs. Verify it returns
+// only the tracked headers, with values matching what's on the request.
+func TestDynamicHeaderAttrs(t *testing.T) {
+	p := &Probe{}
+	err := p.Init("http_test", &options.Options{
+		Targets:  targets.StaticTargets("test.com"),
+		Interval: 10 * time.Second,
+		Timeout:  time.Second,
+		ProbeConf: &configpb.ProbeConf{
+			Header: map[string]string{
+				"X-Request-ID": "@uuid@",
+				"X-Static":     "no-substitution",
+			},
+		},
+	})
+	assert.NoError(t, err)
+
+	req, err := p.httpRequestForTarget(endpoint.Endpoint{Name: "test.com"})
+	assert.NoError(t, err)
+	req = p.prepareRequest(context.Background(), req)
+
+	attrs := p.dynamicHeaderAttrs(req)
+	assert.Equal(t, 1, len(attrs), "only X-Request-ID should be dynamic")
+	if len(attrs) == 1 {
+		assert.Equal(t, "X-Request-Id", attrs[0].Key)
+		got := attrs[0].Value.String()
+		_, perr := uuid.Parse(got)
+		assert.NoError(t, perr, "attr value must be a UUID")
+		assert.Equal(t, req.Header.Get("X-Request-ID"), got, "attr value must match req.Header")
+	}
+
+	// No dynamic headers configured -> attrs is nil so callers can no-op.
+	p2 := &Probe{}
+	err = p2.Init("http_test", &options.Options{
+		Targets:   targets.StaticTargets("test.com"),
+		Interval:  10 * time.Second,
+		Timeout:   time.Second,
+		ProbeConf: &configpb.ProbeConf{Header: map[string]string{"X-Static": "no-substitution"}},
+	})
+	assert.NoError(t, err)
+	req2, err := p2.httpRequestForTarget(endpoint.Endpoint{Name: "test.com"})
+	assert.NoError(t, err)
+	assert.Nil(t, p2.dynamicHeaderAttrs(req2))
 }
 
 func TestResolveFirst(t *testing.T) {

--- a/probes/http/request_test.go
+++ b/probes/http/request_test.go
@@ -637,9 +637,6 @@ func TestDynamicHeaderSubstitution(t *testing.T) {
 		assert.Equal(t, n, len(seenIDs), "parallel requests must each get a distinct UUID")
 	})
 
-	// Host substitution is intentionally unsupported: a Host config containing
-	// '@' should not be tracked, and applyDynamicHeaders must leave req.Host
-	// alone. Sibling dynamic headers must still resolve.
 	t.Run("host_not_substituted", func(t *testing.T) {
 		hostName, hostVal := "Host", "api-@uuid@.example.com"
 		p, run := dynamicHeaderTestRig(t, &configpb.ProbeConf{
@@ -658,9 +655,6 @@ func TestDynamicHeaderSubstitution(t *testing.T) {
 	})
 }
 
-// dynamicHeaderAttrs is what doHTTPRequest's error paths use to attach
-// resolved per-send values (e.g. UUIDs) to error logs. Verify it returns
-// only the tracked headers, with values matching what's on the request.
 func TestDynamicHeaderAttrs(t *testing.T) {
 	p := &Probe{}
 	err := p.Init("http_test", &options.Options{
@@ -690,7 +684,6 @@ func TestDynamicHeaderAttrs(t *testing.T) {
 		assert.Equal(t, req.Header.Get("X-Request-ID"), got, "attr value must match req.Header")
 	}
 
-	// No dynamic headers configured -> attrs is nil so callers can no-op.
 	p2 := &Probe{}
 	err = p2.Init("http_test", &options.Options{
 		Targets:   targets.StaticTargets("test.com"),

--- a/probes/http/request_test.go
+++ b/probes/http/request_test.go
@@ -591,7 +591,7 @@ func TestDynamicHeaderSubstitution(t *testing.T) {
 			},
 			UserAgent: proto.String("cloudprober/@uuid@"),
 		})
-		assert.True(t, p.hasDynamicHeader, "user_agent with @uuid@ should set hasDynamicHeader")
+		assert.NotEmpty(t, p.dynamicHeaderNames, "user_agent with @uuid@ should populate dynamicHeaderNames")
 
 		uuids := make([]string, 0, 3)
 		for i := 0; i < 3; i++ {

--- a/probes/http/request_test.go
+++ b/probes/http/request_test.go
@@ -581,6 +581,7 @@ func dynamicHeaderTestRig(t *testing.T, conf *configpb.ProbeConf) (*Probe, func(
 // request misbehaved, not a last-write-wins ghost.
 func TestDynamicHeaderSubstitution(t *testing.T) {
 	t.Run("sequential_runs", func(t *testing.T) {
+		hostName, hostVal := "Host", "api-@uuid@.example.com"
 		p, run := dynamicHeaderTestRig(t, &configpb.ProbeConf{
 			Header: map[string]string{
 				"X-Request-ID": "@uuid@",
@@ -589,9 +590,11 @@ func TestDynamicHeaderSubstitution(t *testing.T) {
 				"X-Unknown":    "@some_other_key@",
 				"X-Literal-At": "left@@right",
 			},
+			Headers:   []*configpb.ProbeConf_Header{{Name: &hostName, Value: &hostVal}},
 			UserAgent: proto.String("cloudprober/@uuid@"),
 		})
 		assert.NotEmpty(t, p.dynamicHeaderNames, "user_agent with @uuid@ should populate dynamicHeaderNames")
+		assert.NotContains(t, p.dynamicHeaderNames, "Host", "Host must never be tracked as a dynamic header")
 
 		uuids := make([]string, 0, 3)
 		for i := 0; i < 3; i++ {
@@ -635,23 +638,6 @@ func TestDynamicHeaderSubstitution(t *testing.T) {
 			seenIDs[id] = struct{}{}
 		}
 		assert.Equal(t, n, len(seenIDs), "parallel requests must each get a distinct UUID")
-	})
-
-	t.Run("host_not_substituted", func(t *testing.T) {
-		hostName, hostVal := "Host", "api-@uuid@.example.com"
-		p, run := dynamicHeaderTestRig(t, &configpb.ProbeConf{
-			Headers: []*configpb.ProbeConf_Header{{Name: &hostName, Value: &hostVal}},
-			Header:  map[string]string{"X-Request-ID": "@uuid@"},
-		})
-		for _, n := range p.dynamicHeaderNames {
-			assert.NotEqual(t, "Host", n, "Host must not be tracked as a dynamic header")
-		}
-		got := run()
-		assert.Equal(t, 1, len(got))
-		if len(got) == 1 {
-			_, err := uuid.Parse(got[0].Get("X-Request-ID"))
-			assert.NoError(t, err, "sibling dynamic header should still resolve")
-		}
 	})
 }
 


### PR DESCRIPTION
## Summary

- On probe error (client error, body read error, validator failure), attach the resolved values of headers configured with substitution tokens (e.g. `X-Request-ID: @uuid@`) to the log entry, so the per-request UUID can be matched against server-side logs.
- Drop Host substitution: a literal `@` in a Host config is now warned about at init and sent verbatim. Host substitution rarely reflects user intent.
- Resolved values are read from `req.Header` on demand; names are recorded once at init in `p.dynamicHeaderNames`.
