### PR TITLE
[probes.starlark] assert.http_status: drop the msg kwarg

### DIFF
--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -118,7 +118,7 @@ All scripts get a small, fixed set of builtins. No filesystem, network beyond
 |---|---|
 | `http.get(url, headers=None, max_redirects=N, keep_alive=False)` | HTTP GET, returns a `Response`. `max_redirects=0` disables following; `max_redirects=N` follows up to N (omit for Go's default of 10). `keep_alive` defaults to `False` to match the HTTP probe -- every call exercises DNS/TCP/TLS setup, which is what you usually want from a prober. Pass `keep_alive=True` to reuse a pooled connection across calls in a chained API flow. |
 | `http.post(url, headers=None, body=None, json=None, max_redirects=N, keep_alive=False)` | HTTP POST. Pass `json=` for an auto-encoded JSON body (sets `Content-Type`), or `body=` for a raw string/bytes. `max_redirects` and `keep_alive` match `http.get`. |
-| `assert.http_status(response, expected, msg=None)` | Fails the probe if `response.status != expected`. `msg` is appended to the failure error -- handy for recording context (e.g. dynamic headers) that produced the failed request. |
+| `assert.http_status(response, expected)` | Fails the probe if `response.status != expected`. Stamp per-call context onto the failure log line with `log.set_attr` instead of inlining it into the error message. |
 | `vars.get(name, default=None)` | Read values from the probe's `vars` config map (see below). |
 | `state.get(key, default=None)` / `state.set(key, value)` | Per-target key-value store that persists across runs (see below). |
 | `log.info(msg)` / `log.warn(msg)` / `log.error(msg)` / `log.debug(msg)` | Route a message to Cloudprober's logger with the probe's `target` attribute attached. |

--- a/probes/starlark/builtins_assert.go
+++ b/probes/starlark/builtins_assert.go
@@ -33,11 +33,9 @@ func assertModule() *starlarkstruct.Module {
 func assertHTTPStatus(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
 	var resp starlarklib.Value
 	var expected int
-	var msg string
 	if err := starlarklib.UnpackArgs("assert.http_status", args, kwargs,
 		"response", &resp,
 		"expected", &expected,
-		"msg?", &msg,
 	); err != nil {
 		return nil, err
 	}
@@ -46,9 +44,6 @@ func assertHTTPStatus(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starla
 		return nil, fmt.Errorf("assert.http_status: first argument must be a Response, got %s", resp.Type())
 	}
 	if r.status != expected {
-		if msg != "" {
-			return nil, fmt.Errorf("assert.http_status: expected %d, got %d: %s", expected, r.status, msg)
-		}
 		return nil, fmt.Errorf("assert.http_status: expected %d, got %d", expected, r.status)
 	}
 	return starlarklib.None, nil

--- a/probes/starlark/starlark_test.go
+++ b/probes/starlark/starlark_test.go
@@ -489,29 +489,6 @@ def probe(target):
 	assert.Contains(t, results[0].Error.Error(), "must be a Response")
 }
 
-func TestAssert_HTTPStatusFailureMsg(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer srv.Close()
-
-	source := fmt.Sprintf(`
-def probe(target):
-    r = http.get(url = "%s", headers = {"X-Trace": "abc123"})
-    assert.http_status(r, 200, msg = "trace=%%s" %% "abc123")
-`, srv.URL)
-	opts := newOpts(t, hostFromServer(t, srv), source)
-	p := &Probe{}
-	if err := p.Init("script-assert-msg", opts); err != nil {
-		t.Fatalf("Init: %v", err)
-	}
-
-	results := p.RunOnce(context.Background())
-	assert.False(t, results[0].Success)
-	assert.Contains(t, results[0].Error.Error(), "expected 200, got 500")
-	assert.Contains(t, results[0].Error.Error(), "trace=abc123")
-}
-
 // TestHTTP_MaxRedirects exercises the per-call max_redirects kwarg on
 // http.get. The server redirects /->/1->/2 then 200; the table walks the
 // boundary cases including =0 (which validates the clone codepath actually


### PR DESCRIPTION
## Summary
`log.set_attr` (PR #1338, just merged) is the more general way to attach per-call context to failure logs: it works for *every* failure path (network timeouts, TLS errors, JSON parse errors, assertion failures), produces structured `key=value` attrs instead of error-string suffixes, and avoids two ways to do the same thing.

Before:
```python
assert.http_status(r, 200, msg = "req=" + req_id)
# error: assert.http_status: expected 200, got 500: req=abc123
```

After:
```python
log.set_attr("req_id", req_id)   # once at the top of probe()
assert.http_status(r, 200)
# error stays bare; failure log line carries req_id=abc123 as a structured attr.
```

## Tradeoff
Anything reading bare `LastRun.Error` (status UI, alert match-on-text) loses the suffix. But that's the same trade `log.set_attr` already made for network errors — dropping `msg` makes the design *more* consistent, not less.

The `msg` kwarg was new in #1328 (same session as the rest of this work); no production users to migrate.

## Test plan
- [x] `go test ./probes/starlark/` passes.
- [x] Removed `TestAssert_HTTPStatusFailureMsg` (the test for the kwarg being dropped).