### PR TITLE
[docs] Surface Script Probe (Starlark) on top-of-funnel pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ monitoring signals.
 
 ## Why Cloudprober?
 
-* Versatile Probes: Built-in HTTP, PING, TCP, DNS, gRPC, and UDP probes, plus custom checks via external probes.
+* Versatile Probes: Built-in HTTP, PING, TCP, DNS, gRPC, and UDP probes, plus custom in-process scripts (Starlark) and external probes.
 
 * Auto-Discover Targets: Effortlessly monitor Kubernetes, GCP, or file-based resources without constant redeployment.
 

--- a/docs/content/docs/how-to/external-probe/index.md
+++ b/docs/content/docs/how-to/external-probe/index.md
@@ -7,6 +7,10 @@ title: "External Probe"
 date: 2022-11-01T17:24:32-07:00
 ---
 
+> Need a scripted check without the per-run subprocess overhead? See the
+> [Script Probe]({{< ref "starlark-probe" >}}) -- in-process, no external
+> binary required.
+
 External probe type allows you to run arbitrary, complex probes through
 Cloudprober. An external probe runs an independent external program for actual
 probing. Cloudprober calculates probe metrics based on program's exit status

--- a/docs/content/docs/how-to/list/index.md
+++ b/docs/content/docs/how-to/list/index.md
@@ -9,7 +9,7 @@ weight: 100
 - [Alerting]({{< ref "alerting" >}})
 - [Targets]({{< ref "targets" >}})
 - [External Probe]({{< ref "external-probe" >}})
-- [Script Probe]({{< ref "starlark-probe" >}})
+- [Script Probe (Starlark)]({{< ref "starlark-probe" >}})
 - [Browser Probe]({{< ref "browser-probe" >}})
 - [Kubernetes Targets]({{< ref "k8s_targets" >}})
 - [Running on Kubernetes]({{< ref "run-on-kubernetes" >}})

--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -2,7 +2,7 @@
 menu:
   docs:
     parent: "how-to"
-    name: "Script Probe"
+    name: "Script Probe (Starlark)"
     weight: 14
 title: "Script Probe (Starlark)"
 date: 2026-05-10T10:00:00-07:00


### PR DESCRIPTION
## Summary
- README "Versatile Probes" bullet lists the script probe (Starlark) alongside the built-in and external probes.
- External probe doc opens with a one-line callout pointing to the Script Probe for scripted checks without per-run subprocess overhead.

Blog post (the third top-of-funnel move from the design doc) is deliberately deferred.

## Test plan
- [x] Renders as a normal Markdown blockquote on cloudprober.org (`{{< ref "starlark-probe" >}}` is the same shortcode used by `how-to/list/index.md`).