### PR TITLE
[docs] homepage: slim down trusted-by band so it doesn't dominate

### DIFF
--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -346,9 +346,9 @@
     .cp-cap-panels { padding: 1.5rem 1.25rem; }
   }
 
-  /* ===== Trusted-by (band 4) ===== */
+  /* ===== Trusted-by (band 4) — slim strip, not a centerpiece ===== */
   .cp-trusted {
-    padding: clamp(2rem, 3.5vw, 3rem) 1.5rem clamp(4rem, 8vw, 6.5rem);
+    padding: clamp(1.5rem, 2.5vw, 2rem) 1.5rem clamp(2.5rem, 5vw, 4rem);
     background: var(--bg);
     text-align: center;
   }
@@ -358,7 +358,7 @@
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: var(--text-muted);
-    margin: 0 0 2rem;
+    margin: 0 0 1.25rem;
   }
   .cp-logo-grid {
     max-width: 1200px;
@@ -366,14 +366,14 @@
     box-sizing: border-box;
     display: grid;
     grid-template-columns: repeat(8, minmax(0, 1fr));
-    gap: 2.25rem 2rem;
+    gap: 1.4rem 1.5rem;
     justify-items: center;
     align-items: center;
   }
   .cp-logo-grid > :nth-child(8n+1) { justify-self: start; }
   .cp-logo-grid > :nth-child(8n)   { justify-self: end; }
   .cp-logo-grid img {
-    max-height: 42px;
+    max-height: 28px;
     max-width: 100%;
     object-fit: contain;
     filter: grayscale(100%);
@@ -408,7 +408,7 @@
   }
   .cp-logo-list strong { color: var(--text); font-weight: 600; }
   @media (max-width: 900px) {
-    .cp-logo-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 2rem 1.5rem; }
+    .cp-logo-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 1.25rem 1.25rem; }
     .cp-logo-grid > :nth-child(8n+1),
     .cp-logo-grid > :nth-child(8n)   { justify-self: center; }
     .cp-logo-grid > :nth-child(4n+1) { justify-self: start; }


### PR DESCRIPTION
## Summary
The trusted-by band was sized as a centerpiece (42px logos, big paddings) when it was the only trust signal on the page. Now that the testimonials band carries verbatim quotes from Snowflake, DoorDash, and Hostinger, and the deep-dive bands carry the substance, the logos sitting at full centerpiece weight had become the dominant element right after the hero — not what we want for a technical OSS tool. Slimming to a tailscale-style strip:

| Property | Before | After |
|---|---|---|
| Logo max-height | 42px | 28px |
| Grid gap (row × col) | 36 × 32 | 22 × 24 |
| Eyebrow margin-bottom | 2rem | 1.25rem |
| Band padding-top | ~45px | ~32px |
| Band padding-bottom | ~102px | ~64px |
| Total band height (1280px viewport) | **318px** | **213px** |

The strip still lands its trust signal above the fold (the eyebrow + 16 logos remain visible); hero stays unambiguously the dominant visual moment.

## Test plan
- [ ] Visual: at 1280px, the hero is clearly the dominant moment; logos sit as a quiet strip below.
- [ ] At 900px viewport (4-col logo grid), confirm tighter gaps look intentional, not crowded.
- [ ] At <600px, mobile text fallback still renders (we never show the grid below 600px).
- [ ] Dark mode logos still legible at the smaller size.