### PR TITLE
[probes.starlark] Add jwt.encode builtin for JWT-bearer APIs

### DIFF
--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -232,8 +232,8 @@ exchange -- such as Google service-account JWTs or Snowflake's key-pair auth.
   only to the same value as `algorithm` -- a conflicting `alg` is an error, so
   the header can never disagree with how the token is actually signed.
 
-Signing a JWT each run is cheap, but if you probe frequently you can cache the
-token in `state` and re-mint periodically.
+Signing a JWT each run is cheap (sub-millisecond), so minting one per run is
+the simplest approach and what these examples do.
 
 Probe a Google API with a service-account self-signed JWT (full example in
 [examples/starlark/gcp_jwt.star](https://github.com/cloudprober/cloudprober/tree/master/examples/starlark/gcp_jwt.star)):

--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -121,6 +121,7 @@ All scripts get a small, fixed set of builtins. No filesystem, network beyond
 | `assert.http_status(response, expected)` | Fails the probe if `response.status != expected`. Stamp per-call context onto the failure log line with `log.set_attr` instead of inlining it into the error message. |
 | `vars.get(name, default=None)` | Read values from the probe's `vars` config map (see below). |
 | `state.get(key, default=None)` / `state.set(key, value)` | Per-target key-value store that persists across runs (see below). |
+| `jwt.encode(payload, key, algorithm="RS256", headers=None, lifetime=60)` | Mint and sign a JWT for APIs that take a self-signed token as the bearer credential -- Google service-account JWTs, Snowflake key-pair auth (see below). |
 | `log.info(msg)` / `log.warn(msg)` / `log.error(msg)` / `log.debug(msg)` | Route a message to Cloudprober's logger with the probe's `target` attribute attached. |
 | `log.set_attr(key, value)` | Add a sticky attribute to this run's logger. All subsequent `log.*` calls *and* the probe-failure log line Cloudprober writes if the script errors out (network timeout, assertion failure, etc.) carry it. Cleared at the end of the run. Useful for stamping `req_id` or other per-run context onto failure logs. |
 | `print_metric(line)` | Emit a custom metric line (see below). |
@@ -213,6 +214,49 @@ def probe(target):
 
 The bucket lives only as long as the target does: when a target disappears
 from discovery, its state is dropped. Each bucket holds up to 1024 keys.
+
+### `jwt`
+
+`jwt.encode(payload, key, algorithm="RS256", headers=None, lifetime=60)` mints
+and signs a JWT and returns the compact token string. Use it for APIs that
+accept a self-signed JWT directly as the bearer credential -- no OAuth token
+exchange -- such as Google service-account JWTs or Snowflake's key-pair auth.
+
+- `payload`: dict of claims. `iat` and `exp` are filled in from `lifetime`
+  (seconds) when the payload omits them, since scripts have no clock; an
+  explicit `iat`/`exp` in the payload wins.
+- `key`: the signing key. For `RS256` (default) this is a PEM-encoded RSA
+  private key (PKCS#1 or PKCS#8), typically loaded through `vars`; for `HS256`
+  it is the shared secret.
+- `headers`: extra JOSE header fields, e.g. `{"kid": ...}`. It may set `alg`
+  only to the same value as `algorithm` -- a conflicting `alg` is an error, so
+  the header can never disagree with how the token is actually signed.
+
+Signing a JWT each run is cheap, but if you probe frequently you can cache the
+token in `state` and re-mint periodically.
+
+Probe a Google API with a service-account self-signed JWT (full example in
+[examples/starlark/gcp_jwt.star](https://github.com/cloudprober/cloudprober/tree/master/examples/starlark/gcp_jwt.star)):
+
+```python
+def probe(target):
+    email = vars.get("sa_email")
+    token = jwt.encode(
+        {"iss": email, "sub": email, "aud": "https://storage.googleapis.com/"},
+        vars.get("sa_private_key"),
+        headers = {"kid": vars.get("sa_private_key_id")},
+        lifetime = 3600,
+    )
+    r = http.get(
+        url = "https://storage.googleapis.com/storage/v1/b?project=%s" % vars.get("project"),
+        headers = {"Authorization": "Bearer " + token},
+    )
+    assert.http_status(r, 200)
+```
+
+Load the service-account key material into `vars` from the JSON key file's
+`client_email`, `private_key`, and `private_key_id` fields (see
+[gcp_jwt.cfg](https://github.com/cloudprober/cloudprober/tree/master/examples/starlark/gcp_jwt.cfg)).
 
 ## Custom metrics with `print_metric`
 

--- a/examples/starlark/gcp_jwt.cfg
+++ b/examples/starlark/gcp_jwt.cfg
@@ -20,15 +20,8 @@ probe {
   starlark_probe {
     source_file: "examples/starlark/gcp_jwt.star"
     vars { key: "sa_email" value: "{{ envVar \"GCP_SA_EMAIL\" }}" }
-    vars { key: "sa_private_key" value: "{{ envVar \"GCP_SA_PRIVATE_KEY\" }}" }
+    vars { key: "sa_private_key" value: "{{ envSecret \"GCP_SA_PRIVATE_KEY\" }}" }
     vars { key: "sa_private_key_id" value: "{{ envVar \"GCP_SA_PRIVATE_KEY_ID\" }}" }
     vars { key: "project" value: "{{ envVar \"GCP_PROJECT\" }}" }
-  }
-}
-
-surfacer {
-  type: FILE
-  file_surfacer {
-    file_path: "/tmp/cloudprober-gcp-jwt.metrics"
   }
 }

--- a/examples/starlark/gcp_jwt.cfg
+++ b/examples/starlark/gcp_jwt.cfg
@@ -19,9 +19,9 @@ probe {
   timeout_msec: 10000
   starlark_probe {
     source_file: "examples/starlark/gcp_jwt.star"
-    vars { key: "sa_email" value: "{{ envVar \"GCP_SA_EMAIL\" }}" }
-    vars { key: "sa_private_key" value: "{{ envSecret \"GCP_SA_PRIVATE_KEY\" }}" }
-    vars { key: "sa_private_key_id" value: "{{ envVar \"GCP_SA_PRIVATE_KEY_ID\" }}" }
-    vars { key: "project" value: "{{ envVar \"GCP_PROJECT\" }}" }
+    vars { key: "sa_email" value: "{{ env "GCP_SA_EMAIL" }}" }
+    vars { key: "sa_private_key" value: "{{ envSecret "GCP_SA_PRIVATE_KEY" }}" }
+    vars { key: "sa_private_key_id" value: "{{ env "GCP_SA_PRIVATE_KEY_ID" }}" }
+    vars { key: "project" value: "{{ env "GCP_PROJECT" }}" }
   }
 }

--- a/examples/starlark/gcp_jwt.cfg
+++ b/examples/starlark/gcp_jwt.cfg
@@ -1,0 +1,34 @@
+# Illustrative config for gcp_jwt.star -- talks to real Google APIs, so it
+# needs a real service-account key (unlike cloudprober.cfg, which runs against
+# the local mock_server.go).
+#
+# Load the three fields from the service-account JSON key file into env vars,
+# e.g. with jq, before starting cloudprober:
+#   export GCP_SA_EMAIL=$(jq -r .client_email key.json)
+#   export GCP_SA_PRIVATE_KEY=$(jq -r .private_key key.json)
+#   export GCP_SA_PRIVATE_KEY_ID=$(jq -r .private_key_id key.json)
+#   export GCP_PROJECT=my-project
+
+probe {
+  name: "gcp_storage_jwt"
+  type: STARLARK
+  targets {
+    dummy_targets {}  # No network target; the script picks its own URL.
+  }
+  interval_msec: 30000
+  timeout_msec: 10000
+  starlark_probe {
+    source_file: "examples/starlark/gcp_jwt.star"
+    vars { key: "sa_email" value: "{{ envVar \"GCP_SA_EMAIL\" }}" }
+    vars { key: "sa_private_key" value: "{{ envVar \"GCP_SA_PRIVATE_KEY\" }}" }
+    vars { key: "sa_private_key_id" value: "{{ envVar \"GCP_SA_PRIVATE_KEY_ID\" }}" }
+    vars { key: "project" value: "{{ envVar \"GCP_PROJECT\" }}" }
+  }
+}
+
+surfacer {
+  type: FILE
+  file_surfacer {
+    file_path: "/tmp/cloudprober-gcp-jwt.metrics"
+  }
+}

--- a/examples/starlark/gcp_jwt.star
+++ b/examples/starlark/gcp_jwt.star
@@ -1,0 +1,40 @@
+# Probe a Google API using a service-account *self-signed JWT*.
+#
+# For Google APIs you can skip the OAuth token exchange entirely: mint a JWT
+# signed with the service account's private key and send it directly as the
+# Bearer credential. Google validates it against the account's public key, so
+# there is no round-trip to a token endpoint.
+#
+# The service-account key material is passed in via `vars` (from the JSON key
+# file's `client_email`, `private_key`, and `private_key_id` fields -- see
+# gcp_jwt.cfg). This check lists the Cloud Storage buckets for a project, which
+# succeeds only if the token authenticates.
+#
+# Unlike the trading_api example, this one talks to real Google endpoints and
+# needs real credentials -- it is illustrative, not part of the mock demo.
+
+def probe(target):
+    sa_email = vars.get("sa_email")
+
+    # aud scopes the token to an API; for a self-signed JWT it is the service's
+    # base URL. iat/exp are filled in from lifetime (max 1h for Google).
+    claims = {
+        "iss": sa_email,
+        "sub": sa_email,
+        "aud": "https://storage.googleapis.com/",
+    }
+
+    # kid (the key's private_key_id) lets Google pick the right public key.
+    token = jwt.encode(
+        claims,
+        vars.get("sa_private_key"),
+        headers = {"kid": vars.get("sa_private_key_id")},
+        lifetime = 3600,
+    )
+
+    r = http.get(
+        url = "https://storage.googleapis.com/storage/v1/b?project=%s" % vars.get("project"),
+        headers = {"Authorization": "Bearer " + token},
+    )
+    assert.http_status(r, 200)
+    print("buckets: %d" % len(r.json().get("items", [])))

--- a/probes/starlark/builtins.go
+++ b/probes/starlark/builtins.go
@@ -30,6 +30,7 @@ func builtins(vars map[string]string) starlarklib.StringDict {
 		"vars":         varsModule(vars),
 		"log":          logModule(),
 		"state":        stateModule(),
+		"jwt":          jwtModule(),
 		"print_metric": starlarklib.NewBuiltin("print_metric", printMetric),
 	}
 }

--- a/probes/starlark/builtins_jwt.go
+++ b/probes/starlark/builtins_jwt.go
@@ -1,0 +1,183 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package starlark
+
+import (
+	"crypto"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"time"
+
+	starlarklib "go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+// jwt.encode(payload, key, algorithm="RS256", headers=None, lifetime=60) mints
+// and signs a compact-serialization JWT. It exists for APIs that take a
+// self-signed JWT directly as the bearer credential — Snowflake's SQL REST API
+// key-pair auth is the driving case, GCP service-account JWTs are the other.
+// It is deliberately not part of the oauth module: there is no token exchange
+// here, the script signs its own short-lived token and sends it.
+//
+// The private key (for RS*) comes in as a PEM string, typically via the vars
+// module, e.g. jwt.encode(claims, vars.get("sf_private_key")). Scripts have no
+// clock, so iat/exp are filled in from lifetime unless the payload sets them
+// (see jwtEncode). Cache the result across runs with the state builtin rather
+// than re-signing every run — Snowflake tokens are valid up to an hour.
+//
+//	def probe(target):
+//	    q = vars.get("sf_account") + "." + vars.get("sf_user")   # UPPERCASE
+//	    claims = {"iss": q + "." + vars.get("sf_pubkey_fp"), "sub": q}
+//	    tok = jwt.encode(claims, vars.get("sf_private_key"), lifetime=3600)
+//	    r = http.post(url, headers={"Authorization": "Bearer " + tok})
+
+func jwtModule() *starlarkstruct.Module {
+	return &starlarkstruct.Module{
+		Name: "jwt",
+		Members: starlarklib.StringDict{
+			"encode": starlarklib.NewBuiltin("jwt.encode", jwtEncode),
+		},
+	}
+}
+
+func jwtEncode(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
+	var payloadV starlarklib.Value
+	var key string
+	alg := "RS256"
+	var headersV starlarklib.Value = starlarklib.None
+	lifetime := 60
+	if err := starlarklib.UnpackArgs("jwt.encode", args, kwargs,
+		"payload", &payloadV,
+		"key", &key,
+		"algorithm?", &alg,
+		"headers?", &headersV,
+		"lifetime?", &lifetime,
+	); err != nil {
+		return nil, err
+	}
+
+	claims, err := jwtDict(payloadV, "payload")
+	if err != nil {
+		return nil, err
+	}
+	// Scripts have no clock, so fill the time claims here. Anything the payload
+	// already sets wins — an explicit iat/exp is never overwritten.
+	now := time.Now().Unix()
+	if _, ok := claims["iat"]; !ok {
+		claims["iat"] = now
+	}
+	if lifetime > 0 {
+		if _, ok := claims["exp"]; !ok {
+			claims["exp"] = now + int64(lifetime)
+		}
+	}
+
+	header := map[string]interface{}{"alg": alg, "typ": "JWT"}
+	if headersV != starlarklib.None {
+		extra, err := jwtDict(headersV, "headers")
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range extra {
+			header[k] = v
+		}
+	}
+
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return nil, fmt.Errorf("jwt.encode: marshaling header: %v", err)
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return nil, fmt.Errorf("jwt.encode: marshaling payload: %v", err)
+	}
+
+	signingInput := jwtBase64(headerJSON) + "." + jwtBase64(claimsJSON)
+	sig, err := jwtSign(alg, []byte(signingInput), key)
+	if err != nil {
+		return nil, fmt.Errorf("jwt.encode: %v", err)
+	}
+	return starlarklib.String(signingInput + "." + jwtBase64(sig)), nil
+}
+
+// jwtDict converts a Starlark dict argument to a Go map via the shared
+// starlarkToGo, rejecting anything that isn't a dict.
+func jwtDict(v starlarklib.Value, name string) (map[string]interface{}, error) {
+	g, err := starlarkToGo(v)
+	if err != nil {
+		return nil, fmt.Errorf("jwt.encode: %s: %v", name, err)
+	}
+	m, ok := g.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("jwt.encode: %s must be a dict, got %s", name, v.Type())
+	}
+	return m, nil
+}
+
+func jwtBase64(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// jwtSign signs signingInput for the given JOSE alg. RS256 (RSA-PKCS1v15 +
+// SHA-256) is the Snowflake/GCP case; HS256 (HMAC-SHA256) is the shared-secret
+// companion. Add more alg entries here as concrete APIs need them.
+func jwtSign(alg string, signingInput []byte, key string) ([]byte, error) {
+	switch alg {
+	case "RS256":
+		priv, err := jwtParseRSAKey(key)
+		if err != nil {
+			return nil, err
+		}
+		h := sha256.Sum256(signingInput)
+		return rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA256, h[:])
+	case "HS256":
+		mac := hmac.New(sha256.New, []byte(key))
+		mac.Write(signingInput)
+		return mac.Sum(nil), nil
+	default:
+		return nil, fmt.Errorf("unsupported algorithm %q (supported: RS256, HS256)", alg)
+	}
+}
+
+func jwtParseRSAKey(pemStr string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in key")
+	}
+	if block.Type == "ENCRYPTED PRIVATE KEY" {
+		return nil, fmt.Errorf("encrypted private keys are not supported; provide an unencrypted PEM")
+	}
+	// Snowflake keys are usually PKCS#8 (openssl genpkey); older tooling emits
+	// PKCS#1. Try both.
+	if k, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return k, nil
+	}
+	k, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing RSA private key (tried PKCS1 and PKCS8): %v", err)
+	}
+	rsaKey, ok := k.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("key is %T, want an RSA private key for RS256", k)
+	}
+	return rsaKey, nil
+}

--- a/probes/starlark/builtins_jwt.go
+++ b/probes/starlark/builtins_jwt.go
@@ -33,22 +33,22 @@ import (
 
 // jwt.encode(payload, key, algorithm="RS256", headers=None, lifetime=60) mints
 // and signs a compact-serialization JWT. It exists for APIs that take a
-// self-signed JWT directly as the bearer credential — Snowflake's SQL REST API
-// key-pair auth is the driving case, GCP service-account JWTs are the other.
-// It is deliberately not part of the oauth module: there is no token exchange
-// here, the script signs its own short-lived token and sends it.
+// self-signed JWT directly as the bearer credential — Google service-account
+// JWTs are the driving case, Snowflake's SQL REST API key-pair auth is the
+// other. It is deliberately not part of the oauth module: there is no token
+// exchange here, the script signs its own short-lived token and sends it.
 //
 // The private key (for RS*) comes in as a PEM string, typically via the vars
-// module, e.g. jwt.encode(claims, vars.get("sf_private_key")). Scripts have no
+// module, e.g. jwt.encode(claims, vars.get("sa_private_key")). Scripts have no
 // clock, so iat/exp are filled in from lifetime unless the payload sets them
-// (see jwtEncode). Cache the result across runs with the state builtin rather
-// than re-signing every run — Snowflake tokens are valid up to an hour.
+// (see jwtEncode).
 //
 //	def probe(target):
-//	    q = vars.get("sf_account") + "." + vars.get("sf_user")   # UPPERCASE
-//	    claims = {"iss": q + "." + vars.get("sf_pubkey_fp"), "sub": q}
-//	    tok = jwt.encode(claims, vars.get("sf_private_key"), lifetime=3600)
-//	    r = http.post(url, headers={"Authorization": "Bearer " + tok})
+//	    email = vars.get("sa_email")
+//	    claims = {"iss": email, "sub": email, "aud": "https://storage.googleapis.com/"}
+//	    tok = jwt.encode(claims, vars.get("sa_private_key"),
+//	                     headers={"kid": vars.get("sa_private_key_id")}, lifetime=3600)
+//	    r = http.get(url, headers={"Authorization": "Bearer " + tok})
 
 func jwtModule() *starlarkstruct.Module {
 	return &starlarkstruct.Module{

--- a/probes/starlark/builtins_jwt.go
+++ b/probes/starlark/builtins_jwt.go
@@ -79,14 +79,15 @@ func jwtEncode(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.T
 	if err != nil {
 		return nil, err
 	}
-	// Scripts have no clock, so fill the time claims here. Anything the payload
-	// already sets wins — an explicit iat/exp is never overwritten.
+	// Scripts have no clock, so fill the time claims here. An explicit
+	// (non-None) iat/exp in the payload wins; a None value counts as unset, so
+	// `exp = None` still gets a default rather than serializing as null.
 	now := time.Now().Unix()
-	if _, ok := claims["iat"]; !ok {
+	if v, ok := claims["iat"]; !ok || v == nil {
 		claims["iat"] = now
 	}
 	if lifetime > 0 {
-		if _, ok := claims["exp"]; !ok {
+		if v, ok := claims["exp"]; !ok || v == nil {
 			claims["exp"] = now + int64(lifetime)
 		}
 	}
@@ -96,6 +97,11 @@ func jwtEncode(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.T
 		extra, err := jwtDict(headersV, "headers")
 		if err != nil {
 			return nil, err
+		}
+		// A header alg must never disagree with the algorithm we actually sign
+		// with. An explicit matching alg is fine; a mismatch is an error.
+		if a, ok := extra["alg"]; ok && a != alg {
+			return nil, fmt.Errorf("jwt.encode: headers[\"alg\"]=%v conflicts with algorithm=%q", a, alg)
 		}
 		for k, v := range extra {
 			header[k] = v

--- a/probes/starlark/builtins_jwt_test.go
+++ b/probes/starlark/builtins_jwt_test.go
@@ -192,6 +192,48 @@ func TestJWTEncode_CustomHeaders(t *testing.T) {
 	assert.Equal(t, "RS256", header["alg"])
 }
 
+// TestJWTEncode_HeaderAlg covers the alg-in-headers rule: a matching explicit
+// alg is allowed, a mismatching one is rejected (header must not lie about the
+// signing algorithm).
+func TestJWTEncode_HeaderAlg(t *testing.T) {
+	keyPEM, _ := genRSAKeyPEM(t)
+	sub := dict(t, map[string]starlarklib.Value{"sub": starlarklib.String("x")})
+
+	// Matching alg is fine.
+	token, err := callJWTEncode(t, sub, keyPEM,
+		starlarklib.Tuple{starlarklib.String("headers"), dict(t, map[string]starlarklib.Value{
+			"alg": starlarklib.String("RS256"),
+		})})
+	require.NoError(t, err)
+	header, _, _, _ := decodeJWT(t, token)
+	assert.Equal(t, "RS256", header["alg"])
+
+	// Mismatching alg is rejected.
+	_, err = callJWTEncode(t, sub, keyPEM,
+		starlarklib.Tuple{starlarklib.String("headers"), dict(t, map[string]starlarklib.Value{
+			"alg": starlarklib.String("none"),
+		})})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicts with algorithm")
+}
+
+// TestJWTEncode_NoneTimeClaim pins that an explicit None iat/exp is treated as
+// unset and auto-filled, not serialized as JSON null.
+func TestJWTEncode_NoneTimeClaim(t *testing.T) {
+	keyPEM, _ := genRSAKeyPEM(t)
+	token, err := callJWTEncode(t, dict(t, map[string]starlarklib.Value{
+		"sub": starlarklib.String("x"),
+		"exp": starlarklib.None,
+		"iat": starlarklib.None,
+	}), keyPEM, starlarklib.Tuple{starlarklib.String("lifetime"), starlarklib.MakeInt(3600)})
+	require.NoError(t, err)
+
+	_, claims, _, _ := decodeJWT(t, token)
+	require.NotNil(t, claims["exp"], "exp should be auto-filled, not null")
+	require.NotNil(t, claims["iat"], "iat should be auto-filled, not null")
+	assert.Equal(t, int64(claims["iat"].(float64))+3600, int64(claims["exp"].(float64)))
+}
+
 func TestJWTEncode_Errors(t *testing.T) {
 	keyPEM, _ := genRSAKeyPEM(t)
 	sub := dict(t, map[string]starlarklib.Value{"sub": starlarklib.String("x")})

--- a/probes/starlark/builtins_jwt_test.go
+++ b/probes/starlark/builtins_jwt_test.go
@@ -1,0 +1,252 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package starlark
+
+import (
+	"crypto"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cloudprober/cloudprober/probes/common/sched"
+	configpb "github.com/cloudprober/cloudprober/probes/starlark/proto"
+	"github.com/cloudprober/cloudprober/targets/endpoint"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	starlarklib "go.starlark.net/starlark"
+)
+
+// callJWTEncode invokes the jwt.encode builtin directly (it needs no
+// thread-locals) and returns the token string.
+func callJWTEncode(t *testing.T, payload *starlarklib.Dict, key string, kwargs ...starlarklib.Tuple) (string, error) {
+	t.Helper()
+	v, err := jwtEncode(nil, nil, starlarklib.Tuple{payload, starlarklib.String(key)}, kwargs)
+	if err != nil {
+		return "", err
+	}
+	s, ok := starlarklib.AsString(v)
+	require.True(t, ok, "jwt.encode returned non-string %s", v.Type())
+	return s, nil
+}
+
+// decodeJWT splits a compact JWT and returns the parsed header, parsed claims,
+// the signing input, and the raw signature bytes.
+func decodeJWT(t *testing.T, token string) (header, claims map[string]interface{}, signingInput string, sig []byte) {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3, "JWT must have 3 dot-separated parts")
+
+	hb, err := base64.RawURLEncoding.DecodeString(parts[0])
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(hb, &header))
+
+	cb, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(cb, &claims))
+
+	sig, err = base64.RawURLEncoding.DecodeString(parts[2])
+	require.NoError(t, err)
+
+	return header, claims, parts[0] + "." + parts[1], sig
+}
+
+func dict(t *testing.T, kv map[string]starlarklib.Value) *starlarklib.Dict {
+	t.Helper()
+	d := starlarklib.NewDict(len(kv))
+	for k, v := range kv {
+		require.NoError(t, d.SetKey(starlarklib.String(k), v))
+	}
+	return d
+}
+
+func genRSAKeyPEM(t *testing.T) (string, *rsa.PublicKey) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	return string(pemBytes), &priv.PublicKey
+}
+
+// TestJWTEncode_RS256 signs with an RSA key and verifies the signature and
+// header round-trips end to end — this is the Snowflake path.
+func TestJWTEncode_RS256(t *testing.T) {
+	keyPEM, pub := genRSAKeyPEM(t)
+	payload := dict(t, map[string]starlarklib.Value{
+		"iss": starlarklib.String("ACCT.USER.SHA256:abc"),
+		"sub": starlarklib.String("ACCT.USER"),
+	})
+
+	token, err := callJWTEncode(t, payload, keyPEM)
+	require.NoError(t, err)
+
+	header, claims, signingInput, sig := decodeJWT(t, token)
+	assert.Equal(t, "RS256", header["alg"])
+	assert.Equal(t, "JWT", header["typ"])
+	assert.Equal(t, "ACCT.USER.SHA256:abc", claims["iss"])
+	assert.Equal(t, "ACCT.USER", claims["sub"])
+
+	h := sha256.Sum256([]byte(signingInput))
+	assert.NoError(t, rsa.VerifyPKCS1v15(pub, crypto.SHA256, h[:], sig),
+		"signature must verify against the public key")
+}
+
+// TestJWTEncode_PKCS1Key checks that a legacy PKCS#1 ("RSA PRIVATE KEY") PEM
+// works too, not just PKCS#8.
+func TestJWTEncode_PKCS1Key(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(priv),
+	})
+	payload := dict(t, map[string]starlarklib.Value{"sub": starlarklib.String("x")})
+
+	token, err := callJWTEncode(t, payload, string(pemBytes))
+	require.NoError(t, err)
+
+	_, _, signingInput, sig := decodeJWT(t, token)
+	h := sha256.Sum256([]byte(signingInput))
+	assert.NoError(t, rsa.VerifyPKCS1v15(&priv.PublicKey, crypto.SHA256, h[:], sig))
+}
+
+// TestJWTEncode_HS256 signs with a shared secret and verifies the HMAC.
+func TestJWTEncode_HS256(t *testing.T) {
+	secret := "s3cret"
+	payload := dict(t, map[string]starlarklib.Value{"sub": starlarklib.String("alice")})
+
+	token, err := callJWTEncode(t, payload, secret,
+		starlarklib.Tuple{starlarklib.String("algorithm"), starlarklib.String("HS256")})
+	require.NoError(t, err)
+
+	header, _, signingInput, sig := decodeJWT(t, token)
+	assert.Equal(t, "HS256", header["alg"])
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(signingInput))
+	assert.True(t, hmac.Equal(sig, mac.Sum(nil)), "HMAC must verify")
+}
+
+// TestJWTEncode_AutoFillsTimeClaims covers the clock behavior: iat/exp are
+// filled from lifetime when absent, and an explicit exp is left untouched.
+func TestJWTEncode_AutoFillsTimeClaims(t *testing.T) {
+	keyPEM, _ := genRSAKeyPEM(t)
+
+	before := time.Now().Unix()
+	token, err := callJWTEncode(t, dict(t, map[string]starlarklib.Value{"sub": starlarklib.String("x")}), keyPEM,
+		starlarklib.Tuple{starlarklib.String("lifetime"), starlarklib.MakeInt(3600)})
+	require.NoError(t, err)
+	after := time.Now().Unix()
+
+	_, claims, _, _ := decodeJWT(t, token)
+	iat := int64(claims["iat"].(float64))
+	exp := int64(claims["exp"].(float64))
+	assert.GreaterOrEqual(t, iat, before)
+	assert.LessOrEqual(t, iat, after)
+	assert.Equal(t, iat+3600, exp, "exp should be iat + lifetime")
+
+	// Explicit exp/iat in the payload must win over auto-fill.
+	token2, err := callJWTEncode(t, dict(t, map[string]starlarklib.Value{
+		"sub": starlarklib.String("x"),
+		"iat": starlarklib.MakeInt(1000),
+		"exp": starlarklib.MakeInt(2000),
+	}), keyPEM)
+	require.NoError(t, err)
+	_, claims2, _, _ := decodeJWT(t, token2)
+	assert.Equal(t, int64(1000), int64(claims2["iat"].(float64)))
+	assert.Equal(t, int64(2000), int64(claims2["exp"].(float64)))
+}
+
+// TestJWTEncode_CustomHeaders checks that extra JOSE header fields (e.g. kid)
+// merge in and can override typ.
+func TestJWTEncode_CustomHeaders(t *testing.T) {
+	keyPEM, _ := genRSAKeyPEM(t)
+	token, err := callJWTEncode(t, dict(t, map[string]starlarklib.Value{"sub": starlarklib.String("x")}), keyPEM,
+		starlarklib.Tuple{starlarklib.String("headers"), dict(t, map[string]starlarklib.Value{
+			"kid": starlarklib.String("key-1"),
+		})})
+	require.NoError(t, err)
+	header, _, _, _ := decodeJWT(t, token)
+	assert.Equal(t, "key-1", header["kid"])
+	assert.Equal(t, "RS256", header["alg"])
+}
+
+func TestJWTEncode_Errors(t *testing.T) {
+	keyPEM, _ := genRSAKeyPEM(t)
+	sub := dict(t, map[string]starlarklib.Value{"sub": starlarklib.String("x")})
+
+	t.Run("bad algorithm", func(t *testing.T) {
+		_, err := callJWTEncode(t, sub, keyPEM,
+			starlarklib.Tuple{starlarklib.String("algorithm"), starlarklib.String("XX999")})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported algorithm")
+	})
+
+	t.Run("not a PEM key", func(t *testing.T) {
+		_, err := callJWTEncode(t, sub, "not-a-pem")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no PEM block")
+	})
+
+	t.Run("payload not a dict", func(t *testing.T) {
+		_, err := jwtEncode(nil, nil,
+			starlarklib.Tuple{starlarklib.String("nope"), starlarklib.String(keyPEM)}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "payload must be a dict")
+	})
+}
+
+// TestJWTEncode_InScript runs the builtin through a real script, exercising the
+// registration and the vars-supplied key path (the Snowflake shape).
+func TestJWTEncode_InScript(t *testing.T) {
+	keyPEM, pub := genRSAKeyPEM(t)
+	source := `
+def probe(target):
+    q = vars.get("account") + "." + vars.get("user")
+    claims = {"iss": q + "." + vars.get("fp"), "sub": q}
+    tok = jwt.encode(claims, vars.get("key"), lifetime=3600)
+    state.set("token", tok)
+`
+	opts := newOpts(t, "example.com", source)
+	opts.ProbeConf.(*configpb.ProbeConf).Vars = map[string]string{
+		"account": "ACCT",
+		"user":    "USER",
+		"fp":      "SHA256:abc",
+		"key":     keyPEM,
+	}
+	p := &Probe{}
+	require.NoError(t, p.Init("script-jwt", opts))
+
+	runReq := &sched.RunProbeForTargetRequest{Target: endpoint.Endpoint{Name: "example.com"}}
+	runProbeWith(t, p, runReq)
+	require.NoError(t, runReq.LastRun.Error)
+
+	bucket := runReq.TargetState.(*stateBucket)
+	token := bucket.values["token"].(string)
+	header, claims, signingInput, sig := decodeJWT(t, token)
+	assert.Equal(t, "RS256", header["alg"])
+	assert.Equal(t, "ACCT.USER.SHA256:abc", claims["iss"])
+	h := sha256.Sum256([]byte(signingInput))
+	assert.NoError(t, rsa.VerifyPKCS1v15(pub, crypto.SHA256, h[:], sig))
+}


### PR DESCRIPTION
## Summary
- Adds `jwt.encode(payload, key, algorithm="RS256", headers=None, lifetime=60)` to the Starlark probe, so scripts can mint self-signed JWTs and hit JWT-bearer APIs (Snowflake SQL REST API key-pair auth, GCP service-account JWTs) with the existing `http` builtin.
- RS256 (RSA, PKCS#1 or PKCS#8 PEM) and HS256 (HMAC). `iat`/`exp` filled from `lifetime` when absent. No proto change — the key comes in via `vars`.

## Test plan
- `go test ./probes/starlark/` — new `builtins_jwt_test.go` verifies RS256/HS256 signatures, PKCS#1 keys, time-claim auto-fill, custom headers, error paths, and an end-to-end script run.