### PR TITLE
[docs/starlark] Fix env template example

### DIFF
--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -194,7 +194,7 @@ def probe(target):
 ```
 
 For host environment values, use Cloudprober's config-loading template layer
-(e.g. `vars { key: "api_key" value: "{{ envVar \"API_KEY\" }}" }`).
+(e.g. `vars { key: "api_key" value: "{{ env "API_KEY" }}" }`).
 
 ### `state`
 


### PR DESCRIPTION
## Summary
- Fix the script-probe docs `vars` example: the config template layer uses sprig's `env`, not `envVar`, and template args need unescaped quotes (`{{ env "API_KEY" }}`). Same bug that broke the example-config CI check on the `jwt.encode` PR.