### PR TITLE
[docs] homepage: footer How-to/FAQ links → list pages

### DIFF
--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -1209,8 +1209,8 @@
       <div class="cp-footer-col">
         <h4>Resources</h4>
         <ul>
-          <li><a href="/docs/how-to/">How-to</a></li>
-          <li><a href="/docs/faq/">FAQ</a></li>
+          <li><a href="/docs/how-to/list/">How-to</a></li>
+          <li><a href="/docs/faq/list/">FAQ</a></li>
           <li><a href="https://medium.com/cloudprober/" target="_blank" rel="noopener">Blog</a></li>
           <li><a href="/docs/about/">About</a></li>
         </ul>


### PR DESCRIPTION
## Summary
The footer Resources column linked How-to and FAQ to the section roots (\`/docs/how-to/\` and \`/docs/faq/\`). The doks nav menu actually uses explicit list-page URLs (\`/docs/how-to/list/\` and \`/docs/faq/list/\`) which render the proper listing layout. This PR aligns the footer with the nav.

## Test plan
- [ ] Footer Resources → How-to opens \`/docs/how-to/list/\` (same listing the nav uses).
- [ ] Footer Resources → FAQ opens \`/docs/faq/list/\` (same listing the nav uses).