### PR TITLE
[docs] homepage: footer Resources + Browser Probe + Blog → Medium

### DIFF
--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -926,7 +926,7 @@
           </svg>
         </div>
         <div class="cp-cap-card-title">Built-in Probes</div>
-        <div class="cp-cap-card-sub">HTTP · gRPC · Script · DNS · PING · TCP · UDP</div>
+        <div class="cp-cap-card-sub">HTTP · gRPC · Browser · Script · DNS · PING · TCP · UDP</div>
       </button>
 
       <button class="cp-cap-card" data-cap="custom" role="tab" aria-selected="false">
@@ -971,9 +971,11 @@
 
       <div class="cp-cap-panel" data-cap="builtin" data-active="true">
         <h3>Built-in Probes</h3>
-        <p>Probe every layer of your stack with built-ins. <strong>HTTP</strong>, <strong>gRPC</strong>, and <strong>Starlark Script</strong> probes test the surface your users actually touch. <strong>DNS</strong>, <strong>PING</strong>, <strong>TCP</strong>, and <strong>UDP</strong> probes verify the network underneath — name resolution, packet loss, connection refused, byte-level transport issues.</p>
+        <p>Probe every layer of your stack with built-ins. <strong>HTTP</strong>, <strong>gRPC</strong>, <strong>Browser</strong>, and <strong>Starlark Script</strong> probes test the surface your users actually touch — including full headless-browser checks that drive multi-step user flows. <strong>DNS</strong>, <strong>PING</strong>, <strong>TCP</strong>, and <strong>UDP</strong> probes verify the network underneath — name resolution, packet loss, connection refused, byte-level transport issues.</p>
         <p>All built-ins share the same scheduling, target discovery, validators, and surfacers. Mix them in one config to monitor an application end-to-end — from DNS resolution, through the TCP handshake, to the HTTP response body.</p>
         <a class="cp-dd-link" href="/docs/overview/probe/">See all probe types</a>
+        &nbsp;&nbsp;
+        <a class="cp-dd-link" href="https://browser-probe-demo.cloudprober.org/status" target="_blank" rel="noopener">Try the Browser Probe demo</a>
       </div>
 
       <div class="cp-cap-panel" data-cap="custom">

--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -975,7 +975,7 @@
         <p>All built-ins share the same scheduling, target discovery, validators, and surfacers. Mix them in one config to monitor an application end-to-end — from DNS resolution, through the TCP handshake, to the HTTP response body.</p>
         <a class="cp-dd-link" href="/docs/overview/probe/">See all probe types</a>
         &nbsp;&nbsp;
-        <a class="cp-dd-link" href="https://browser-probe-demo.cloudprober.org/status" target="_blank" rel="noopener">Try the Browser Probe demo</a>
+        <a class="cp-dd-link" href="https://browser-probe-demo.cloudprober.org/status" target="_blank" rel="noopener">See the Browser Probe demo</a>
       </div>
 
       <div class="cp-cap-panel" data-cap="custom">

--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -1211,7 +1211,7 @@
         <ul>
           <li><a href="/docs/how-to/">How-to</a></li>
           <li><a href="/docs/faq/">FAQ</a></li>
-          <li><a href="/blog/">Blog</a></li>
+          <li><a href="https://medium.com/cloudprober/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/docs/about/">About</a></li>
         </ul>
       </div>

--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -1074,7 +1074,6 @@
       <h2>One binary, the whole stack.</h2>
       <p>Probes, target discovery, surfacers, alert rules, and a live status dashboard all live in the same process — driven by the same config. No alertmanager. No sidecar. No glue.</p>
       <p>Add <strong>Prometheus</strong>, <strong>Grafana</strong>, <strong>PagerDuty</strong>, or any other tool you're already running. Don't, if you don't want to. The same setup grows from one VM to multi-region production without swapping in a "real" tool later.</p>
-      <a class="cp-dd-link" href="/docs/">See deployment patterns</a>
     </div>
     <div class="cp-deepdive-visual">
       <svg class="cp-dd-diagram" viewBox="0 0 480 320" role="img" aria-label="Cloudprober all-in-one architecture">
@@ -1208,9 +1207,9 @@
       <div class="cp-footer-col">
         <h4>Resources</h4>
         <ul>
-          <li><a href="/docs/">Docs</a></li>
-          <li><a href="/docs/overview/cloudprober/">Quickstart</a></li>
-          <li><a href="/docs/surfacers/overview/">Surfacers</a></li>
+          <li><a href="/docs/how-to/">How-to</a></li>
+          <li><a href="/docs/faq/">FAQ</a></li>
+          <li><a href="/blog/">Blog</a></li>
           <li><a href="/docs/about/">About</a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- **Footer Resources column** rebuilt: How-to / FAQ / Blog / About. Blog points to https://medium.com/cloudprober/ (matches the doks nav).
- **Browser Probe** is now called out in the Built-in Probes tab (sub-label + bolded in the panel paragraph) with a 'See the Browser Probe demo →' link to https://browser-probe-demo.cloudprober.org/status.
- **Deep-dive 5.3 ('One binary, the whole stack.')** dropped its 'See deployment patterns' link — there's no such doc; the destination was a misleading /docs/ fallback. The diagram + text stand on their own.

(Replaces stale PR #1346 — that one was off a branch whose history was tangled with the already-merged #1344.)

## Test plan
- [x] Built-in Probes tab sub-label shows 'HTTP · gRPC · Browser · Script · DNS · PING · TCP · UDP'.
- [x] Built-in Probes panel: 'See all probe types →' and 'See the Browser Probe demo →' links both render and resolve.
- [x] Deep-dive 5.3 has no link below the text.
- [x] Footer Resources: How-to / FAQ / About resolve to existing docs; Blog opens medium.com/cloudprober in a new tab.