### PR TITLE
[probes.starlark] http: max_redirects kwarg; share helper with HTTP probe

### DIFF
--- a/common/httpclient/httpclient.go
+++ b/common/httpclient/httpclient.go
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package httpclient holds small helpers shared by probes that build their
-// own *http.Client (e.g. the HTTP probe and the Starlark probe). Grow it as
-// more configuration knobs need to be expressed identically in both places.
+// Package httpclient holds helpers shared by probes that build their own
+// *http.Client.
 package httpclient
 
 import "net/http"
 
-// CheckRedirectFunc returns an http.Client.CheckRedirect that follows up to
-// n redirects (n=0 disables redirect following). It uses
-// http.ErrUseLastResponse, so the client returns the redirect response itself
-// instead of an error — matching the HTTP probe's max_redirects semantics.
+// CheckRedirectFunc returns a CheckRedirect that follows up to n redirects
+// (n=0 disables). Uses ErrUseLastResponse so the redirect response is
+// returned to the caller instead of surfacing as an error.
 func CheckRedirectFunc(n int) func(*http.Request, []*http.Request) error {
 	return func(_ *http.Request, via []*http.Request) error {
 		if len(via) > n {

--- a/common/httpclient/httpclient.go
+++ b/common/httpclient/httpclient.go
@@ -1,0 +1,33 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package httpclient holds small helpers shared by probes that build their
+// own *http.Client (e.g. the HTTP probe and the Starlark probe). Grow it as
+// more configuration knobs need to be expressed identically in both places.
+package httpclient
+
+import "net/http"
+
+// CheckRedirectFunc returns an http.Client.CheckRedirect that follows up to
+// n redirects (n=0 disables redirect following). It uses
+// http.ErrUseLastResponse, so the client returns the redirect response itself
+// instead of an error — matching the HTTP probe's max_redirects semantics.
+func CheckRedirectFunc(n int) func(*http.Request, []*http.Request) error {
+	return func(_ *http.Request, via []*http.Request) error {
+		if len(via) > n {
+			return http.ErrUseLastResponse
+		}
+		return nil
+	}
+}

--- a/common/httpclient/httpclient_test.go
+++ b/common/httpclient/httpclient_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpclient
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckRedirectFunc(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			http.Redirect(w, r, "/1", http.StatusTemporaryRedirect)
+		case "/1":
+			http.Redirect(w, r, "/2", http.StatusTemporaryRedirect)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	cases := []struct {
+		desc       string
+		n          int
+		wantStatus int
+	}{
+		{"zero blocks all redirects", 0, http.StatusTemporaryRedirect},
+		{"one allows first redirect only", 1, http.StatusTemporaryRedirect},
+		{"two follows both redirects", 2, http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			c := &http.Client{CheckRedirect: CheckRedirectFunc(tc.n)}
+			resp, err := c.Get(ts.URL)
+			assert.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, tc.wantStatus, resp.StatusCode)
+		})
+	}
+}

--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -116,8 +116,8 @@ All scripts get a small, fixed set of builtins. No filesystem, network beyond
 
 | Builtin | Purpose |
 |---|---|
-| `http.get(url, headers=None, max_redirects=None)` | HTTP GET, returns a `Response`. `max_redirects=0` disables following; `max_redirects=N` follows up to N. |
-| `http.post(url, headers=None, body=None, json=None, max_redirects=None)` | HTTP POST. Pass `json=` for an auto-encoded JSON body (sets `Content-Type`), or `body=` for a raw string/bytes. `max_redirects` matches `http.get`. |
+| `http.get(url, headers=None, max_redirects=N)` | HTTP GET, returns a `Response`. `max_redirects=0` disables following; `max_redirects=N` follows up to N. Omit the kwarg to use Go's default behavior (follow up to 10). |
+| `http.post(url, headers=None, body=None, json=None, max_redirects=N)` | HTTP POST. Pass `json=` for an auto-encoded JSON body (sets `Content-Type`), or `body=` for a raw string/bytes. `max_redirects` matches `http.get`. |
 | `assert.http_status(response, expected, msg=None)` | Fails the probe if `response.status != expected`. `msg` is appended to the failure error -- handy for recording context (e.g. dynamic headers) that produced the failed request. |
 | `vars.get(name, default=None)` | Read values from the probe's `vars` config map (see below). |
 | `state.get(key, default=None)` / `state.set(key, value)` | Per-target key-value store that persists across runs (see below). |

--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -116,8 +116,8 @@ All scripts get a small, fixed set of builtins. No filesystem, network beyond
 
 | Builtin | Purpose |
 |---|---|
-| `http.get(url, headers=None)` | HTTP GET, returns a `Response`. |
-| `http.post(url, headers=None, body=None, json=None)` | HTTP POST. Pass `json=` for an auto-encoded JSON body (sets `Content-Type`), or `body=` for a raw string/bytes. |
+| `http.get(url, headers=None, max_redirects=None)` | HTTP GET, returns a `Response`. `max_redirects=0` disables following; `max_redirects=N` follows up to N. |
+| `http.post(url, headers=None, body=None, json=None, max_redirects=None)` | HTTP POST. Pass `json=` for an auto-encoded JSON body (sets `Content-Type`), or `body=` for a raw string/bytes. `max_redirects` matches `http.get`. |
 | `assert.http_status(response, expected, msg=None)` | Fails the probe if `response.status != expected`. `msg` is appended to the failure error -- handy for recording context (e.g. dynamic headers) that produced the failed request. |
 | `vars.get(name, default=None)` | Read values from the probe's `vars` config map (see below). |
 | `state.get(key, default=None)` / `state.set(key, value)` | Per-target key-value store that persists across runs (see below). |

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -32,6 +32,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cloudprober/cloudprober/common/httpclient"
 	"github.com/cloudprober/cloudprober/common/oauth"
 	"github.com/cloudprober/cloudprober/common/tlsconfig"
 	"github.com/cloudprober/cloudprober/internal/httpreq"
@@ -225,12 +226,7 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 	p.baseTransport = transport
 
 	if p.c.MaxRedirects != nil {
-		p.redirectFunc = func(req *http.Request, via []*http.Request) error {
-			if len(via) > int(p.c.GetMaxRedirects()) {
-				return http.ErrUseLastResponse
-			}
-			return nil
-		}
+		p.redirectFunc = httpclient.CheckRedirectFunc(int(p.c.GetMaxRedirects()))
 	}
 
 	if p.c.GetResponseMetricsOptions() != nil {

--- a/probes/starlark/builtins_http.go
+++ b/probes/starlark/builtins_http.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/cloudprober/cloudprober/common/httpclient"
 	starlarklib "go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 )
@@ -39,16 +40,24 @@ func httpModule() *starlarkstruct.Module {
 	}
 }
 
+// reqOpts holds per-call knobs that mirror http probe config fields.
+// maxRedirects: -1 = unset (default client behavior); >=0 = enforce limit.
+type reqOpts struct {
+	maxRedirects int
+}
+
 func httpGet(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
 	var url string
 	var headers *starlarklib.Dict
+	opts := reqOpts{maxRedirects: -1}
 	if err := starlarklib.UnpackArgs("http.get", args, kwargs,
 		"url", &url,
 		"headers?", &headers,
+		"max_redirects?", &opts.maxRedirects,
 	); err != nil {
 		return nil, err
 	}
-	return doHTTP(thread, "GET", url, headers, nil, nil)
+	return doHTTP(thread, "GET", url, headers, nil, nil, opts)
 }
 
 func httpPost(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
@@ -56,18 +65,20 @@ func httpPost(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarkl
 	var headers *starlarklib.Dict
 	var body starlarklib.Value
 	var jsonArg starlarklib.Value
+	opts := reqOpts{maxRedirects: -1}
 	if err := starlarklib.UnpackArgs("http.post", args, kwargs,
 		"url", &url,
 		"headers?", &headers,
 		"body?", &body,
 		"json?", &jsonArg,
+		"max_redirects?", &opts.maxRedirects,
 	); err != nil {
 		return nil, err
 	}
-	return doHTTP(thread, "POST", url, headers, body, jsonArg)
+	return doHTTP(thread, "POST", url, headers, body, jsonArg, opts)
 }
 
-func doHTTP(thread *starlarklib.Thread, method, url string, headers *starlarklib.Dict, body, jsonArg starlarklib.Value) (starlarklib.Value, error) {
+func doHTTP(thread *starlarklib.Thread, method, url string, headers *starlarklib.Dict, body, jsonArg starlarklib.Value, opts reqOpts) (starlarklib.Value, error) {
 	var reqBody io.Reader
 	contentType := ""
 	switch {
@@ -113,7 +124,15 @@ func doHTTP(thread *starlarklib.Thread, method, url string, headers *starlarklib
 		}
 	}
 
-	resp, err := httpClientFromThread(thread).Do(req)
+	client := httpClientFromThread(thread)
+	if opts.maxRedirects >= 0 {
+		// Clone the client to apply per-call CheckRedirect; the Transport
+		// pointer is shared, so connection pooling is preserved.
+		clone := *client
+		clone.CheckRedirect = httpclient.CheckRedirectFunc(opts.maxRedirects)
+		client = &clone
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/probes/starlark/builtins_http.go
+++ b/probes/starlark/builtins_http.go
@@ -40,18 +40,11 @@ func httpModule() *starlarkstruct.Module {
 	}
 }
 
-// reqOpts holds per-call knobs that mirror http probe config fields. nil
-// pointers mean "unset" — fall back to the runtime's shared client default.
-type reqOpts struct {
-	maxRedirects *int
-}
-
-// optionalInt extracts a *int from a Starlark value bound by UnpackArgs.
-// Returns nil for an omitted kwarg (v == nil) or an explicit None; errors
-// for any other non-Int type. Used so optional int kwargs can distinguish
-// "unset" from a real value without resorting to magic sentinels.
+// optionalInt converts a Value bound by UnpackArgs (with "??" suffix) into a
+// *int. nil result means the kwarg was omitted or None; otherwise the int
+// value. Errors on any other type.
 func optionalInt(v starlarklib.Value, name string) (*int, error) {
-	if v == nil || v == starlarklib.None {
+	if v == nil {
 		return nil, nil
 	}
 	i, ok := v.(starlarklib.Int)
@@ -73,7 +66,7 @@ func httpGet(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarkli
 	if err := starlarklib.UnpackArgs("http.get", args, kwargs,
 		"url", &url,
 		"headers?", &headers,
-		"max_redirects?", &maxRedirectsArg,
+		"max_redirects??", &maxRedirectsArg,
 	); err != nil {
 		return nil, err
 	}
@@ -81,7 +74,7 @@ func httpGet(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarkli
 	if err != nil {
 		return nil, err
 	}
-	return doHTTP(thread, "GET", url, headers, nil, nil, reqOpts{maxRedirects: maxRedirects})
+	return doHTTP(thread, "GET", url, headers, nil, nil, maxRedirects)
 }
 
 func httpPost(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
@@ -95,7 +88,7 @@ func httpPost(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarkl
 		"headers?", &headers,
 		"body?", &body,
 		"json?", &jsonArg,
-		"max_redirects?", &maxRedirectsArg,
+		"max_redirects??", &maxRedirectsArg,
 	); err != nil {
 		return nil, err
 	}
@@ -103,10 +96,10 @@ func httpPost(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarkl
 	if err != nil {
 		return nil, err
 	}
-	return doHTTP(thread, "POST", url, headers, body, jsonArg, reqOpts{maxRedirects: maxRedirects})
+	return doHTTP(thread, "POST", url, headers, body, jsonArg, maxRedirects)
 }
 
-func doHTTP(thread *starlarklib.Thread, method, url string, headers *starlarklib.Dict, body, jsonArg starlarklib.Value, opts reqOpts) (starlarklib.Value, error) {
+func doHTTP(thread *starlarklib.Thread, method, url string, headers *starlarklib.Dict, body, jsonArg starlarklib.Value, maxRedirects *int) (starlarklib.Value, error) {
 	var reqBody io.Reader
 	contentType := ""
 	switch {
@@ -153,11 +146,11 @@ func doHTTP(thread *starlarklib.Thread, method, url string, headers *starlarklib
 	}
 
 	client := httpClientFromThread(thread)
-	if opts.maxRedirects != nil {
-		// Clone the client to apply per-call CheckRedirect; the Transport
-		// pointer is shared, so connection pooling is preserved.
+	if maxRedirects != nil {
+		// Shallow-copy: the Transport pointer is shared, so connection
+		// pooling is preserved across calls.
 		clone := *client
-		clone.CheckRedirect = httpclient.CheckRedirectFunc(*opts.maxRedirects)
+		clone.CheckRedirect = httpclient.CheckRedirectFunc(*maxRedirects)
 		client = &clone
 	}
 	resp, err := client.Do(req)

--- a/probes/starlark/builtins_http.go
+++ b/probes/starlark/builtins_http.go
@@ -40,24 +40,48 @@ func httpModule() *starlarkstruct.Module {
 	}
 }
 
-// reqOpts holds per-call knobs that mirror http probe config fields.
-// maxRedirects: -1 = unset (default client behavior); >=0 = enforce limit.
+// reqOpts holds per-call knobs that mirror http probe config fields. nil
+// pointers mean "unset" — fall back to the runtime's shared client default.
 type reqOpts struct {
-	maxRedirects int
+	maxRedirects *int
+}
+
+// optionalInt extracts a *int from a Starlark value bound by UnpackArgs.
+// Returns nil for an omitted kwarg (v == nil) or an explicit None; errors
+// for any other non-Int type. Used so optional int kwargs can distinguish
+// "unset" from a real value without resorting to magic sentinels.
+func optionalInt(v starlarklib.Value, name string) (*int, error) {
+	if v == nil || v == starlarklib.None {
+		return nil, nil
+	}
+	i, ok := v.(starlarklib.Int)
+	if !ok {
+		return nil, fmt.Errorf("%s: expected int, got %s", name, v.Type())
+	}
+	n, ok := i.Int64()
+	if !ok {
+		return nil, fmt.Errorf("%s: int does not fit in int64", name)
+	}
+	out := int(n)
+	return &out, nil
 }
 
 func httpGet(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
 	var url string
 	var headers *starlarklib.Dict
-	opts := reqOpts{maxRedirects: -1}
+	var maxRedirectsArg starlarklib.Value
 	if err := starlarklib.UnpackArgs("http.get", args, kwargs,
 		"url", &url,
 		"headers?", &headers,
-		"max_redirects?", &opts.maxRedirects,
+		"max_redirects?", &maxRedirectsArg,
 	); err != nil {
 		return nil, err
 	}
-	return doHTTP(thread, "GET", url, headers, nil, nil, opts)
+	maxRedirects, err := optionalInt(maxRedirectsArg, "http.get: max_redirects")
+	if err != nil {
+		return nil, err
+	}
+	return doHTTP(thread, "GET", url, headers, nil, nil, reqOpts{maxRedirects: maxRedirects})
 }
 
 func httpPost(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
@@ -65,17 +89,21 @@ func httpPost(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarkl
 	var headers *starlarklib.Dict
 	var body starlarklib.Value
 	var jsonArg starlarklib.Value
-	opts := reqOpts{maxRedirects: -1}
+	var maxRedirectsArg starlarklib.Value
 	if err := starlarklib.UnpackArgs("http.post", args, kwargs,
 		"url", &url,
 		"headers?", &headers,
 		"body?", &body,
 		"json?", &jsonArg,
-		"max_redirects?", &opts.maxRedirects,
+		"max_redirects?", &maxRedirectsArg,
 	); err != nil {
 		return nil, err
 	}
-	return doHTTP(thread, "POST", url, headers, body, jsonArg, opts)
+	maxRedirects, err := optionalInt(maxRedirectsArg, "http.post: max_redirects")
+	if err != nil {
+		return nil, err
+	}
+	return doHTTP(thread, "POST", url, headers, body, jsonArg, reqOpts{maxRedirects: maxRedirects})
 }
 
 func doHTTP(thread *starlarklib.Thread, method, url string, headers *starlarklib.Dict, body, jsonArg starlarklib.Value, opts reqOpts) (starlarklib.Value, error) {
@@ -125,11 +153,11 @@ func doHTTP(thread *starlarklib.Thread, method, url string, headers *starlarklib
 	}
 
 	client := httpClientFromThread(thread)
-	if opts.maxRedirects >= 0 {
+	if opts.maxRedirects != nil {
 		// Clone the client to apply per-call CheckRedirect; the Transport
 		// pointer is shared, so connection pooling is preserved.
 		clone := *client
-		clone.CheckRedirect = httpclient.CheckRedirectFunc(opts.maxRedirects)
+		clone.CheckRedirect = httpclient.CheckRedirectFunc(*opts.maxRedirects)
 		client = &clone
 	}
 	resp, err := client.Do(req)

--- a/probes/starlark/builtins_http.go
+++ b/probes/starlark/builtins_http.go
@@ -40,6 +40,15 @@ func httpModule() *starlarkstruct.Module {
 	}
 }
 
+// reqOpts collects everything from an http.{get,post} call that varies
+// between requests. Fields are zero/nil when unset.
+type reqOpts struct {
+	headers      *starlarklib.Dict
+	body         starlarklib.Value
+	jsonArg      starlarklib.Value
+	maxRedirects *int
+}
+
 // optionalInt converts a Value bound by UnpackArgs (with "??" suffix) into a
 // *int. nil result means the kwarg was omitted or None; otherwise the int
 // value. Errors on any other type.
@@ -61,11 +70,11 @@ func optionalInt(v starlarklib.Value, name string) (*int, error) {
 
 func httpGet(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
 	var url string
-	var headers *starlarklib.Dict
+	var opts reqOpts
 	var maxRedirectsArg starlarklib.Value
 	if err := starlarklib.UnpackArgs("http.get", args, kwargs,
 		"url", &url,
-		"headers?", &headers,
+		"headers?", &opts.headers,
 		"max_redirects??", &maxRedirectsArg,
 	); err != nil {
 		return nil, err
@@ -74,20 +83,19 @@ func httpGet(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarkli
 	if err != nil {
 		return nil, err
 	}
-	return doHTTP(thread, "GET", url, headers, nil, nil, maxRedirects)
+	opts.maxRedirects = maxRedirects
+	return doHTTP(thread, "GET", url, opts)
 }
 
 func httpPost(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
 	var url string
-	var headers *starlarklib.Dict
-	var body starlarklib.Value
-	var jsonArg starlarklib.Value
+	var opts reqOpts
 	var maxRedirectsArg starlarklib.Value
 	if err := starlarklib.UnpackArgs("http.post", args, kwargs,
 		"url", &url,
-		"headers?", &headers,
-		"body?", &body,
-		"json?", &jsonArg,
+		"headers?", &opts.headers,
+		"body?", &opts.body,
+		"json?", &opts.jsonArg,
 		"max_redirects??", &maxRedirectsArg,
 	); err != nil {
 		return nil, err
@@ -96,15 +104,16 @@ func httpPost(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarkl
 	if err != nil {
 		return nil, err
 	}
-	return doHTTP(thread, "POST", url, headers, body, jsonArg, maxRedirects)
+	opts.maxRedirects = maxRedirects
+	return doHTTP(thread, "POST", url, opts)
 }
 
-func doHTTP(thread *starlarklib.Thread, method, url string, headers *starlarklib.Dict, body, jsonArg starlarklib.Value, maxRedirects *int) (starlarklib.Value, error) {
+func doHTTP(thread *starlarklib.Thread, method, url string, opts reqOpts) (starlarklib.Value, error) {
 	var reqBody io.Reader
 	contentType := ""
 	switch {
-	case jsonArg != nil:
-		raw, err := starlarkToGo(jsonArg)
+	case opts.jsonArg != nil:
+		raw, err := starlarkToGo(opts.jsonArg)
 		if err != nil {
 			return nil, fmt.Errorf("http.%s: encoding json arg: %v", strings.ToLower(method), err)
 		}
@@ -114,10 +123,10 @@ func doHTTP(thread *starlarklib.Thread, method, url string, headers *starlarklib
 		}
 		reqBody = bytes.NewReader(buf)
 		contentType = "application/json"
-	case body != nil:
-		s, ok := starlarklib.AsString(body)
+	case opts.body != nil:
+		s, ok := starlarklib.AsString(opts.body)
 		if !ok {
-			if b, ok := body.(starlarklib.Bytes); ok {
+			if b, ok := opts.body.(starlarklib.Bytes); ok {
 				reqBody = bytes.NewReader([]byte(b))
 			} else {
 				return nil, fmt.Errorf("http.%s: body must be string or bytes", strings.ToLower(method))
@@ -134,8 +143,8 @@ func doHTTP(thread *starlarklib.Thread, method, url string, headers *starlarklib
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
 	}
-	if headers != nil {
-		for _, item := range headers.Items() {
+	if opts.headers != nil {
+		for _, item := range opts.headers.Items() {
 			k, ok1 := starlarklib.AsString(item[0])
 			v, ok2 := starlarklib.AsString(item[1])
 			if !ok1 || !ok2 {
@@ -146,11 +155,11 @@ func doHTTP(thread *starlarklib.Thread, method, url string, headers *starlarklib
 	}
 
 	client := httpClientFromThread(thread)
-	if maxRedirects != nil {
+	if opts.maxRedirects != nil {
 		// Shallow-copy: the Transport pointer is shared, so connection
 		// pooling is preserved across calls.
 		clone := *client
-		clone.CheckRedirect = httpclient.CheckRedirectFunc(*maxRedirects)
+		clone.CheckRedirect = httpclient.CheckRedirectFunc(*opts.maxRedirects)
 		client = &clone
 	}
 	resp, err := client.Do(req)

--- a/probes/starlark/starlark_test.go
+++ b/probes/starlark/starlark_test.go
@@ -510,8 +510,9 @@ def probe(target):
 }
 
 // TestHTTP_MaxRedirects exercises the per-call max_redirects kwarg on
-// http.get. The server redirects /->/1->/2 then 200; max_redirects=1 should
-// stop at /1 (status 307).
+// http.get. The server redirects /->/1->/2 then 200; the table walks the
+// boundary cases including =0 (which validates the clone codepath actually
+// blocks all redirects).
 func TestHTTP_MaxRedirects(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -525,19 +526,31 @@ func TestHTTP_MaxRedirects(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	source := fmt.Sprintf(`
-def probe(target):
-    r = http.get(url = "%s", max_redirects = 1)
-    assert.http_status(r, 307)
-`, srv.URL)
-	opts := newOpts(t, hostFromServer(t, srv), source)
-	p := &Probe{}
-	if err := p.Init("script-max-redirects", opts); err != nil {
-		t.Fatalf("Init: %v", err)
+	cases := []struct {
+		name       string
+		max        int
+		wantStatus int
+	}{
+		{"zero_disables", 0, http.StatusTemporaryRedirect},
+		{"one_follows_first_hop", 1, http.StatusTemporaryRedirect},
+		{"two_follows_both_hops", 2, http.StatusOK},
 	}
-
-	results := p.RunOnce(context.Background())
-	assert.True(t, results[0].Success, "probe should succeed; got error: %v", results[0].Error)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			source := fmt.Sprintf(`
+def probe(target):
+    r = http.get(url = "%s", max_redirects = %d)
+    assert.http_status(r, %d)
+`, srv.URL, tc.max, tc.wantStatus)
+			opts := newOpts(t, hostFromServer(t, srv), source)
+			p := &Probe{}
+			if err := p.Init("script-max-redirects-"+tc.name, opts); err != nil {
+				t.Fatalf("Init: %v", err)
+			}
+			results := p.RunOnce(context.Background())
+			assert.True(t, results[0].Success, "probe should succeed; got error: %v", results[0].Error)
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/probes/starlark/starlark_test.go
+++ b/probes/starlark/starlark_test.go
@@ -509,6 +509,37 @@ def probe(target):
 	assert.Contains(t, results[0].Error.Error(), "trace=abc123")
 }
 
+// TestHTTP_MaxRedirects exercises the per-call max_redirects kwarg on
+// http.get. The server redirects /->/1->/2 then 200; max_redirects=1 should
+// stop at /1 (status 307).
+func TestHTTP_MaxRedirects(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/":
+			http.Redirect(w, r, "/1", http.StatusTemporaryRedirect)
+		case "/1":
+			http.Redirect(w, r, "/2", http.StatusTemporaryRedirect)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer srv.Close()
+
+	source := fmt.Sprintf(`
+def probe(target):
+    r = http.get(url = "%s", max_redirects = 1)
+    assert.http_status(r, 307)
+`, srv.URL)
+	opts := newOpts(t, hostFromServer(t, srv), source)
+	p := &Probe{}
+	if err := p.Init("script-max-redirects", opts); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	results := p.RunOnce(context.Background())
+	assert.True(t, results[0].Success, "probe should succeed; got error: %v", results[0].Error)
+}
+
 // ---------------------------------------------------------------------------
 // Init / config validation
 


### PR DESCRIPTION
## Summary
- New `common/httpclient` package with `CheckRedirectFunc`, factored from the HTTP probe. HTTP probe behavior unchanged.
- Starlark `http.get`/`http.post` take an optional `max_redirects=` kwarg (0 disables; N follows up to N; unset = Go default). Per-call so a script can vary the policy between requests; the client is cloned (Transport pointer shared, pooling preserved).
- First step toward sharing httpclient knobs between the HTTP probe and Starlark builtin; more fields (timeout, TLS, proxy, keepalive) can move into the same package as needed.

## Test plan
- [x] `go test ./common/httpclient/ ./probes/starlark/ ./probes/http/` passes.
- [x] New `TestCheckRedirectFunc` (httpclient) and `TestHTTP_MaxRedirects` (starlark) cover 0/1/2 redirect cases.
- [x] Existing `TestMaxRedirects` in probes/http still passes (helper is behavior-preserving).