### PR TITLE
[external.serverutils]: fix late-binding closure bug and logging.error bug in serverutils.serve()

### DIFF
--- a/probes/external/serverutils/py/src/cloudprober/external/serverutils.py
+++ b/probes/external/serverutils/py/src/cloudprober/external/serverutils.py
@@ -158,21 +158,21 @@ def serve(probe_func: Callable, stdin=sys.stdin.buffer, stdout=sys.stdout.buffer
             if request is None:
                 sys.exit(1)
             
-            def handle_request():
+            def handle_request(req):
                 reply = serverpb.ProbeReply()
-                reply.request_id = request.request_id
+                reply.request_id = req.request_id
                 done = threading.Event()
-                timeout = time.time() + request.time_limit / 1000
+                timeout = time.time() + req.time_limit / 1000.0
 
-                def probe():
-                    probe_func(request, reply)
+                def probe(req=req, reply=reply):
+                    probe_func(req, reply)
                     done.set()
 
                 threading.Thread(target=probe, daemon=True).start()
 
-                if done.wait(timeout - time.time()):
+                if done.wait(max(0.0, timeout - time.time())):
                     replies_queue.put(reply)
                 else:
-                    logging.error(f"Timeout for request {reply.request_id}", file=stderr)
+                    print(f"Timeout for request {reply.request_id}", file=stderr)
 
-            threading.Thread(target=handle_request, daemon=True).start()
+            threading.Thread(target=handle_request, args=(request,), daemon=True).start()

--- a/probes/external/serverutils/py/src/cloudprober/external/serverutils.py
+++ b/probes/external/serverutils/py/src/cloudprober/external/serverutils.py
@@ -162,7 +162,7 @@ def serve(probe_func: Callable, stdin=sys.stdin.buffer, stdout=sys.stdout.buffer
                 reply = serverpb.ProbeReply()
                 reply.request_id = req.request_id
                 done = threading.Event()
-                timeout = time.time() + req.time_limit / 1000.0
+                deadline = time.monotonic() + req.time_limit / 1000.0
 
                 def probe(req=req, reply=reply):
                     probe_func(req, reply)
@@ -170,7 +170,7 @@ def serve(probe_func: Callable, stdin=sys.stdin.buffer, stdout=sys.stdout.buffer
 
                 threading.Thread(target=probe, daemon=True).start()
 
-                if done.wait(max(0.0, timeout - time.time())):
+                if done.wait(max(0.0, deadline - time.monotonic())):
                     replies_queue.put(reply)
                 else:
                     print(f"Timeout for request {reply.request_id}", file=stderr)

--- a/probes/external/serverutils/py/src/cloudprober/external/serverutils.py
+++ b/probes/external/serverutils/py/src/cloudprober/external/serverutils.py
@@ -173,6 +173,6 @@ def serve(probe_func: Callable, stdin=sys.stdin.buffer, stdout=sys.stdout.buffer
                 if done.wait(max(0.0, deadline - time.monotonic())):
                     replies_queue.put(reply)
                 else:
-                    print(f"Timeout for request {reply.request_id}", file=stderr)
+                    print(f"Timeout for request {reply.request_id}", file=stderr, flush=True)
 
             threading.Thread(target=handle_request, args=(request,), daemon=True).start()

--- a/probes/external/serverutils/py/tests/test_serverutils.py
+++ b/probes/external/serverutils/py/tests/test_serverutils.py
@@ -86,6 +86,49 @@ class TestServerUtils(unittest.TestCase):
             self.assertEqual(reply.payload, "Hello, World!")
             time.sleep(1)  # Wait for the serve function to exit
             t.stop = True
+
+    @unittest.skipIf(os.name != "posix", "Skipping test on non-Unix systems")
+    def test_serve_concurrent(self):
+        def probe_func(request, reply):
+            time.sleep(0.02)
+            reply.request_id = request.request_id
+            reply.payload = f"Handled {request.request_id}"
+
+        stdin_read, stdin_write = os.pipe()
+        stdout_read, stdout_write = os.pipe()
+
+        ctx = Context("stop")
+        with open(stdin_read, "rb") as stdin, open(stdout_write, "wb") as stdout:
+            t = ExcThread(target=serve, args=(probe_func, stdin, stdout, io.BytesIO(), ctx), daemon=True)
+            t.start()
+            time.sleep(0.1)
+
+            num_requests = 10
+            requests = []
+            for i in range(num_requests):
+                req = serverpb.ProbeRequest()
+                req.request_id = i
+                req.time_limit = 1000
+                requests.append(req)
+
+            with open(stdin_write, "wb") as w:
+                for req in requests:
+                    _write_message(req, w)
+
+            replies = []
+            with open(stdout_read, "rb") as r:
+                for _ in range(num_requests):
+                    payload = _read_payload(r)
+                    reply = serverpb.ProbeReply()
+                    reply.ParseFromString(payload)
+                    replies.append(reply)
+
+            for reply in replies:
+                expected_payload = f"Handled {reply.request_id}"
+                self.assertEqual(reply.payload, expected_payload)
+
+            t.stop = True
         
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
Fixes #1365 by binding request parameters per iteration/thread start in serve() to avoid late-binding closure issues under concurrency, and fixes unsupported file= parameter in logging.error.