### PR TITLE
fix(config): check scanner.Err() after handleIncludes loop

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -127,6 +127,10 @@ func handleIncludes(baseDir string, content []byte) (string, error) {
 		}
 	}
 
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error reading config content: %w", err)
+	}
+
 	newline := "\n"
 	if runtime.GOOS == "windows" {
 		newline = "\r\n"


### PR DESCRIPTION
## Description

`handleIncludes` in `config/config.go` uses a `bufio.Scanner` to iterate over config file lines, but never checks `scanner.Err()` after the scan loop. When a line exceeds `bufio.MaxScanTokenSize` (64KiB), the scanner silently stops — `Scan()` returns false and the remaining content is discarded with no error surfaced.

This affects machine-generated config files (e.g., output from `.String()` on `ProberConfig`) where all configuration is on a single line. Once the config grows past ~60 probes, the line exceeds 64KiB, the scanner stops, and Cloudprober starts with zero probes — with no error in the logs.

## Fix

Add `scanner.Err()` check after the scan loop:

```go
if err := scanner.Err(); err != nil {
    return "", fmt.Errorf("error reading config content: %w", err)
}
```

This surfaces the error (typically `bufio.ErrTooLong`) instead of silently producing an incomplete config.

Fixes #1355
