### PR TITLE
[probes.starlark] log: add set_attr for per-run logger attributes

### DIFF
--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -122,6 +122,7 @@ All scripts get a small, fixed set of builtins. No filesystem, network beyond
 | `vars.get(name, default=None)` | Read values from the probe's `vars` config map (see below). |
 | `state.get(key, default=None)` / `state.set(key, value)` | Per-target key-value store that persists across runs (see below). |
 | `log.info(msg)` / `log.warn(msg)` / `log.error(msg)` / `log.debug(msg)` | Route a message to Cloudprober's logger with the probe's `target` attribute attached. |
+| `log.set_attr(key, value)` | Add a sticky attribute to this run's logger. All subsequent `log.*` calls *and* the probe-failure log line Cloudprober writes if the script errors out (network timeout, assertion failure, etc.) carry it. Cleared at the end of the run. Useful for stamping `req_id` or other per-run context onto failure logs. |
 | `print_metric(line)` | Emit a custom metric line (see below). |
 | `print(...)` | Standard Starlark `print`; routed to the logger at INFO. |
 | `fail(msg)` | Standard Starlark; ends the run as a failure. |

--- a/probes/starlark/builtins_log.go
+++ b/probes/starlark/builtins_log.go
@@ -15,6 +15,8 @@
 package starlark
 
 import (
+	"log/slog"
+
 	starlarklib "go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 )
@@ -28,12 +30,30 @@ func logModule() *starlarkstruct.Module {
 	return &starlarkstruct.Module{
 		Name: "log",
 		Members: starlarklib.StringDict{
-			"info":  starlarklib.NewBuiltin("log.info", logAt("info")),
-			"warn":  starlarklib.NewBuiltin("log.warn", logAt("warn")),
-			"error": starlarklib.NewBuiltin("log.error", logAt("error")),
-			"debug": starlarklib.NewBuiltin("log.debug", logAt("debug")),
+			"info":     starlarklib.NewBuiltin("log.info", logAt("info")),
+			"warn":     starlarklib.NewBuiltin("log.warn", logAt("warn")),
+			"error":    starlarklib.NewBuiltin("log.error", logAt("error")),
+			"debug":    starlarklib.NewBuiltin("log.debug", logAt("debug")),
+			"set_attr": starlarklib.NewBuiltin("log.set_attr", logSetAttr),
 		},
 	}
+}
+
+// logSetAttr installs an attribute (key=value) on the per-run logger so all
+// subsequent log calls from the script — and the probe-failure log line
+// runProbe writes if probe() returns an error — carry it. Sticky for the
+// duration of one probe() invocation; cleared on the next.
+func logSetAttr(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
+	var key, value string
+	if err := starlarklib.UnpackArgs("log.set_attr", args, kwargs,
+		"key", &key,
+		"value", &value,
+	); err != nil {
+		return nil, err
+	}
+	h := loggerHolderFromThread(thread)
+	h.l = h.l.WithAttributes(slog.String(key, value))
+	return starlarklib.None, nil
 }
 
 func logAt(level string) func(*starlarklib.Thread, *starlarklib.Builtin, starlarklib.Tuple, []starlarklib.Tuple) (starlarklib.Value, error) {

--- a/probes/starlark/builtins_log.go
+++ b/probes/starlark/builtins_log.go
@@ -15,8 +15,6 @@
 package starlark
 
 import (
-	"log/slog"
-
 	starlarklib "go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 )
@@ -51,8 +49,7 @@ func logSetAttr(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlar
 	); err != nil {
 		return nil, err
 	}
-	h := loggerHolderFromThread(thread)
-	h.l = h.l.WithAttributes(slog.String(key, value))
+	loggerHolderFromThread(thread).SetAttr(key, value)
 	return starlarklib.None, nil
 }
 

--- a/probes/starlark/runtime.go
+++ b/probes/starlark/runtime.go
@@ -107,7 +107,7 @@ func newRuntime(ctx context.Context, name, source, entryPoint string, vars map[s
 	}
 	thread.SetLocal(threadCtxKey, ctx)
 	thread.SetLocal(threadHTTPClientKey, rt.httpClient)
-	thread.SetLocal(threadLoggerKey, l)
+	thread.SetLocal(threadLoggerKey, &loggerHolder{l: l})
 	// Module-level state.{get,set} writes go into a scratch bucket that's
 	// discarded with the load thread. There's no target context at load time,
 	// so persistence has nowhere to land.
@@ -181,15 +181,30 @@ func httpClientFromThread(t *starlarklib.Thread) *http.Client {
 	return c
 }
 
-// loggerFromThread returns the *logger.Logger stashed on the thread. Panics
-// for the same reason httpClientFromThread does — every script thread is
-// constructed by runtime/runProbe, which sets the key.
+// loggerHolder wraps a per-run *logger.Logger so script-side log.set_attr
+// can swap in an enriched logger and have *both* further script-side log
+// calls and the Go-side error-log line (run by runProbe after the script
+// returns) see the new attributes. Without the holder, the script's
+// mutation would only be visible inside its own thread.
+type loggerHolder struct {
+	l *logger.Logger
+}
+
+// loggerFromThread returns the current *logger.Logger from the per-thread
+// loggerHolder. Panics for the same reason httpClientFromThread does — every
+// script thread is constructed by runtime/runProbe, which sets the key.
 func loggerFromThread(t *starlarklib.Thread) *logger.Logger {
-	l, ok := t.Local(threadLoggerKey).(*logger.Logger)
+	return loggerHolderFromThread(t).l
+}
+
+// loggerHolderFromThread returns the per-run loggerHolder. log.set_attr uses
+// it to install an enriched logger that persists for the rest of the run.
+func loggerHolderFromThread(t *starlarklib.Thread) *loggerHolder {
+	h, ok := t.Local(threadLoggerKey).(*loggerHolder)
 	if !ok {
-		panic("loggerFromThread: thread missing logger local; constructed outside runtime?")
+		panic("loggerHolderFromThread: thread missing logger local; constructed outside runtime?")
 	}
-	return l
+	return h
 }
 
 // stateBucketFromThread returns the per-target state bucket stashed on the
@@ -229,9 +244,11 @@ func cancelThreadOnContext(ctx context.Context, thread *starlarklib.Thread) func
 	}
 }
 
-// Run invokes the entry point with a target value. It returns nil on clean
-// return, or an error on Starlark eval failure / assertion failure / ctx
-// cancellation.
+// Run invokes the entry point with a target value. It returns the final
+// *logger.Logger (enriched by any log.set_attr calls in the script) so the
+// caller can use it to log the script's error with the same attributes, plus
+// nil on clean return or an error on Starlark eval failure / assertion
+// failure / ctx cancellation.
 //
 // l is the per-target logger, stashed on the thread so the log builtin can
 // find it. Pass the per-target logger (not the probe-level one) so log lines
@@ -249,17 +266,18 @@ func cancelThreadOnContext(ctx context.Context, thread *starlarklib.Thread) func
 // each call its own avoids any chance of state leaking between runs (target
 // X's failed assertion shouldn't poison target Y's thread.Cancel state).
 // The global StringDict is shared and treated as read-only.
-func (rt *runtime) Run(ctx context.Context, ep endpoint.Endpoint, l *logger.Logger, bucket *stateBucket, metricEmit metricEmitFn) error {
+func (rt *runtime) Run(ctx context.Context, ep endpoint.Endpoint, l *logger.Logger, bucket *stateBucket, metricEmit metricEmitFn) (*logger.Logger, error) {
+	lh := &loggerHolder{l: l}
 	thread := &starlarklib.Thread{
 		Name:  rt.name,
-		Print: func(_ *starlarklib.Thread, msg string) { l.Info(msg) },
+		Print: func(_ *starlarklib.Thread, msg string) { lh.l.Info(msg) },
 	}
 	// Stash ctx + httpClient + logger + state bucket + metric-emit callback
 	// so builtins can pull them back out via *FromThread helpers. See
 	// top-of-file notes.
 	thread.SetLocal(threadCtxKey, ctx)
 	thread.SetLocal(threadHTTPClientKey, rt.httpClient)
-	thread.SetLocal(threadLoggerKey, l)
+	thread.SetLocal(threadLoggerKey, lh)
 	thread.SetLocal(threadStateKey, bucket)
 	thread.SetLocal(threadMetricEmitKey, metricEmit)
 
@@ -274,7 +292,7 @@ func (rt *runtime) Run(ctx context.Context, ep endpoint.Endpoint, l *logger.Logg
 	fn := rt.globals[rt.entryPoint]
 	target := targetValue(ep)
 	_, err := starlarklib.Call(thread, fn, starlarklib.Tuple{target}, nil)
-	return err
+	return lh.l, err
 }
 
 // targetValue builds the Starlark value passed to probe(target). It mirrors

--- a/probes/starlark/runtime.go
+++ b/probes/starlark/runtime.go
@@ -188,25 +188,29 @@ func httpClientFromThread(t *starlarklib.Thread) *http.Client {
 // returns) see the new attributes. Without the holder, the script's
 // mutation would only be visible inside its own thread.
 type loggerHolder struct {
-	base  *logger.Logger
-	attrs map[string]string
-	l     *logger.Logger
+	base   *logger.Logger
+	attrs  []slog.Attr
+	keyPos map[string]int
+	l      *logger.Logger
 }
 
 func newLoggerHolder(base *logger.Logger) *loggerHolder {
-	return &loggerHolder{base: base, attrs: map[string]string{}, l: base}
+	return &loggerHolder{base: base, keyPos: map[string]int{}, l: base}
 }
 
-// SetAttr rebuilds l from base with the current attrs map so repeated calls
-// with the same key replace rather than append — Logger.WithAttributes
-// otherwise produces duplicate log fields.
+// SetAttr rebuilds l from base with the current attrs so repeated calls
+// with the same key replace in place rather than append — preserves the
+// script's set_attr call order in the log output, and avoids the duplicate
+// fields Logger.WithAttributes would otherwise produce on repeat keys.
 func (h *loggerHolder) SetAttr(key, value string) {
-	h.attrs[key] = value
-	attrs := make([]slog.Attr, 0, len(h.attrs))
-	for k, v := range h.attrs {
-		attrs = append(attrs, slog.String(k, v))
+	attr := slog.String(key, value)
+	if i, ok := h.keyPos[key]; ok {
+		h.attrs[i] = attr
+	} else {
+		h.keyPos[key] = len(h.attrs)
+		h.attrs = append(h.attrs, attr)
 	}
-	h.l = h.base.WithAttributes(attrs...)
+	h.l = h.base.WithAttributes(h.attrs...)
 }
 
 // loggerFromThread returns the current *logger.Logger from the per-thread

--- a/probes/starlark/runtime.go
+++ b/probes/starlark/runtime.go
@@ -187,9 +187,6 @@ func httpClientFromThread(t *starlarklib.Thread) *http.Client {
 // calls and the Go-side error-log line (run by runProbe after the script
 // returns) see the new attributes. Without the holder, the script's
 // mutation would only be visible inside its own thread.
-//
-// SetAttr replaces (not appends) by key: it rebuilds l from base with the
-// current attrs map, so log lines never carry duplicate keys.
 type loggerHolder struct {
 	base  *logger.Logger
 	attrs map[string]string
@@ -197,16 +194,13 @@ type loggerHolder struct {
 }
 
 func newLoggerHolder(base *logger.Logger) *loggerHolder {
-	return &loggerHolder{base: base, l: base}
+	return &loggerHolder{base: base, attrs: map[string]string{}, l: base}
 }
 
-// SetAttr sets the script-side attribute key=value on l. Repeated calls with
-// the same key overwrite the previous value rather than producing duplicate
-// log fields.
+// SetAttr rebuilds l from base with the current attrs map so repeated calls
+// with the same key replace rather than append — Logger.WithAttributes
+// otherwise produces duplicate log fields.
 func (h *loggerHolder) SetAttr(key, value string) {
-	if h.attrs == nil {
-		h.attrs = map[string]string{}
-	}
 	h.attrs[key] = value
 	attrs := make([]slog.Attr, 0, len(h.attrs))
 	for k, v := range h.attrs {
@@ -271,9 +265,7 @@ func cancelThreadOnContext(ctx context.Context, thread *starlarklib.Thread) func
 
 // Run invokes the entry point with a target value. It returns the final
 // *logger.Logger (enriched by any log.set_attr calls in the script) so the
-// caller can use it to log the script's error with the same attributes, plus
-// nil on clean return or an error on Starlark eval failure / assertion
-// failure / ctx cancellation.
+// caller can use it to log the script's error with the same attributes.
 //
 // l is the per-target logger, stashed on the thread so the log builtin can
 // find it. Pass the per-target logger (not the probe-level one) so log lines

--- a/probes/starlark/runtime.go
+++ b/probes/starlark/runtime.go
@@ -58,6 +58,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	"github.com/cloudprober/cloudprober/logger"
@@ -107,7 +108,7 @@ func newRuntime(ctx context.Context, name, source, entryPoint string, vars map[s
 	}
 	thread.SetLocal(threadCtxKey, ctx)
 	thread.SetLocal(threadHTTPClientKey, rt.httpClient)
-	thread.SetLocal(threadLoggerKey, &loggerHolder{l: l})
+	thread.SetLocal(threadLoggerKey, newLoggerHolder(l))
 	// Module-level state.{get,set} writes go into a scratch bucket that's
 	// discarded with the load thread. There's no target context at load time,
 	// so persistence has nowhere to land.
@@ -186,8 +187,32 @@ func httpClientFromThread(t *starlarklib.Thread) *http.Client {
 // calls and the Go-side error-log line (run by runProbe after the script
 // returns) see the new attributes. Without the holder, the script's
 // mutation would only be visible inside its own thread.
+//
+// SetAttr replaces (not appends) by key: it rebuilds l from base with the
+// current attrs map, so log lines never carry duplicate keys.
 type loggerHolder struct {
-	l *logger.Logger
+	base  *logger.Logger
+	attrs map[string]string
+	l     *logger.Logger
+}
+
+func newLoggerHolder(base *logger.Logger) *loggerHolder {
+	return &loggerHolder{base: base, l: base}
+}
+
+// SetAttr sets the script-side attribute key=value on l. Repeated calls with
+// the same key overwrite the previous value rather than producing duplicate
+// log fields.
+func (h *loggerHolder) SetAttr(key, value string) {
+	if h.attrs == nil {
+		h.attrs = map[string]string{}
+	}
+	h.attrs[key] = value
+	attrs := make([]slog.Attr, 0, len(h.attrs))
+	for k, v := range h.attrs {
+		attrs = append(attrs, slog.String(k, v))
+	}
+	h.l = h.base.WithAttributes(attrs...)
 }
 
 // loggerFromThread returns the current *logger.Logger from the per-thread
@@ -267,7 +292,7 @@ func cancelThreadOnContext(ctx context.Context, thread *starlarklib.Thread) func
 // X's failed assertion shouldn't poison target Y's thread.Cancel state).
 // The global StringDict is shared and treated as read-only.
 func (rt *runtime) Run(ctx context.Context, ep endpoint.Endpoint, l *logger.Logger, bucket *stateBucket, metricEmit metricEmitFn) (*logger.Logger, error) {
-	lh := &loggerHolder{l: l}
+	lh := newLoggerHolder(l)
 	thread := &starlarklib.Thread{
 		Name:  rt.name,
 		Print: func(_ *starlarklib.Thread, msg string) { lh.l.Info(msg) },

--- a/probes/starlark/starlark.go
+++ b/probes/starlark/starlark.go
@@ -188,9 +188,6 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 	latency := time.Since(start)
 
 	if err != nil {
-		// finalL carries any attributes added by the script via log.set_attr,
-		// so the failure log line gets the same context (e.g. req_id) as the
-		// script's own log lines.
 		finalL.Error(err.Error())
 		runReq.LastRun.Set(false, 0, err)
 		return

--- a/probes/starlark/starlark.go
+++ b/probes/starlark/starlark.go
@@ -184,11 +184,14 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 		}
 	})
 	start := time.Now()
-	err := p.runtime.Run(runCtx, target, l, bucket, emit)
+	finalL, err := p.runtime.Run(runCtx, target, l, bucket, emit)
 	latency := time.Since(start)
 
 	if err != nil {
-		l.Error(err.Error())
+		// finalL carries any attributes added by the script via log.set_attr,
+		// so the failure log line gets the same context (e.g. req_id) as the
+		// script's own log lines.
+		finalL.Error(err.Error())
 		runReq.LastRun.Set(false, 0, err)
 		return
 	}

--- a/probes/starlark/starlark_test.go
+++ b/probes/starlark/starlark_test.go
@@ -682,8 +682,6 @@ def probe(target):
 			wantSuccess: false,
 		},
 		{
-			// Calling set_attr twice with the same key replaces (not appends);
-			// the log line should contain the second value once, not both.
 			name: "repeat_key_replaces",
 			source: `
 def probe(target):

--- a/probes/starlark/starlark_test.go
+++ b/probes/starlark/starlark_test.go
@@ -658,9 +658,10 @@ func TestLogSetAttr_FlowsToProbeFailureLog(t *testing.T) {
 	srv.Close()
 
 	cases := []struct {
-		name        string
-		source      string
-		wantSuccess bool
+		name           string
+		source         string
+		wantSuccess    bool
+		wantNotInLog   string // optional: must not appear in output
 	}{
 		{
 			name: "script_side_log_info_carries_attr",
@@ -680,6 +681,19 @@ def probe(target):
 `, srv.URL),
 			wantSuccess: false,
 		},
+		{
+			// Calling set_attr twice with the same key replaces (not appends);
+			// the log line should contain the second value once, not both.
+			name: "repeat_key_replaces",
+			source: `
+def probe(target):
+    log.set_attr("req_id", "first")
+    log.set_attr("req_id", "abc123")
+    log.info("processing")
+`,
+			wantSuccess:  true,
+			wantNotInLog: "req_id=first",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -694,6 +708,9 @@ def probe(target):
 
 			output := buf.String()
 			assert.Contains(t, output, "req_id=abc123", "expected attr in log output, got: %s", output)
+			if tc.wantNotInLog != "" {
+				assert.NotContains(t, output, tc.wantNotInLog, "stale attr value still present")
+			}
 		})
 	}
 }

--- a/probes/starlark/starlark_test.go
+++ b/probes/starlark/starlark_test.go
@@ -649,6 +649,55 @@ def probe(target):
 	})
 }
 
+func TestLogSetAttr_FlowsToProbeFailureLog(t *testing.T) {
+	// Closed server gives us a deterministic, immediate connection refused
+	// for the failure-path subcase.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.Close()
+
+	cases := []struct {
+		name        string
+		source      string
+		wantSuccess bool
+	}{
+		{
+			name: "script_side_log_info_carries_attr",
+			source: `
+def probe(target):
+    log.set_attr("req_id", "abc123")
+    log.info("processing")
+`,
+			wantSuccess: true,
+		},
+		{
+			name: "probe_failure_log_carries_attr",
+			source: fmt.Sprintf(`
+def probe(target):
+    log.set_attr("req_id", "abc123")
+    http.get(url = "%s")
+`, srv.URL),
+			wantSuccess: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			opts := newOpts(t, "127.0.0.1", tc.source)
+			opts.Logger = logger.New(logger.WithWriter(&buf))
+
+			p := &Probe{}
+			require.NoError(t, p.Init("script-log-setattr-"+tc.name, opts))
+			results := p.RunOnce(context.Background())
+			assert.Equal(t, tc.wantSuccess, results[0].Success)
+
+			output := buf.String()
+			assert.Contains(t, output, "req_id=abc123", "expected attr in log output, got: %s", output)
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Init / config validation
 

--- a/probes/starlark/starlark_test.go
+++ b/probes/starlark/starlark_test.go
@@ -713,6 +713,37 @@ def probe(target):
 	}
 }
 
+// TestLogSetAttr_PreservesInsertionOrder pins that two log.set_attr calls
+// with different keys produce attrs in the order they were set (not
+// alphabetical, not random map-iteration order).
+func TestLogSetAttr_PreservesInsertionOrder(t *testing.T) {
+	source := `
+def probe(target):
+    log.set_attr("zeta", "1")
+    log.set_attr("alpha", "2")
+    log.set_attr("middle", "3")
+    log.info("ordered")
+`
+	var buf bytes.Buffer
+	opts := newOpts(t, "127.0.0.1", source)
+	opts.Logger = logger.New(logger.WithWriter(&buf))
+
+	p := &Probe{}
+	require.NoError(t, p.Init("script-log-setattr-order", opts))
+	results := p.RunOnce(context.Background())
+	require.True(t, results[0].Success, "probe should succeed; got error: %v", results[0].Error)
+
+	output := buf.String()
+	iZeta := strings.Index(output, "zeta=1")
+	iAlpha := strings.Index(output, "alpha=2")
+	iMiddle := strings.Index(output, "middle=3")
+	require.NotEqual(t, -1, iZeta, "zeta not in log output: %s", output)
+	require.NotEqual(t, -1, iAlpha, "alpha not in log output: %s", output)
+	require.NotEqual(t, -1, iMiddle, "middle not in log output: %s", output)
+	assert.Less(t, iZeta, iAlpha, "zeta should appear before alpha (set first)")
+	assert.Less(t, iAlpha, iMiddle, "alpha should appear before middle (set second)")
+}
+
 // ---------------------------------------------------------------------------
 // Init / config validation
 


### PR DESCRIPTION
## Summary
- `log.set_attr(key, value)` installs a sticky attribute on the per-run logger.
- Subsequent `log.*` calls **and** the probe-failure log line Cloudprober writes if the script errors carry it.
- Solves the case where a network error from `http.get` produces a failure log with no context — e.g. now you can stamp the `X-Request-ID` you put on the failed request and find it in the logs.
- Bare error string on `runReq.LastRun` is unchanged — only the log output gets enriched, so alerts matching on error text don't see noise.

## Test plan
- [x] `TestLogSetAttr_FlowsToProbeFailureLog` (table-driven):
  - `script_side_log_info_carries_attr`: `log.set_attr("req_id", "abc123"); log.info("processing")` — captured log contains `req_id=abc123`.
  - `probe_failure_log_carries_attr`: closed httptest server triggers connection refused; captured log line for the failure still contains `req_id=abc123`.
- [x] `go test ./probes/starlark/` passes.

## Usage
```python
def probe(target):
    req_id = str(state.get("req_id", 0) + 1)
    state.set("req_id", req_id)
    log.set_attr("req_id", req_id)

    r = http.get(url, headers={"X-Request-ID": req_id})
    # If the GET errors (timeout, TLS, refused), the probe-failure log line
    # written by Cloudprober carries req_id=<n> just like log.info would.
    assert.http_status(r, 200)
```