### PR TITLE
[alerting.notify] Add Microsoft Teams notifier for alerting

### DIFF
--- a/internal/alerting/notifier/notifier.go
+++ b/internal/alerting/notifier/notifier.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cloudprober/cloudprober/internal/alerting/notifier/opsgenie"
 	"github.com/cloudprober/cloudprober/internal/alerting/notifier/pagerduty"
 	"github.com/cloudprober/cloudprober/internal/alerting/notifier/slack"
+	"github.com/cloudprober/cloudprober/internal/alerting/notifier/teams"
 	configpb "github.com/cloudprober/cloudprober/internal/alerting/proto"
 	httpreqpb "github.com/cloudprober/cloudprober/internal/httpreq/proto"
 	"github.com/cloudprober/cloudprober/logger"
@@ -58,6 +59,7 @@ type Notifier struct {
 	pagerdutyNotifier *pagerduty.Client
 	opsgenieNotifier  *opsgenie.Client
 	slackNotifier     *slack.Client
+	teamsNotifier     *teams.Client
 	httpNotifier      *httpreqpb.HTTPRequest
 }
 
@@ -121,6 +123,14 @@ func (n *Notifier) Notify(ctx context.Context, alertInfo *alertinfo.AlertInfo) e
 		err := n.slackNotifier.Notify(ctx, fields)
 		if err != nil {
 			n.l.Errorf("Error sending Slack message: %v", err)
+			errs = errors.Join(errs, err)
+		}
+	}
+
+	if n.teamsNotifier != nil {
+		err := n.teamsNotifier.Notify(ctx, fields)
+		if err != nil {
+			n.l.Errorf("Error sending Teams message: %v", err)
 			errs = errors.Join(errs, err)
 		}
 	}
@@ -220,6 +230,14 @@ func New(alertcfg *configpb.AlertConf, l *logger.Logger) (*Notifier, error) {
 			return nil, fmt.Errorf("error configuring Slack notifier: %v", err)
 		}
 		n.slackNotifier = slack
+	}
+
+	if n.cfg.GetTeams() != nil {
+		teams, err := teams.New(n.cfg.GetTeams(), l)
+		if err != nil {
+			return nil, fmt.Errorf("error configuring Teams notifier: %v", err)
+		}
+		n.teamsNotifier = teams
 	}
 
 	if n.cfg.GetHttpNotify() != nil {

--- a/internal/alerting/notifier/teams/teams.go
+++ b/internal/alerting/notifier/teams/teams.go
@@ -1,3 +1,17 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package teams implements Microsoft Teams notifications for Cloudprober alert
 // events.
 package teams
@@ -43,7 +57,7 @@ func New(teamscfg *configpb.Teams, l *logger.Logger) (*Client, error) {
 }
 
 // lookupWebhookUrl looks up the webhook URL to use for the Teams client,
-// in order of precendence:
+// in order of precedence:
 // 1. Webhook URL in the config
 // 2. Webhook URL environment variable
 func lookupWebhookUrl(teamscfg *configpb.Teams) (string, error) {
@@ -144,8 +158,8 @@ func (c *Client) Notify(ctx context.Context, alertFields map[string]string) erro
 	}
 	defer resp.Body.Close()
 
-	// check status code, return error if not 202
-	if resp.StatusCode != http.StatusAccepted {
+	// check status code, return error if not 2xx
+	if resp.StatusCode/100 != 2 {
 		b, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("teams webhook returned error; statusCode: %d, response: %s", resp.StatusCode, string(b))
 	}

--- a/internal/alerting/notifier/teams/teams.go
+++ b/internal/alerting/notifier/teams/teams.go
@@ -1,0 +1,207 @@
+// Package teams implements Microsoft Teams notifications for Cloudprober alert
+// events.
+package teams
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	configpb "github.com/cloudprober/cloudprober/internal/alerting/proto"
+	"github.com/cloudprober/cloudprober/logger"
+)
+
+const (
+	// DEFAULT_TEAMS_WEBHOOK_URL_ENV_VAR is the default environment variable
+	// to use for the Teams webhook URL.
+	DEFAULT_TEAMS_WEBHOOK_URL_ENV_VAR = "TEAMS_WEBHOOK_URL"
+)
+
+// Client is a Teams client.
+type Client struct {
+	httpClient *http.Client
+	logger     *logger.Logger
+	webhookURL string
+}
+
+// New creates a new Teams client.
+func New(teamscfg *configpb.Teams, l *logger.Logger) (*Client, error) {
+	webhookURL, err := lookupWebhookUrl(teamscfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		httpClient: &http.Client{},
+		logger:     l,
+		webhookURL: webhookURL,
+	}, nil
+}
+
+// lookupWebhookUrl looks up the webhook URL to use for the Teams client,
+// in order of precendence:
+// 1. Webhook URL in the config
+// 2. Webhook URL environment variable
+func lookupWebhookUrl(teamscfg *configpb.Teams) (string, error) {
+	// check if the webhook URL is set in the config
+	if teamscfg.GetWebhookUrl() != "" {
+		return teamscfg.GetWebhookUrl(), nil
+	}
+
+	// check if the environment variable is set for the webhook URL
+	if webhookURL, exists := os.LookupEnv(webhookUrlEnvVar(teamscfg)); exists {
+		return webhookURL, nil
+	}
+
+	return "", fmt.Errorf("no Teams webhook URL found")
+}
+
+// webhookUrlEnvVar returns the environment variable to use for the Teams
+func webhookUrlEnvVar(teamscfg *configpb.Teams) string {
+	if teamscfg.GetWebhookUrlEnvVar() != "" {
+		return teamscfg.GetWebhookUrlEnvVar()
+	}
+
+	return DEFAULT_TEAMS_WEBHOOK_URL_ENV_VAR
+}
+
+// webhookMessage is the message that is sent to the Teams webhook.
+type webhookMessage struct {
+	Type        string       `json:"type"`
+	Attachments []attachment `json:"attachments"`
+}
+
+type attachment struct {
+	ContentType string       `json:"contentType"`
+	Content     adaptiveCard `json:"content"`
+}
+
+type adaptiveCard struct {
+	SchemaURL string    `json:"$schema"`
+	Type      string    `json:"type"`
+	Version   string    `json:"version"`
+	MSTeams   teamsCard `json:"msteams"`
+	Body      []any     `json:"body"`
+	Actions   []action  `json:"actions,omitempty"`
+}
+
+type teamsCard struct {
+	Width string `json:"width"`
+}
+
+type textBlock struct {
+	Type   string `json:"type"`
+	Size   string `json:"size,omitempty"`
+	Weight string `json:"weight,omitempty"`
+	Text   string `json:"text"`
+	Wrap   bool   `json:"wrap,omitempty"`
+}
+
+type factSet struct {
+	Type  string `json:"type"`
+	Facts []fact `json:"facts"`
+}
+
+type fact struct {
+	Title string `json:"title"`
+	Value string `json:"value"`
+}
+
+type action struct {
+	Type  string `json:"type"`
+	Title string `json:"title"`
+	URL   string `json:"url"`
+}
+
+// Notify sends a notification to Teams.
+func (c *Client) Notify(ctx context.Context, alertFields map[string]string) error {
+	message := createMessage(alertFields)
+
+	jsonBody, err := json.Marshal(message)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		c.webhookURL,
+		bytes.NewBuffer(jsonBody),
+	)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// check status code, return error if not 200
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("teams webhook returned error; statusCode: %d, response: %s", resp.StatusCode, string(b))
+	}
+
+	return nil
+}
+
+// createMessage creates a new Teams webhook message, from the alertFields
+func createMessage(alertFields map[string]string) webhookMessage {
+	card := adaptiveCard{
+		SchemaURL: "http://adaptivecards.io/schemas/adaptive-card.json",
+		Type:      "AdaptiveCard",
+		Version:   "1.2",
+		MSTeams: teamsCard{
+			Width: "Full",
+		},
+		Body: []any{
+			textBlock{
+				Type:   "TextBlock",
+				Size:   "Large",
+				Weight: "Bolder",
+				Text:   "Cloudprober alert",
+			},
+			factSet{
+				Type: "FactSet",
+				Facts: []fact{
+					{Title: "Alert", Value: alertFields["alert"]},
+					{Title: "Target", Value: alertFields["target"]},
+					{
+						Title: "Failures",
+						Value: fmt.Sprintf(
+							"%s out of %s probes",
+							alertFields["failures"],
+							alertFields["total"],
+						),
+					},
+					{Title: "Failing since", Value: alertFields["since"]},
+					{Title: "Probe", Value: alertFields["probe"]},
+				},
+			},
+		},
+	}
+
+	if alertFields["dashboard_url"] != "" {
+		card.Actions = []action{{
+			Type:  "Action.OpenUrl",
+			Title: "Open Dashboard",
+			URL:   alertFields["dashboard_url"],
+		}}
+	}
+
+	return webhookMessage{
+		Type: "message",
+		Attachments: []attachment{{
+			ContentType: "application/vnd.microsoft.card.adaptive",
+			Content:     card,
+		}},
+	}
+}

--- a/internal/alerting/notifier/teams/teams.go
+++ b/internal/alerting/notifier/teams/teams.go
@@ -144,8 +144,8 @@ func (c *Client) Notify(ctx context.Context, alertFields map[string]string) erro
 	}
 	defer resp.Body.Close()
 
-	// check status code, return error if not 200
-	if resp.StatusCode != http.StatusOK {
+	// check status code, return error if not 202
+	if resp.StatusCode != http.StatusAccepted {
 		b, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("teams webhook returned error; statusCode: %d, response: %s", resp.StatusCode, string(b))
 	}

--- a/internal/alerting/notifier/teams/teams_test.go
+++ b/internal/alerting/notifier/teams/teams_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package teams
 
 import (

--- a/internal/alerting/notifier/teams/teams_test.go
+++ b/internal/alerting/notifier/teams/teams_test.go
@@ -148,7 +148,7 @@ func TestTeamsNotify(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ReadAll() error = %v", err)
 		}
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusAccepted)
 	}))
 	defer httpServer.Close()
 

--- a/internal/alerting/notifier/teams/teams_test.go
+++ b/internal/alerting/notifier/teams/teams_test.go
@@ -1,0 +1,261 @@
+package teams
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	configpb "github.com/cloudprober/cloudprober/internal/alerting/proto"
+)
+
+func TestTeamsNew(t *testing.T) {
+	tests := map[string]struct {
+		cfg         *configpb.Teams
+		envVars     map[string]string
+		wantWebhook string
+	}{
+		"valid config": {
+			cfg: &configpb.Teams{
+				WebhookUrl: "test-webhook-url",
+			},
+			envVars:     map[string]string{},
+			wantWebhook: "test-webhook-url",
+		},
+		"valid config with env var": {
+			cfg: &configpb.Teams{
+				WebhookUrl: "test-webhook-url",
+			},
+			envVars: map[string]string{
+				"TEAMS_WEBHOOK_URL": "test-webhook-url-env-var",
+			},
+			wantWebhook: "test-webhook-url",
+		},
+		"env var": {
+			cfg: &configpb.Teams{},
+			envVars: map[string]string{
+				"TEAMS_WEBHOOK_URL": "test-webhook-url-env-var",
+			},
+			wantWebhook: "test-webhook-url-env-var",
+		},
+		"env var override": {
+			cfg: &configpb.Teams{
+				WebhookUrlEnvVar: "TEAMS_WEBHOOK_URL_OVERRIDE",
+			},
+			envVars: map[string]string{
+				"TEAMS_WEBHOOK_URL_OVERRIDE": "test-webhook-url-env-var",
+				"TEAMS_WEBHOOK_URL":          "test-webhook-url-env-var-2",
+			},
+			wantWebhook: "test-webhook-url-env-var",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			for k, v := range tc.envVars {
+				t.Setenv(k, v)
+			}
+
+			c, err := New(tc.cfg, nil)
+			if err != nil {
+				t.Errorf("New() error = %v", err)
+			}
+
+			if c.webhookURL != tc.wantWebhook {
+				t.Errorf("New() = %v, want %v", c.webhookURL, tc.wantWebhook)
+			}
+		})
+	}
+}
+
+func TestTeamsCreateWebhookMessage(t *testing.T) {
+	tests := map[string]struct {
+		alertFields map[string]string
+		want        webhookMessage
+	}{
+		"valid": {
+			alertFields: map[string]string{
+				"alert":         "teams_webhook_test",
+				"target":        "127.0.0.1:8000",
+				"failures":      "1",
+				"total":         "1",
+				"since":         "2026-05-27T15:20:18-04:00",
+				"probe":         "teams-test",
+				"playbook_url":  "",
+				"dashboard_url": "http://localhost:9313/status?probe=teams-test",
+			},
+			want: webhookMessage{
+				Type: "message",
+				Attachments: []attachment{{
+					ContentType: "application/vnd.microsoft.card.adaptive",
+					Content: adaptiveCard{
+						SchemaURL: "http://adaptivecards.io/schemas/adaptive-card.json",
+						Type:      "AdaptiveCard",
+						Version:   "1.2",
+						MSTeams: teamsCard{
+							Width: "Full",
+						},
+						Body: []any{
+							textBlock{
+								Type:   "TextBlock",
+								Size:   "Large",
+								Weight: "Bolder",
+								Text:   "Cloudprober alert",
+							},
+							factSet{
+								Type: "FactSet",
+								Facts: []fact{
+									{Title: "Alert", Value: "teams_webhook_test"},
+									{Title: "Target", Value: "127.0.0.1:8000"},
+									{Title: "Failures", Value: "1 out of 1 probes"},
+									{Title: "Failing since", Value: "2026-05-27T15:20:18-04:00"},
+									{Title: "Probe", Value: "teams-test"},
+								},
+							},
+						},
+						Actions: []action{
+							{
+								Type:  "Action.OpenUrl",
+								Title: "Open Dashboard",
+								URL:   "http://localhost:9313/status?probe=teams-test",
+							},
+						},
+					},
+				}},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := createMessage(tc.alertFields)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("createMessage() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTeamsNotify(t *testing.T) {
+	var gotBody []byte
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var err error
+		gotBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer httpServer.Close()
+
+	tests := map[string]struct {
+		alertFields map[string]string
+		want        webhookMessage
+		wantErr     bool
+	}{
+		"valid": {
+			alertFields: map[string]string{
+				"alert":         "teams_webhook_test",
+				"target":        "127.0.0.1:8000",
+				"failures":      "1",
+				"total":         "1",
+				"since":         "2026-05-27T15:20:18-04:00",
+				"probe":         "teams-test",
+				"playbook_url":  "",
+				"dashboard_url": "http://localhost:9313/status?probe=teams-test",
+			},
+			want: webhookMessage{
+				Type: "message",
+				Attachments: []attachment{{
+					ContentType: "application/vnd.microsoft.card.adaptive",
+					Content: adaptiveCard{
+						SchemaURL: "http://adaptivecards.io/schemas/adaptive-card.json",
+						Type:      "AdaptiveCard",
+						Version:   "1.2",
+						MSTeams: teamsCard{
+							Width: "Full",
+						},
+						Body: []any{
+							textBlock{
+								Type:   "TextBlock",
+								Size:   "Large",
+								Weight: "Bolder",
+								Text:   "Cloudprober alert",
+							},
+							factSet{
+								Type: "FactSet",
+								Facts: []fact{
+									{Title: "Alert", Value: "teams_webhook_test"},
+									{Title: "Target", Value: "127.0.0.1:8000"},
+									{Title: "Failures", Value: "1 out of 1 probes"},
+									{Title: "Failing since", Value: "2026-05-27T15:20:18-04:00"},
+									{Title: "Probe", Value: "teams-test"},
+								},
+							},
+						},
+						Actions: []action{
+							{
+								Type:  "Action.OpenUrl",
+								Title: "Open Dashboard",
+								URL:   "http://localhost:9313/status?probe=teams-test",
+							},
+						},
+					},
+				}},
+			},
+			wantErr: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := &Client{
+				httpClient: httpServer.Client(),
+				webhookURL: httpServer.URL,
+			}
+
+			err := c.Notify(context.Background(), tc.alertFields)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Notify() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			wantBody, err := json.Marshal(tc.want)
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+			var gotJSON, wantJSON any
+			if err := json.Unmarshal(gotBody, &gotJSON); err != nil {
+				t.Fatalf("Unmarshal(gotBody) error = %v", err)
+			}
+			if err := json.Unmarshal(wantBody, &wantJSON); err != nil {
+				t.Fatalf("Unmarshal(wantBody) error = %v", err)
+			}
+			if !reflect.DeepEqual(gotJSON, wantJSON) {
+				t.Errorf("Notify() sent = %s, want %s", string(gotBody), string(wantBody))
+			}
+		})
+	}
+}
+
+func TestTeamsNotifyError(t *testing.T) {
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer httpServer.Close()
+
+	c := &Client{
+		httpClient: httpServer.Client(),
+		webhookURL: httpServer.URL,
+	}
+
+	err := c.Notify(context.Background(), map[string]string{
+		"details": "test-details",
+	})
+
+	if err == nil {
+		t.Errorf("Notify() error = %v, wantErr %v", err, true)
+	}
+}

--- a/internal/alerting/proto/config.pb.go
+++ b/internal/alerting/proto/config.pb.go
@@ -132,7 +132,7 @@ func (x AlertConf_Severity) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AlertConf_Severity.Descriptor instead.
 func (AlertConf_Severity) EnumDescriptor() ([]byte, []int) {
-	return file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_rawDescGZIP(), []int{6, 0}
+	return file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_rawDescGZIP(), []int{7, 0}
 }
 
 type Email struct {
@@ -449,6 +449,64 @@ func (x *Slack) GetWebhookUrlEnvVar() string {
 	return ""
 }
 
+type Teams struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Webhook URL
+	// The Teams notifications use an Incoming Webhook URL to send
+	// notifications to a Teams channel.
+	// Note: set either webhook_url or webhook_url_env_var. webhook_url
+	// takes precedence over webhook_url_env_var.
+	WebhookUrl string `protobuf:"bytes,1,opt,name=webhook_url,json=webhookUrl,proto3" json:"webhook_url,omitempty"`
+	// The environment variable that is used to contain the Teams webhook URL.
+	WebhookUrlEnvVar string `protobuf:"bytes,2,opt,name=webhook_url_env_var,json=webhookUrlEnvVar,proto3" json:"webhook_url_env_var,omitempty"` // Default: TEAMS_WEBHOOK_URL;
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *Teams) Reset() {
+	*x = Teams{}
+	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Teams) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Teams) ProtoMessage() {}
+
+func (x *Teams) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Teams.ProtoReflect.Descriptor instead.
+func (*Teams) Descriptor() ([]byte, []int) {
+	return file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *Teams) GetWebhookUrl() string {
+	if x != nil {
+		return x.WebhookUrl
+	}
+	return ""
+}
+
+func (x *Teams) GetWebhookUrlEnvVar() string {
+	if x != nil {
+		return x.WebhookUrlEnvVar
+	}
+	return ""
+}
+
 type NotifyConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Command to run when alert is fired. You can use this command to do
@@ -480,6 +538,8 @@ type NotifyConfig struct {
 	Slack *Slack `protobuf:"bytes,13,opt,name=slack,proto3" json:"slack,omitempty"`
 	// Opsgenie configuration.
 	Opsgenie *Opsgenie `protobuf:"bytes,14,opt,name=opsgenie,proto3" json:"opsgenie,omitempty"`
+	// Microsoft Teams configuration.
+	Teams *Teams `protobuf:"bytes,15,opt,name=teams,proto3" json:"teams,omitempty"`
 	// Notify using an HTTP request. HTTP request fields are expanded using the
 	// same template expansion rules as "command" above:
 	// For example, to send a notification using rest API:
@@ -500,7 +560,7 @@ type NotifyConfig struct {
 
 func (x *NotifyConfig) Reset() {
 	*x = NotifyConfig{}
-	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[4]
+	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -512,7 +572,7 @@ func (x *NotifyConfig) String() string {
 func (*NotifyConfig) ProtoMessage() {}
 
 func (x *NotifyConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[4]
+	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -525,7 +585,7 @@ func (x *NotifyConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotifyConfig.ProtoReflect.Descriptor instead.
 func (*NotifyConfig) Descriptor() ([]byte, []int) {
-	return file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_rawDescGZIP(), []int{4}
+	return file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *NotifyConfig) GetCommand() string {
@@ -563,6 +623,13 @@ func (x *NotifyConfig) GetOpsgenie() *Opsgenie {
 	return nil
 }
 
+func (x *NotifyConfig) GetTeams() *Teams {
+	if x != nil {
+		return x.Teams
+	}
+	return nil
+}
+
 func (x *NotifyConfig) GetHttpNotify() *proto.HTTPRequest {
 	if x != nil {
 		return x.HttpNotify
@@ -580,7 +647,7 @@ type Condition struct {
 
 func (x *Condition) Reset() {
 	*x = Condition{}
-	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[5]
+	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -592,7 +659,7 @@ func (x *Condition) String() string {
 func (*Condition) ProtoMessage() {}
 
 func (x *Condition) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[5]
+	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -605,7 +672,7 @@ func (x *Condition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Condition.ProtoReflect.Descriptor instead.
 func (*Condition) Descriptor() ([]byte, []int) {
-	return file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_rawDescGZIP(), []int{5}
+	return file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *Condition) GetFailures() int32 {
@@ -666,7 +733,7 @@ type AlertConf struct {
 
 func (x *AlertConf) Reset() {
 	*x = AlertConf{}
-	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[6]
+	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -678,7 +745,7 @@ func (x *AlertConf) String() string {
 func (*AlertConf) ProtoMessage() {}
 
 func (x *AlertConf) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[6]
+	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -691,7 +758,7 @@ func (x *AlertConf) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AlertConf.ProtoReflect.Descriptor instead.
 func (*AlertConf) Descriptor() ([]byte, []int) {
-	return file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_rawDescGZIP(), []int{6}
+	return file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *AlertConf) GetName() string {
@@ -778,7 +845,7 @@ type Opsgenie_Responder struct {
 
 func (x *Opsgenie_Responder) Reset() {
 	*x = Opsgenie_Responder{}
-	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[7]
+	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -790,7 +857,7 @@ func (x *Opsgenie_Responder) String() string {
 func (*Opsgenie_Responder) ProtoMessage() {}
 
 func (x *Opsgenie_Responder) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[7]
+	mi := &file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -895,7 +962,11 @@ const file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_pro
 	"\x05Slack\x12\x1f\n" +
 	"\vwebhook_url\x18\x01 \x01(\tR\n" +
 	"webhookUrl\x12-\n" +
-	"\x13webhook_url_env_var\x18\x02 \x01(\tR\x10webhookUrlEnvVar\"\xd3\x02\n" +
+	"\x13webhook_url_env_var\x18\x02 \x01(\tR\x10webhookUrlEnvVar\"W\n" +
+	"\x05Teams\x12\x1f\n" +
+	"\vwebhook_url\x18\x01 \x01(\tR\n" +
+	"webhookUrl\x12-\n" +
+	"\x13webhook_url_env_var\x18\x02 \x01(\tR\x10webhookUrlEnvVar\"\x86\x03\n" +
 	"\fNotifyConfig\x12\x18\n" +
 	"\acommand\x18\n" +
 	" \x01(\tR\acommand\x121\n" +
@@ -903,7 +974,8 @@ const file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_pro
 	"\n" +
 	"pager_duty\x18\f \x01(\v2\x1f.cloudprober.alerting.PagerDutyR\tpagerDuty\x121\n" +
 	"\x05slack\x18\r \x01(\v2\x1b.cloudprober.alerting.SlackR\x05slack\x12:\n" +
-	"\bopsgenie\x18\x0e \x01(\v2\x1e.cloudprober.alerting.OpsgenieR\bopsgenie\x12G\n" +
+	"\bopsgenie\x18\x0e \x01(\v2\x1e.cloudprober.alerting.OpsgenieR\bopsgenie\x121\n" +
+	"\x05teams\x18\x0f \x01(\v2\x1b.cloudprober.alerting.TeamsR\x05teams\x12G\n" +
 	"\vhttp_notify\x18\x03 \x01(\v2&.cloudprober.utils.httpreq.HTTPRequestR\n" +
 	"httpNotify\"=\n" +
 	"\tCondition\x12\x1a\n" +
@@ -948,7 +1020,7 @@ func file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_prot
 }
 
 var file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_goTypes = []any{
 	(Opsgenie_Responder_Type)(0), // 0: cloudprober.alerting.Opsgenie.Responder.Type
 	(AlertConf_Severity)(0),      // 1: cloudprober.alerting.AlertConf.Severity
@@ -956,30 +1028,32 @@ var file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto
 	(*Opsgenie)(nil),             // 3: cloudprober.alerting.Opsgenie
 	(*PagerDuty)(nil),            // 4: cloudprober.alerting.PagerDuty
 	(*Slack)(nil),                // 5: cloudprober.alerting.Slack
-	(*NotifyConfig)(nil),         // 6: cloudprober.alerting.NotifyConfig
-	(*Condition)(nil),            // 7: cloudprober.alerting.Condition
-	(*AlertConf)(nil),            // 8: cloudprober.alerting.AlertConf
-	(*Opsgenie_Responder)(nil),   // 9: cloudprober.alerting.Opsgenie.Responder
-	nil,                          // 10: cloudprober.alerting.AlertConf.OtherInfoEntry
-	(*proto.HTTPRequest)(nil),    // 11: cloudprober.utils.httpreq.HTTPRequest
+	(*Teams)(nil),                // 6: cloudprober.alerting.Teams
+	(*NotifyConfig)(nil),         // 7: cloudprober.alerting.NotifyConfig
+	(*Condition)(nil),            // 8: cloudprober.alerting.Condition
+	(*AlertConf)(nil),            // 9: cloudprober.alerting.AlertConf
+	(*Opsgenie_Responder)(nil),   // 10: cloudprober.alerting.Opsgenie.Responder
+	nil,                          // 11: cloudprober.alerting.AlertConf.OtherInfoEntry
+	(*proto.HTTPRequest)(nil),    // 12: cloudprober.utils.httpreq.HTTPRequest
 }
 var file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_depIdxs = []int32{
-	9,  // 0: cloudprober.alerting.Opsgenie.responders:type_name -> cloudprober.alerting.Opsgenie.Responder
+	10, // 0: cloudprober.alerting.Opsgenie.responders:type_name -> cloudprober.alerting.Opsgenie.Responder
 	2,  // 1: cloudprober.alerting.NotifyConfig.email:type_name -> cloudprober.alerting.Email
 	4,  // 2: cloudprober.alerting.NotifyConfig.pager_duty:type_name -> cloudprober.alerting.PagerDuty
 	5,  // 3: cloudprober.alerting.NotifyConfig.slack:type_name -> cloudprober.alerting.Slack
 	3,  // 4: cloudprober.alerting.NotifyConfig.opsgenie:type_name -> cloudprober.alerting.Opsgenie
-	11, // 5: cloudprober.alerting.NotifyConfig.http_notify:type_name -> cloudprober.utils.httpreq.HTTPRequest
-	7,  // 6: cloudprober.alerting.AlertConf.condition:type_name -> cloudprober.alerting.Condition
-	6,  // 7: cloudprober.alerting.AlertConf.notify:type_name -> cloudprober.alerting.NotifyConfig
-	10, // 8: cloudprober.alerting.AlertConf.other_info:type_name -> cloudprober.alerting.AlertConf.OtherInfoEntry
-	1,  // 9: cloudprober.alerting.AlertConf.severity:type_name -> cloudprober.alerting.AlertConf.Severity
-	0,  // 10: cloudprober.alerting.Opsgenie.Responder.type:type_name -> cloudprober.alerting.Opsgenie.Responder.Type
-	11, // [11:11] is the sub-list for method output_type
-	11, // [11:11] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	6,  // 5: cloudprober.alerting.NotifyConfig.teams:type_name -> cloudprober.alerting.Teams
+	12, // 6: cloudprober.alerting.NotifyConfig.http_notify:type_name -> cloudprober.utils.httpreq.HTTPRequest
+	8,  // 7: cloudprober.alerting.AlertConf.condition:type_name -> cloudprober.alerting.Condition
+	7,  // 8: cloudprober.alerting.AlertConf.notify:type_name -> cloudprober.alerting.NotifyConfig
+	11, // 9: cloudprober.alerting.AlertConf.other_info:type_name -> cloudprober.alerting.AlertConf.OtherInfoEntry
+	1,  // 10: cloudprober.alerting.AlertConf.severity:type_name -> cloudprober.alerting.AlertConf.Severity
+	0,  // 11: cloudprober.alerting.Opsgenie.Responder.type:type_name -> cloudprober.alerting.Opsgenie.Responder.Type
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_init() }
@@ -987,8 +1061,8 @@ func file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_prot
 	if File_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto != nil {
 		return
 	}
-	file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[6].OneofWrappers = []any{}
-	file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[7].OneofWrappers = []any{
+	file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[7].OneofWrappers = []any{}
+	file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_msgTypes[8].OneofWrappers = []any{
 		(*Opsgenie_Responder_Id)(nil),
 		(*Opsgenie_Responder_Name)(nil),
 	}
@@ -998,7 +1072,7 @@ func file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_prot
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_rawDesc), len(file_github_com_cloudprober_cloudprober_internal_alerting_proto_config_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   9,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/alerting/proto/config.proto
+++ b/internal/alerting/proto/config.proto
@@ -104,6 +104,18 @@ message Slack {
     string webhook_url_env_var = 2; // Default: SLACK_WEBHOOK_URL;
 }
 
+message Teams {
+    // Webhook URL
+    // The Teams notifications use an Incoming Webhook URL to send
+    // notifications to a Teams channel.
+    // Note: set either webhook_url or webhook_url_env_var. webhook_url
+    // takes precedence over webhook_url_env_var.
+    string webhook_url = 1;
+
+    // The environment variable that is used to contain the Teams webhook URL.
+    string webhook_url_env_var = 2; // Default: TEAMS_WEBHOOK_URL;
+}
+
 message NotifyConfig {
     // Command to run when alert is fired. You can use this command to do
     // various things, e.g.:
@@ -137,6 +149,9 @@ message NotifyConfig {
 
     // Opsgenie configuration.
     Opsgenie opsgenie = 14;
+
+    // Microsoft Teams configuration.
+    Teams teams = 15;
 
     // Notify using an HTTP request. HTTP request fields are expanded using the
     // same template expansion rules as "command" above:


### PR DESCRIPTION
## Summary

This PR adds support for Microsoft Teams notifications.

It introduces a `teams` notification config block, similar to the existing `slack` notifier, allowing alert notifications to be sent to a Microsoft Teams Incoming Webhook.

## What changed

- Added a new `Teams` message to `internal/alerting/proto/config.proto`
- Regenerated `internal/alerting/proto/config.pb.go`
- Added a new notifier implementation under `internal/alerting/notifier/teams`
- Integrated the Teams notifier into the main alert notifier
- Added unit tests for Teams notifier config resolution, payload generation, and HTTP request handling

## Testing

Verified with:

```bash
go test ./internal/alerting/notifier/teams ./internal/alerting/notifier
```

Also validated locally against a Microsoft Teams Incoming Webhook:

1. Create `teams-test.cfg`

```cfg
probe {
  name: "teams-test"
  type: HTTP
  targets {
    host_names: "127.0.0.1:8000"
  }
  interval: "10s"
  timeout: "1s"
  alert {
    name: "teams_webhook_test"
    condition {
      failures: 1
    }
    notify {
      teams {
        webhook_url: "https://..."
      }
    }
  }
}
```

2. Run Cloudprober

```bash
go run ./cmd/cloudprober --config_file teams-test.cfg
```

3. Verify the message in the Microsoft Teams channel:

<img width="829" height="284" alt="image" src="https://github.com/user-attachments/assets/f20b6118-a19b-4da1-b5da-00828bc89017" />

## Notes

- This implementation is intentionally minimal and follows the existing notifier pattern used by Slack.
- The Teams payload uses an Adaptive Card rather than a plain text payload, since the Microsoft Teams Incoming Webhook endpoint expects card-based message content.