### PR TITLE
[docs] homepage: force hero h1 to Inter (was inheriting Jost)

### DIFF
--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -158,7 +158,7 @@
     margin: 0 auto;
   }
   .cp-hero h1 {
-    font-size: clamp(2.5rem, 5.5vw + 0.5rem, 4.5rem) !important;
+    font-size: clamp(2.25rem, 5vw + 0.25rem, 4rem) !important;
     line-height: 1.05;
     letter-spacing: -0.035em;
     font-weight: 700;

--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -66,6 +66,12 @@
     line-height: 1.5;
   }
   body.home a { color: inherit; text-decoration: none; }
+  /* Bootstrap/doks emits `h1, .h1 { font-family: Jost, ... }` directly on
+     the element (specificity 0,0,1), which wins over our body.home
+     font-family by inheritance. Explicitly set Inter on home h1s. */
+  body.home h1, body.home .h1 {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  }
   /* Accent-color link classes need higher specificity than body.home a
      (which is 0,1,2). Adding the body.home prefix bumps to 0,2,1. */
   body.home a.cp-dd-link,


### PR DESCRIPTION
## Summary
The hero h1 was rendering in **Jost**, not Inter as our \`body.home\` font-family declares. Cause: Bootstrap/doks emits

\`\`\`css
h1, .h1 { font-family: Jost, ...; }
\`\`\`

directly on the element (specificity 0,0,1), which beats inheritance from \`body.home\`. The other headings (h2, h3, h4) inherited Inter correctly because Bootstrap doesn't emit explicit font-family rules for them (\`$headings-font-family\` is null in doks).

Added a \`body.home h1, body.home .h1\` override (specificity 0,2,1) so the hero headline visually matches the rest of the homepage typography. No effect on docs/blog pages.

Before: hero h1 = Jost; everything else on home = Inter. Mixed typography on a single band.
After: hero h1 = Inter; everything else = Inter. Consistent.

## Test plan
- [ ] Hero headline at \`/\` renders in Inter (rounded geometric sans, matches the subhead below).
- [ ] Docs page h1 (e.g. \`/docs/\`) is unchanged — still Jost.
- [ ] Dark mode hero h1 also renders in Inter.