### PR TITLE
[probes.starlark] Add tls_config (custom CA, mTLS, SNI, skip-verify)

### DIFF
--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -141,6 +141,36 @@ r.body       # bytes
 r.json()     # parsed JSON (raises on parse error)
 ```
 
+### TLS configuration
+
+For HTTPS calls to hosts that need a custom CA bundle, mTLS client cert, SNI
+override, or disabled cert validation, set `tls_config` on the probe. Same
+message the HTTP probe uses; applies to every `http.get`/`http.post` in the
+script. Example using a custom CA:
+
+```proto
+probe {
+  type: STARLARK
+  starlark_probe {
+    source_file: "internal_api.star"
+    tls_config {
+      ca_cert_file: "/etc/ssl/internal-root-ca.pem"
+    }
+  }
+}
+```
+
+For development against self-signed certs:
+
+```proto
+tls_config {
+  disable_cert_validation: true
+}
+```
+
+For per-host TLS variation (rare), run the script under multiple probes
+with different `tls_config` blocks.
+
 ### `vars`
 
 `vars.get` reads from the probe's static config map -- useful for passing

--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -168,9 +168,6 @@ tls_config {
 }
 ```
 
-For per-host TLS variation (rare), run the script under multiple probes
-with different `tls_config` blocks.
-
 ### `vars`
 
 `vars.get` reads from the probe's static config map -- useful for passing

--- a/probes/starlark/proto/config.pb.go
+++ b/probes/starlark/proto/config.pb.go
@@ -7,6 +7,7 @@
 package proto
 
 import (
+	proto1 "github.com/cloudprober/cloudprober/common/tlsconfig/proto"
 	proto "github.com/cloudprober/cloudprober/metrics/payload/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -64,8 +65,14 @@ type ProbeConf struct {
 	// distribution-bucket configuration, in-cloudprober aggregation, and
 	// additional labels all carry over with no Starlark-specific surface.
 	OutputMetricsOptions *proto.OutputMetricsOptions `protobuf:"bytes,5,opt,name=output_metrics_options,json=outputMetricsOptions" json:"output_metrics_options,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// TLS config for outbound HTTPS calls made by the script. Applies to every
+	// http.{get,post} call in the probe — set this when the script targets
+	// hosts that need a custom CA bundle, a client certificate (mTLS), an SNI
+	// override, or disabled cert validation. Same message the HTTP probe uses;
+	// see common/tlsconfig/proto/config.proto for the full field list.
+	TlsConfig     *proto1.TLSConfig `protobuf:"bytes,6,opt,name=tls_config,json=tlsConfig" json:"tls_config,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 // Default values for ProbeConf fields.
@@ -138,11 +145,18 @@ func (x *ProbeConf) GetOutputMetricsOptions() *proto.OutputMetricsOptions {
 	return nil
 }
 
+func (x *ProbeConf) GetTlsConfig() *proto1.TLSConfig {
+	if x != nil {
+		return x.TlsConfig
+	}
+	return nil
+}
+
 var File_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto protoreflect.FileDescriptor
 
 const file_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto_rawDesc = "" +
 	"\n" +
-	"Egithub.com/cloudprober/cloudprober/probes/starlark/proto/config.proto\x12\x1bcloudprober.probes.starlark\x1aEgithub.com/cloudprober/cloudprober/metrics/payload/proto/config.proto\"\xd4\x02\n" +
+	"Egithub.com/cloudprober/cloudprober/probes/starlark/proto/config.proto\x12\x1bcloudprober.probes.starlark\x1aFgithub.com/cloudprober/cloudprober/common/tlsconfig/proto/config.proto\x1aEgithub.com/cloudprober/cloudprober/metrics/payload/proto/config.proto\"\x95\x03\n" +
 	"\tProbeConf\x12\x16\n" +
 	"\x06source\x18\x01 \x01(\tR\x06source\x12\x1f\n" +
 	"\vsource_file\x18\x02 \x01(\tR\n" +
@@ -150,7 +164,9 @@ const file_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto
 	"\ventry_point\x18\x03 \x01(\t:\x05probeR\n" +
 	"entryPoint\x12D\n" +
 	"\x04vars\x18\x04 \x03(\v20.cloudprober.probes.starlark.ProbeConf.VarsEntryR\x04vars\x12g\n" +
-	"\x16output_metrics_options\x18\x05 \x01(\v21.cloudprober.metrics.payload.OutputMetricsOptionsR\x14outputMetricsOptions\x1a7\n" +
+	"\x16output_metrics_options\x18\x05 \x01(\v21.cloudprober.metrics.payload.OutputMetricsOptionsR\x14outputMetricsOptions\x12?\n" +
+	"\n" +
+	"tls_config\x18\x06 \x01(\v2 .cloudprober.tlsconfig.TLSConfigR\ttlsConfig\x1a7\n" +
 	"\tVarsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B:Z8github.com/cloudprober/cloudprober/probes/starlark/proto"
@@ -172,15 +188,17 @@ var file_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto_g
 	(*ProbeConf)(nil),                  // 0: cloudprober.probes.starlark.ProbeConf
 	nil,                                // 1: cloudprober.probes.starlark.ProbeConf.VarsEntry
 	(*proto.OutputMetricsOptions)(nil), // 2: cloudprober.metrics.payload.OutputMetricsOptions
+	(*proto1.TLSConfig)(nil),           // 3: cloudprober.tlsconfig.TLSConfig
 }
 var file_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto_depIdxs = []int32{
 	1, // 0: cloudprober.probes.starlark.ProbeConf.vars:type_name -> cloudprober.probes.starlark.ProbeConf.VarsEntry
 	2, // 1: cloudprober.probes.starlark.ProbeConf.output_metrics_options:type_name -> cloudprober.metrics.payload.OutputMetricsOptions
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	3, // 2: cloudprober.probes.starlark.ProbeConf.tls_config:type_name -> cloudprober.tlsconfig.TLSConfig
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_github_com_cloudprober_cloudprober_probes_starlark_proto_config_proto_init() }

--- a/probes/starlark/proto/config.proto
+++ b/probes/starlark/proto/config.proto
@@ -2,6 +2,7 @@ syntax = "proto2";
 
 package cloudprober.probes.starlark;
 
+import "github.com/cloudprober/cloudprober/common/tlsconfig/proto/config.proto";
 import "github.com/cloudprober/cloudprober/metrics/payload/proto/config.proto";
 
 option go_package = "github.com/cloudprober/cloudprober/probes/starlark/proto";
@@ -46,4 +47,11 @@ message ProbeConf {
   // distribution-bucket configuration, in-cloudprober aggregation, and
   // additional labels all carry over with no Starlark-specific surface.
   optional metrics.payload.OutputMetricsOptions output_metrics_options = 5;
+
+  // TLS config for outbound HTTPS calls made by the script. Applies to every
+  // http.{get,post} call in the probe — set this when the script targets
+  // hosts that need a custom CA bundle, a client certificate (mTLS), an SNI
+  // override, or disabled cert validation. Same message the HTTP probe uses;
+  // see common/tlsconfig/proto/config.proto for the full field list.
+  optional tlsconfig.TLSConfig tls_config = 6;
 }

--- a/probes/starlark/runtime.go
+++ b/probes/starlark/runtime.go
@@ -56,6 +56,7 @@ package starlark
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 
@@ -86,7 +87,11 @@ type runtime struct {
 // exists with the expected arity. Module-level code runs once here and is
 // bounded by ctx; runtime calls to Run cannot mutate the resulting globals
 // (Starlark freezes them).
-func newRuntime(ctx context.Context, name, source, entryPoint string, vars map[string]string, l *logger.Logger) (*runtime, error) {
+//
+// tlsCfg, when non-nil, is applied to a fresh *http.Transport and used by
+// the runtime's *http.Client. nil = Go's default Transport (default trust
+// store, no client cert, no SNI override).
+func newRuntime(ctx context.Context, name, source, entryPoint string, vars map[string]string, tlsCfg *tls.Config, l *logger.Logger) (*runtime, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -94,7 +99,7 @@ func newRuntime(ctx context.Context, name, source, entryPoint string, vars map[s
 		name:       name,
 		entryPoint: entryPoint,
 		l:          l,
-		httpClient: &http.Client{},
+		httpClient: newHTTPClient(tlsCfg),
 	}
 	rt.predeclared = builtins(vars)
 
@@ -131,6 +136,26 @@ func newRuntime(ctx context.Context, name, source, entryPoint string, vars map[s
 		return nil, fmt.Errorf("entry point %q must take exactly one argument (target), got %d", entryPoint, fn.NumParams())
 	}
 	return rt, nil
+}
+
+// newHTTPClient returns the *http.Client the runtime uses for script-side
+// http.{get,post} calls. When tlsCfg is non-nil, we install a fresh
+// http.Transport whose TLSClientConfig is tlsCfg — Go's DefaultTransport is
+// shared process-wide, so we can't mutate its TLS config without affecting
+// unrelated probes / dependencies. Other Transport defaults (proxy from env,
+// HTTP/2 attempt, dialer timeouts) are left at their stdlib values; future
+// proxy / keepalive / timeout knobs slot in here.
+func newHTTPClient(tlsCfg *tls.Config) *http.Client {
+	if tlsCfg == nil {
+		return &http.Client{}
+	}
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:             http.ProxyFromEnvironment,
+			ForceAttemptHTTP2: true,
+			TLSClientConfig:   tlsCfg,
+		},
+	}
 }
 
 // Thread-local keys. See top-of-file notes for the SetLocal/Local pattern.

--- a/probes/starlark/runtime.go
+++ b/probes/starlark/runtime.go
@@ -87,10 +87,6 @@ type runtime struct {
 // exists with the expected arity. Module-level code runs once here and is
 // bounded by ctx; runtime calls to Run cannot mutate the resulting globals
 // (Starlark freezes them).
-//
-// tlsCfg, when non-nil, is applied to a fresh *http.Transport and used by
-// the runtime's *http.Client. nil = Go's default Transport (default trust
-// store, no client cert, no SNI override).
 func newRuntime(ctx context.Context, name, source, entryPoint string, vars map[string]string, tlsCfg *tls.Config, l *logger.Logger) (*runtime, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -139,23 +135,17 @@ func newRuntime(ctx context.Context, name, source, entryPoint string, vars map[s
 }
 
 // newHTTPClient returns the *http.Client the runtime uses for script-side
-// http.{get,post} calls. When tlsCfg is non-nil, we install a fresh
-// http.Transport whose TLSClientConfig is tlsCfg — Go's DefaultTransport is
-// shared process-wide, so we can't mutate its TLS config without affecting
-// unrelated probes / dependencies. Other Transport defaults (proxy from env,
-// HTTP/2 attempt, dialer timeouts) are left at their stdlib values; future
-// proxy / keepalive / timeout knobs slot in here.
+// http.{get,post} calls. With tlsCfg set, we clone DefaultTransport rather
+// than starting from a zero-value Transport — Clone preserves the stdlib's
+// dial/handshake/idle-conn timeouts, which a bare &http.Transport{} drops.
+// Mutating DefaultTransport directly would leak into unrelated probes.
 func newHTTPClient(tlsCfg *tls.Config) *http.Client {
 	if tlsCfg == nil {
 		return &http.Client{}
 	}
-	return &http.Client{
-		Transport: &http.Transport{
-			Proxy:             http.ProxyFromEnvironment,
-			ForceAttemptHTTP2: true,
-			TLSClientConfig:   tlsCfg,
-		},
-	}
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.TLSClientConfig = tlsCfg
+	return &http.Client{Transport: t}
 }
 
 // Thread-local keys. See top-of-file notes for the SetLocal/Local pattern.

--- a/probes/starlark/runtime_test.go
+++ b/probes/starlark/runtime_test.go
@@ -38,7 +38,7 @@ def probe(target):
 	defer cancel()
 
 	start := time.Now()
-	_, err := newRuntime(ctx, "script-load-timeout", source, "probe", nil, &logger.Logger{})
+	_, err := newRuntime(ctx, "script-load-timeout", source, "probe", nil, nil, &logger.Logger{})
 	elapsed := time.Since(start)
 
 	assert.Error(t, err)

--- a/probes/starlark/starlark.go
+++ b/probes/starlark/starlark.go
@@ -20,11 +20,13 @@ package starlark
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"os"
 	"time"
 
+	"github.com/cloudprober/cloudprober/common/tlsconfig"
 	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/metrics"
 	"github.com/cloudprober/cloudprober/metrics/payload"
@@ -105,13 +107,21 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 		entryPoint = "probe"
 	}
 
+	var tlsCfg *tls.Config
+	if p.c.GetTlsConfig() != nil {
+		tlsCfg = &tls.Config{}
+		if err := tlsconfig.UpdateTLSConfig(tlsCfg, p.c.GetTlsConfig()); err != nil {
+			return fmt.Errorf("starlark tls_config: %v", err)
+		}
+	}
+
 	// Timeout to compile the starlark script. This is a generous timeout
 	// to avoid accidental infinite loops in the script.
 	loadTimeout := 30 * time.Second
 	loadCtx, cancel := context.WithTimeout(context.Background(), loadTimeout)
 	defer cancel()
 
-	rt, err := newRuntime(loadCtx, name, source, entryPoint, p.c.GetVars(), p.l)
+	rt, err := newRuntime(loadCtx, name, source, entryPoint, p.c.GetVars(), tlsCfg, p.l)
 	if err != nil {
 		return fmt.Errorf("starlark compile error: %v", err)
 	}

--- a/probes/starlark/starlark_test.go
+++ b/probes/starlark/starlark_test.go
@@ -611,10 +611,6 @@ def probe(target):
 	}
 }
 
-// TestHTTP_TLSConfig verifies that probe-level tls_config governs cert
-// validation on script-side http.{get,post} calls. The test server uses a
-// self-signed cert: the probe must fail without tls_config and succeed
-// with disable_cert_validation: true.
 func TestHTTP_TLSConfig(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/probes/starlark/starlark_test.go
+++ b/probes/starlark/starlark_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	tlsconfigpb "github.com/cloudprober/cloudprober/common/tlsconfig/proto"
 	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/probes/common/sched"
 	"github.com/cloudprober/cloudprober/probes/options"
@@ -417,11 +418,11 @@ def probe(target):
 // TestHTTP_RuntimeOwnsClient verifies the review comment fix: each runtime
 // has its own *http.Client rather than reusing http.DefaultClient.
 func TestHTTP_RuntimeOwnsClient(t *testing.T) {
-	rt1, err := newRuntime(context.Background(), "rt1", "def probe(t): pass\n", "probe", nil, &logger.Logger{})
+	rt1, err := newRuntime(context.Background(), "rt1", "def probe(t): pass\n", "probe", nil, nil, &logger.Logger{})
 	if err != nil {
 		t.Fatalf("rt1: %v", err)
 	}
-	rt2, err := newRuntime(context.Background(), "rt2", "def probe(t): pass\n", "probe", nil, &logger.Logger{})
+	rt2, err := newRuntime(context.Background(), "rt2", "def probe(t): pass\n", "probe", nil, nil, &logger.Logger{})
 	if err != nil {
 		t.Fatalf("rt2: %v", err)
 	}
@@ -608,6 +609,48 @@ def probe(target):
 			}
 		})
 	}
+}
+
+// TestHTTP_TLSConfig verifies that probe-level tls_config governs cert
+// validation on script-side http.{get,post} calls. The test server uses a
+// self-signed cert: the probe must fail without tls_config and succeed
+// with disable_cert_validation: true.
+func TestHTTP_TLSConfig(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	source := fmt.Sprintf(`
+def probe(target):
+    r = http.get(url = "%s")
+    assert.http_status(r, 200)
+`, srv.URL)
+
+	t.Run("rejects_self_signed_by_default", func(t *testing.T) {
+		opts := newOpts(t, hostFromServer(t, srv), source)
+		p := &Probe{}
+		if err := p.Init("script-tls-default", opts); err != nil {
+			t.Fatalf("Init: %v", err)
+		}
+		results := p.RunOnce(context.Background())
+		assert.False(t, results[0].Success, "default TLS config should reject self-signed cert")
+		require.NotNil(t, results[0].Error)
+		assert.Contains(t, results[0].Error.Error(), "certificate")
+	})
+
+	t.Run("accepts_with_disable_cert_validation", func(t *testing.T) {
+		opts := newOpts(t, hostFromServer(t, srv), source)
+		opts.ProbeConf.(*configpb.ProbeConf).TlsConfig = &tlsconfigpb.TLSConfig{
+			DisableCertValidation: proto.Bool(true),
+		}
+		p := &Probe{}
+		if err := p.Init("script-tls-skip-verify", opts); err != nil {
+			t.Fatalf("Init: %v", err)
+		}
+		results := p.RunOnce(context.Background())
+		assert.True(t, results[0].Success, "probe should succeed; got error: %v", results[0].Error)
+	})
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `tls_config` to the Starlark probe proto, mirroring the HTTP probe's field (`cloudprober.tlsconfig.TLSConfig`). Covers custom CA bundle, mTLS client cert/key, SNI override, and `disable_cert_validation`.
- Probe-level rather than per-call: TLS lives on the Transport, and per-call Transport cloning would create a fresh connection pool every call. Scripts that need different TLS per host run under multiple probes with different `tls_config` blocks.
- Builds a fresh `*http.Transport` with `TLSClientConfig` set rather than mutating Go's `DefaultTransport`, which would affect unrelated probes / in-process dependencies. Same builder is the natural slot for future proxy / timeout / disable_http2 knobs.

## Test plan
- [x] `TestHTTP_TLSConfig` (table-driven): self-signed `httptest.NewTLSServer` is rejected by the default probe and accepted with `disable_cert_validation: true`.
- [x] Existing test callers of `newRuntime` updated with a nil `*tls.Config` (signature change).
- [x] `go test ./probes/starlark/` passes.