### PR TITLE
[probes.starlark] http: add keep_alive kwarg

### DIFF
--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -126,12 +126,10 @@ All scripts get a small, fixed set of builtins. No filesystem, network beyond
 | `print(...)` | Standard Starlark `print`; routed to the logger at INFO. |
 | `fail(msg)` | Standard Starlark; ends the run as a failure. |
 
-> **Note on `keep_alive`:** the kwarg controls whether *this* request's
-> connection is pooled afterward. A `keep_alive=False` call will still
-> reuse a connection pooled by a prior `keep_alive=True` call to the same
-> host before closing it -- the pool isn't drained on demand. For uniform
-> fresh-TCP semantics, pass `keep_alive=False` on every call (or just
-> omit it -- that's the default).
+> `keep_alive=False` controls *post-request* pooling -- it doesn't drain
+> an already-pooled connection. If you mix `True` and `False` calls to
+> the same host, a `False` call may ride a previously-pooled connection
+> before closing it.
 
 ### Response
 

--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -116,8 +116,8 @@ All scripts get a small, fixed set of builtins. No filesystem, network beyond
 
 | Builtin | Purpose |
 |---|---|
-| `http.get(url, headers=None, max_redirects=N)` | HTTP GET, returns a `Response`. `max_redirects=0` disables following; `max_redirects=N` follows up to N. Omit the kwarg to use Go's default behavior (follow up to 10). |
-| `http.post(url, headers=None, body=None, json=None, max_redirects=N)` | HTTP POST. Pass `json=` for an auto-encoded JSON body (sets `Content-Type`), or `body=` for a raw string/bytes. `max_redirects` matches `http.get`. |
+| `http.get(url, headers=None, max_redirects=N, keep_alive=B)` | HTTP GET, returns a `Response`. `max_redirects=0` disables following; `max_redirects=N` follows up to N (omit for Go's default of 10). `keep_alive=False` sends `Connection: close` and prevents this connection from being pooled afterward -- use when you want each call to test connection setup (DNS/TCP/TLS), the way the HTTP probe's `keep_alive: false` does. |
+| `http.post(url, headers=None, body=None, json=None, max_redirects=N, keep_alive=B)` | HTTP POST. Pass `json=` for an auto-encoded JSON body (sets `Content-Type`), or `body=` for a raw string/bytes. `max_redirects` and `keep_alive` match `http.get`. |
 | `assert.http_status(response, expected, msg=None)` | Fails the probe if `response.status != expected`. `msg` is appended to the failure error -- handy for recording context (e.g. dynamic headers) that produced the failed request. |
 | `vars.get(name, default=None)` | Read values from the probe's `vars` config map (see below). |
 | `state.get(key, default=None)` / `state.set(key, value)` | Per-target key-value store that persists across runs (see below). |

--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -116,7 +116,7 @@ All scripts get a small, fixed set of builtins. No filesystem, network beyond
 
 | Builtin | Purpose |
 |---|---|
-| `http.get(url, headers=None, max_redirects=N, keep_alive=B)` | HTTP GET, returns a `Response`. `max_redirects=0` disables following; `max_redirects=N` follows up to N (omit for Go's default of 10). `keep_alive=False` sends `Connection: close` and prevents this connection from being pooled afterward -- use when you want each call to test connection setup (DNS/TCP/TLS), the way the HTTP probe's `keep_alive: false` does. |
+| `http.get(url, headers=None, max_redirects=N, keep_alive=B)` | HTTP GET, returns a `Response`. `max_redirects=0` disables following; `max_redirects=N` follows up to N (omit for Go's default of 10). `keep_alive` defaults to `False` to match the HTTP probe -- every call exercises DNS/TCP/TLS setup, which is what you usually want from a prober. Pass `keep_alive=True` to reuse a pooled connection across calls in a chained API flow. |
 | `http.post(url, headers=None, body=None, json=None, max_redirects=N, keep_alive=B)` | HTTP POST. Pass `json=` for an auto-encoded JSON body (sets `Content-Type`), or `body=` for a raw string/bytes. `max_redirects` and `keep_alive` match `http.get`. |
 | `assert.http_status(response, expected, msg=None)` | Fails the probe if `response.status != expected`. `msg` is appended to the failure error -- handy for recording context (e.g. dynamic headers) that produced the failed request. |
 | `vars.get(name, default=None)` | Read values from the probe's `vars` config map (see below). |

--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -116,8 +116,8 @@ All scripts get a small, fixed set of builtins. No filesystem, network beyond
 
 | Builtin | Purpose |
 |---|---|
-| `http.get(url, headers=None, max_redirects=N, keep_alive=B)` | HTTP GET, returns a `Response`. `max_redirects=0` disables following; `max_redirects=N` follows up to N (omit for Go's default of 10). `keep_alive` defaults to `False` to match the HTTP probe -- every call exercises DNS/TCP/TLS setup, which is what you usually want from a prober. Pass `keep_alive=True` to reuse a pooled connection across calls in a chained API flow. |
-| `http.post(url, headers=None, body=None, json=None, max_redirects=N, keep_alive=B)` | HTTP POST. Pass `json=` for an auto-encoded JSON body (sets `Content-Type`), or `body=` for a raw string/bytes. `max_redirects` and `keep_alive` match `http.get`. |
+| `http.get(url, headers=None, max_redirects=N, keep_alive=False)` | HTTP GET, returns a `Response`. `max_redirects=0` disables following; `max_redirects=N` follows up to N (omit for Go's default of 10). `keep_alive` defaults to `False` to match the HTTP probe -- every call exercises DNS/TCP/TLS setup, which is what you usually want from a prober. Pass `keep_alive=True` to reuse a pooled connection across calls in a chained API flow. |
+| `http.post(url, headers=None, body=None, json=None, max_redirects=N, keep_alive=False)` | HTTP POST. Pass `json=` for an auto-encoded JSON body (sets `Content-Type`), or `body=` for a raw string/bytes. `max_redirects` and `keep_alive` match `http.get`. |
 | `assert.http_status(response, expected, msg=None)` | Fails the probe if `response.status != expected`. `msg` is appended to the failure error -- handy for recording context (e.g. dynamic headers) that produced the failed request. |
 | `vars.get(name, default=None)` | Read values from the probe's `vars` config map (see below). |
 | `state.get(key, default=None)` / `state.set(key, value)` | Per-target key-value store that persists across runs (see below). |
@@ -125,6 +125,13 @@ All scripts get a small, fixed set of builtins. No filesystem, network beyond
 | `print_metric(line)` | Emit a custom metric line (see below). |
 | `print(...)` | Standard Starlark `print`; routed to the logger at INFO. |
 | `fail(msg)` | Standard Starlark; ends the run as a failure. |
+
+> **Note on `keep_alive`:** the kwarg controls whether *this* request's
+> connection is pooled afterward. A `keep_alive=False` call will still
+> reuse a connection pooled by a prior `keep_alive=True` call to the same
+> host before closing it -- the pool isn't drained on demand. For uniform
+> fresh-TCP semantics, pass `keep_alive=False` on every call (or just
+> omit it -- that's the default).
 
 ### Response
 

--- a/probes/starlark/builtins_http.go
+++ b/probes/starlark/builtins_http.go
@@ -166,9 +166,10 @@ func doHTTP(thread *starlarklib.Thread, method, url string, opts reqOpts) (starl
 	if err != nil {
 		return nil, err
 	}
-	if opts.keepAlive != nil && !*opts.keepAlive {
-		// req.Close adds Connection: close to the request and tells the
-		// Transport not to keep the connection in its pool afterward.
+	// keep_alive defaults to False to match the HTTP probe's prober-style
+	// default (every call exercises DNS/TCP/TLS setup). Scripts that chain
+	// requests across one logical flow opt back in with keep_alive=True.
+	if opts.keepAlive == nil || !*opts.keepAlive {
 		req.Close = true
 	}
 	if contentType != "" {

--- a/probes/starlark/builtins_http.go
+++ b/probes/starlark/builtins_http.go
@@ -40,8 +40,8 @@ func httpModule() *starlarkstruct.Module {
 	}
 }
 
-// reqOpts collects everything from an http.{get,post} call that varies
-// between requests. Fields are zero/nil when unset.
+// reqOpts holds per-call inputs to doHTTP. Fields default to their zero
+// values when the corresponding kwarg is omitted.
 type reqOpts struct {
 	headers      *starlarklib.Dict
 	body         starlarklib.Value
@@ -143,10 +143,9 @@ func doHTTP(thread *starlarklib.Thread, method, url string, opts reqOpts) (starl
 	if err != nil {
 		return nil, err
 	}
-	// keep_alive defaults to False to match the HTTP probe's prober-style
-	// default (every call exercises DNS/TCP/TLS setup). Scripts that chain
-	// requests across one logical flow opt back in with keep_alive=True.
 	if !opts.keepAlive {
+		// req.Close: send Connection: close and don't return this conn
+		// to the Transport's idle pool after the response.
 		req.Close = true
 	}
 	if contentType != "" {

--- a/probes/starlark/builtins_http.go
+++ b/probes/starlark/builtins_http.go
@@ -47,6 +47,7 @@ type reqOpts struct {
 	body         starlarklib.Value
 	jsonArg      starlarklib.Value
 	maxRedirects *int
+	keepAlive    *bool
 }
 
 // optionalInt converts a Value bound by UnpackArgs (with "??" suffix) into a
@@ -68,14 +69,28 @@ func optionalInt(v starlarklib.Value, name string) (*int, error) {
 	return &out, nil
 }
 
+// optionalBool is the bool analog of optionalInt.
+func optionalBool(v starlarklib.Value, name string) (*bool, error) {
+	if v == nil {
+		return nil, nil
+	}
+	b, ok := v.(starlarklib.Bool)
+	if !ok {
+		return nil, fmt.Errorf("%s: expected bool, got %s", name, v.Type())
+	}
+	out := bool(b)
+	return &out, nil
+}
+
 func httpGet(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
 	var url string
 	var opts reqOpts
-	var maxRedirectsArg starlarklib.Value
+	var maxRedirectsArg, keepAliveArg starlarklib.Value
 	if err := starlarklib.UnpackArgs("http.get", args, kwargs,
 		"url", &url,
 		"headers?", &opts.headers,
 		"max_redirects??", &maxRedirectsArg,
+		"keep_alive??", &keepAliveArg,
 	); err != nil {
 		return nil, err
 	}
@@ -83,20 +98,26 @@ func httpGet(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarkli
 	if err != nil {
 		return nil, err
 	}
+	keepAlive, err := optionalBool(keepAliveArg, "http.get: keep_alive")
+	if err != nil {
+		return nil, err
+	}
 	opts.maxRedirects = maxRedirects
+	opts.keepAlive = keepAlive
 	return doHTTP(thread, "GET", url, opts)
 }
 
 func httpPost(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
 	var url string
 	var opts reqOpts
-	var maxRedirectsArg starlarklib.Value
+	var maxRedirectsArg, keepAliveArg starlarklib.Value
 	if err := starlarklib.UnpackArgs("http.post", args, kwargs,
 		"url", &url,
 		"headers?", &opts.headers,
 		"body?", &opts.body,
 		"json?", &opts.jsonArg,
 		"max_redirects??", &maxRedirectsArg,
+		"keep_alive??", &keepAliveArg,
 	); err != nil {
 		return nil, err
 	}
@@ -104,7 +125,12 @@ func httpPost(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarkl
 	if err != nil {
 		return nil, err
 	}
+	keepAlive, err := optionalBool(keepAliveArg, "http.post: keep_alive")
+	if err != nil {
+		return nil, err
+	}
 	opts.maxRedirects = maxRedirects
+	opts.keepAlive = keepAlive
 	return doHTTP(thread, "POST", url, opts)
 }
 
@@ -139,6 +165,11 @@ func doHTTP(thread *starlarklib.Thread, method, url string, opts reqOpts) (starl
 	req, err := http.NewRequestWithContext(ctxFromThread(thread), method, url, reqBody)
 	if err != nil {
 		return nil, err
+	}
+	if opts.keepAlive != nil && !*opts.keepAlive {
+		// req.Close adds Connection: close to the request and tells the
+		// Transport not to keep the connection in its pool afterward.
+		req.Close = true
 	}
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)

--- a/probes/starlark/builtins_http.go
+++ b/probes/starlark/builtins_http.go
@@ -47,7 +47,7 @@ type reqOpts struct {
 	body         starlarklib.Value
 	jsonArg      starlarklib.Value
 	maxRedirects *int
-	keepAlive    *bool
+	keepAlive    bool
 }
 
 // optionalInt converts a Value bound by UnpackArgs (with "??" suffix) into a
@@ -69,28 +69,15 @@ func optionalInt(v starlarklib.Value, name string) (*int, error) {
 	return &out, nil
 }
 
-// optionalBool is the bool analog of optionalInt.
-func optionalBool(v starlarklib.Value, name string) (*bool, error) {
-	if v == nil {
-		return nil, nil
-	}
-	b, ok := v.(starlarklib.Bool)
-	if !ok {
-		return nil, fmt.Errorf("%s: expected bool, got %s", name, v.Type())
-	}
-	out := bool(b)
-	return &out, nil
-}
-
 func httpGet(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
 	var url string
 	var opts reqOpts
-	var maxRedirectsArg, keepAliveArg starlarklib.Value
+	var maxRedirectsArg starlarklib.Value
 	if err := starlarklib.UnpackArgs("http.get", args, kwargs,
 		"url", &url,
 		"headers?", &opts.headers,
 		"max_redirects??", &maxRedirectsArg,
-		"keep_alive??", &keepAliveArg,
+		"keep_alive??", &opts.keepAlive,
 	); err != nil {
 		return nil, err
 	}
@@ -98,26 +85,21 @@ func httpGet(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarkli
 	if err != nil {
 		return nil, err
 	}
-	keepAlive, err := optionalBool(keepAliveArg, "http.get: keep_alive")
-	if err != nil {
-		return nil, err
-	}
 	opts.maxRedirects = maxRedirects
-	opts.keepAlive = keepAlive
 	return doHTTP(thread, "GET", url, opts)
 }
 
 func httpPost(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
 	var url string
 	var opts reqOpts
-	var maxRedirectsArg, keepAliveArg starlarklib.Value
+	var maxRedirectsArg starlarklib.Value
 	if err := starlarklib.UnpackArgs("http.post", args, kwargs,
 		"url", &url,
 		"headers?", &opts.headers,
 		"body?", &opts.body,
 		"json?", &opts.jsonArg,
 		"max_redirects??", &maxRedirectsArg,
-		"keep_alive??", &keepAliveArg,
+		"keep_alive??", &opts.keepAlive,
 	); err != nil {
 		return nil, err
 	}
@@ -125,12 +107,7 @@ func httpPost(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarkl
 	if err != nil {
 		return nil, err
 	}
-	keepAlive, err := optionalBool(keepAliveArg, "http.post: keep_alive")
-	if err != nil {
-		return nil, err
-	}
 	opts.maxRedirects = maxRedirects
-	opts.keepAlive = keepAlive
 	return doHTTP(thread, "POST", url, opts)
 }
 
@@ -169,7 +146,7 @@ func doHTTP(thread *starlarklib.Thread, method, url string, opts reqOpts) (starl
 	// keep_alive defaults to False to match the HTTP probe's prober-style
 	// default (every call exercises DNS/TCP/TLS setup). Scripts that chain
 	// requests across one logical flow opt back in with keep_alive=True.
-	if opts.keepAlive == nil || !*opts.keepAlive {
+	if !opts.keepAlive {
 		req.Close = true
 	}
 	if contentType != "" {

--- a/probes/starlark/starlark_test.go
+++ b/probes/starlark/starlark_test.go
@@ -555,12 +555,6 @@ def probe(target):
 	}
 }
 
-// TestHTTP_KeepAlive verifies the keep_alive kwarg controls TCP-connection
-// reuse. Default is False (matches the HTTP probe's keep_alive: false default):
-//   - keep_alive omitted or False: request carries Connection: close and the
-//     next request opens a new TCP connection (distinct RemoteAddr).
-//   - keep_alive=True: Go's default Transport pools the connection, so the
-//     next request reuses it (same RemoteAddr).
 func TestHTTP_KeepAlive(t *testing.T) {
 	cases := []struct {
 		name          string

--- a/probes/starlark/starlark_test.go
+++ b/probes/starlark/starlark_test.go
@@ -554,10 +554,10 @@ def probe(target):
 }
 
 // TestHTTP_KeepAlive verifies the keep_alive kwarg controls TCP-connection
-// reuse:
-//   - keep_alive=False: request carries Connection: close and the next request
-//     opens a new TCP connection (distinct RemoteAddr).
-//   - keep_alive omitted: Go's default Transport pools the connection, so the
+// reuse. Default is False (matches the HTTP probe's keep_alive: false default):
+//   - keep_alive omitted or False: request carries Connection: close and the
+//     next request opens a new TCP connection (distinct RemoteAddr).
+//   - keep_alive=True: Go's default Transport pools the connection, so the
 //     next request reuses it (same RemoteAddr).
 func TestHTTP_KeepAlive(t *testing.T) {
 	cases := []struct {
@@ -566,8 +566,9 @@ func TestHTTP_KeepAlive(t *testing.T) {
 		wantConnClose bool
 		wantSameAddr  bool
 	}{
-		{"omitted_pools_connection", "", false, true},
+		{"omitted_closes_connection", "", true, false},
 		{"false_closes_connection", ", keep_alive = False", true, false},
+		{"true_pools_connection", ", keep_alive = True", false, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/probes/starlark/starlark_test.go
+++ b/probes/starlark/starlark_test.go
@@ -553,6 +553,64 @@ def probe(target):
 	}
 }
 
+// TestHTTP_KeepAlive verifies the keep_alive kwarg controls TCP-connection
+// reuse:
+//   - keep_alive=False: request carries Connection: close and the next request
+//     opens a new TCP connection (distinct RemoteAddr).
+//   - keep_alive omitted: Go's default Transport pools the connection, so the
+//     next request reuses it (same RemoteAddr).
+func TestHTTP_KeepAlive(t *testing.T) {
+	cases := []struct {
+		name          string
+		callKwarg     string
+		wantConnClose bool
+		wantSameAddr  bool
+	}{
+		{"omitted_pools_connection", "", false, true},
+		{"false_closes_connection", ", keep_alive = False", true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				gotConnClose atomic.Bool
+				addrs        []string
+			)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Connection") == "close" {
+					gotConnClose.Store(true)
+				}
+				addrs = append(addrs, r.RemoteAddr)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			source := fmt.Sprintf(`
+def probe(target):
+    r1 = http.get(url = "%s"%s)
+    assert.http_status(r1, 200)
+    r2 = http.get(url = "%s"%s)
+    assert.http_status(r2, 200)
+`, srv.URL, tc.callKwarg, srv.URL, tc.callKwarg)
+
+			opts := newOpts(t, hostFromServer(t, srv), source)
+			p := &Probe{}
+			if err := p.Init("script-keep-alive-"+tc.name, opts); err != nil {
+				t.Fatalf("Init: %v", err)
+			}
+			results := p.RunOnce(context.Background())
+			assert.True(t, results[0].Success, "probe should succeed; got error: %v", results[0].Error)
+			assert.Equal(t, tc.wantConnClose, gotConnClose.Load(), "Connection: close header")
+			if len(addrs) == 2 {
+				if tc.wantSameAddr {
+					assert.Equal(t, addrs[0], addrs[1], "expected pooled connection (same RemoteAddr)")
+				} else {
+					assert.NotEqual(t, addrs[0], addrs[1], "expected fresh connection (different RemoteAddr)")
+				}
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Init / config validation
 

--- a/probes/starlark/starlark_test.go
+++ b/probes/starlark/starlark_test.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -38,6 +39,7 @@ import (
 	"github.com/cloudprober/cloudprober/targets"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -574,13 +576,16 @@ func TestHTTP_KeepAlive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var (
 				gotConnClose atomic.Bool
+				mu           sync.Mutex
 				addrs        []string
 			)
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.Header.Get("Connection") == "close" {
 					gotConnClose.Store(true)
 				}
+				mu.Lock()
 				addrs = append(addrs, r.RemoteAddr)
+				mu.Unlock()
 				w.WriteHeader(http.StatusOK)
 			}))
 			defer srv.Close()
@@ -601,12 +606,11 @@ def probe(target):
 			results := p.RunOnce(context.Background())
 			assert.True(t, results[0].Success, "probe should succeed; got error: %v", results[0].Error)
 			assert.Equal(t, tc.wantConnClose, gotConnClose.Load(), "Connection: close header")
-			if len(addrs) == 2 {
-				if tc.wantSameAddr {
-					assert.Equal(t, addrs[0], addrs[1], "expected pooled connection (same RemoteAddr)")
-				} else {
-					assert.NotEqual(t, addrs[0], addrs[1], "expected fresh connection (different RemoteAddr)")
-				}
+			require.Len(t, addrs, 2, "expected exactly two requests to reach the server")
+			if tc.wantSameAddr {
+				assert.Equal(t, addrs[0], addrs[1], "expected pooled connection (same RemoteAddr)")
+			} else {
+				assert.NotEqual(t, addrs[0], addrs[1], "expected fresh connection (different RemoteAddr)")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Add a `keep_alive=` kwarg to `http.get`/`http.post`. **Defaults to `False`** to match the HTTP probe's `keep_alive: false` default — every call exercises DNS/TCP/TLS setup, which is the standard prober convention.
- Internally: when `keep_alive` is omitted or `False`, the outgoing request gets `req.Close = true` (sends `Connection: close`, prevents Go's Transport from pooling the connection afterward).
- Pass `keep_alive=True` to reuse a pooled connection across calls in a chained API flow (login → cart, etc.).

Motivation: a side-by-side `STARLARK` vs `HTTP` probe against the same endpoint showed the Starlark probe consistently faster, because Go's default Transport was pooling connections. That hides DNS/TCP/TLS failures behind a happy steady-state path — exactly what probers shouldn't do.

## Test plan
- [x] TestHTTP_KeepAlive covers three cases: omitted, False, True. Asserts Connection: close presence and RemoteAddr reuse against an httptest.NewServer.
- [x] go test ./probes/starlark/ passes.