### PR TITLE
[oauth] Add generic self-signed JWT token source

### DIFF
--- a/common/jwt/jwt.go
+++ b/common/jwt/jwt.go
@@ -1,0 +1,114 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package jwt mints and signs compact-serialization JSON Web Tokens. It is the
+// shared signing core used by the Starlark probe's jwt.encode builtin and the
+// oauth module's self-signed JWT token source.
+package jwt
+
+import (
+	"crypto"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+)
+
+// Encode builds and signs a compact-serialization JWT and returns the token
+// string. alg selects the signature:
+//
+//   - "RS256": RSA PKCS1v15 with SHA-256; key is a PEM-encoded RSA private key
+//     (PKCS#1 or PKCS#8).
+//   - "HS256": HMAC-SHA256; key is the shared secret.
+//
+// header holds extra JOSE header fields, merged over {"alg":alg,"typ":"JWT"};
+// an "alg" present in header must equal alg, so the header can never disagree
+// with how the token is actually signed. Callers own the claim set, including
+// any time claims (iat/exp).
+func Encode(claims, header map[string]any, key, alg string) (string, error) {
+	h := map[string]any{"alg": alg, "typ": "JWT"}
+	if a, ok := header["alg"]; ok && a != alg {
+		return "", fmt.Errorf("header[\"alg\"]=%v conflicts with algorithm=%q", a, alg)
+	}
+	for k, v := range header {
+		h[k] = v
+	}
+
+	headerJSON, err := json.Marshal(h)
+	if err != nil {
+		return "", fmt.Errorf("marshaling header: %v", err)
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("marshaling claims: %v", err)
+	}
+
+	signingInput := b64(headerJSON) + "." + b64(claimsJSON)
+	sig, err := sign(alg, []byte(signingInput), key)
+	if err != nil {
+		return "", err
+	}
+	return signingInput + "." + b64(sig), nil
+}
+
+func b64(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func sign(alg string, signingInput []byte, key string) ([]byte, error) {
+	switch alg {
+	case "RS256":
+		priv, err := parseRSAKey(key)
+		if err != nil {
+			return nil, err
+		}
+		h := sha256.Sum256(signingInput)
+		return rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA256, h[:])
+	case "HS256":
+		mac := hmac.New(sha256.New, []byte(key))
+		mac.Write(signingInput)
+		return mac.Sum(nil), nil
+	default:
+		return nil, fmt.Errorf("unsupported algorithm %q (supported: RS256, HS256)", alg)
+	}
+}
+
+func parseRSAKey(pemStr string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in key")
+	}
+	if block.Type == "ENCRYPTED PRIVATE KEY" {
+		return nil, fmt.Errorf("encrypted private keys are not supported; provide an unencrypted PEM")
+	}
+	// Snowflake/GCP keys are usually PKCS#8 (openssl genpkey); older tooling
+	// emits PKCS#1. Try both.
+	if k, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return k, nil
+	}
+	k, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing RSA private key (tried PKCS1 and PKCS8): %v", err)
+	}
+	rsaKey, ok := k.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("key is %T, want an RSA private key for RS256", k)
+	}
+	return rsaKey, nil
+}

--- a/common/jwt/jwt_test.go
+++ b/common/jwt/jwt_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jwt
+
+import (
+	"crypto"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func genRSAKeyPEM(t *testing.T) (string, *rsa.PublicKey) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})), &priv.PublicKey
+}
+
+func decode(t *testing.T, token string) (header, claims map[string]any, signingInput string, sig []byte) {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+	hb, err := base64.RawURLEncoding.DecodeString(parts[0])
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(hb, &header))
+	cb, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(cb, &claims))
+	sig, err = base64.RawURLEncoding.DecodeString(parts[2])
+	require.NoError(t, err)
+	return header, claims, parts[0] + "." + parts[1], sig
+}
+
+func TestEncode_RS256(t *testing.T) {
+	keyPEM, pub := genRSAKeyPEM(t)
+	token, err := Encode(
+		map[string]any{"iss": "acct.user", "sub": "acct.user"},
+		map[string]any{"kid": "k1"},
+		keyPEM, "RS256")
+	require.NoError(t, err)
+
+	header, claims, signingInput, sig := decode(t, token)
+	assert.Equal(t, "RS256", header["alg"])
+	assert.Equal(t, "JWT", header["typ"])
+	assert.Equal(t, "k1", header["kid"])
+	assert.Equal(t, "acct.user", claims["iss"])
+
+	h := sha256.Sum256([]byte(signingInput))
+	assert.NoError(t, rsa.VerifyPKCS1v15(pub, crypto.SHA256, h[:], sig))
+}
+
+func TestEncode_PKCS1Key(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	keyPEM := string(pem.EncodeToMemory(&pem.Block{
+		Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv),
+	}))
+	token, err := Encode(map[string]any{"sub": "x"}, nil, keyPEM, "RS256")
+	require.NoError(t, err)
+	_, _, signingInput, sig := decode(t, token)
+	h := sha256.Sum256([]byte(signingInput))
+	assert.NoError(t, rsa.VerifyPKCS1v15(&priv.PublicKey, crypto.SHA256, h[:], sig))
+}
+
+func TestEncode_HS256(t *testing.T) {
+	secret := "s3cret"
+	token, err := Encode(map[string]any{"sub": "alice"}, nil, secret, "HS256")
+	require.NoError(t, err)
+	header, _, signingInput, sig := decode(t, token)
+	assert.Equal(t, "HS256", header["alg"])
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(signingInput))
+	assert.True(t, hmac.Equal(sig, mac.Sum(nil)))
+}
+
+func TestEncode_HeaderAlg(t *testing.T) {
+	keyPEM, _ := genRSAKeyPEM(t)
+
+	// Matching alg in header is allowed.
+	_, err := Encode(map[string]any{"sub": "x"}, map[string]any{"alg": "RS256"}, keyPEM, "RS256")
+	require.NoError(t, err)
+
+	// Conflicting alg is rejected.
+	_, err = Encode(map[string]any{"sub": "x"}, map[string]any{"alg": "none"}, keyPEM, "RS256")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicts with algorithm")
+}
+
+func TestEncode_Errors(t *testing.T) {
+	_, err := Encode(map[string]any{"sub": "x"}, nil, "secret", "XX999")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported algorithm")
+
+	_, err = Encode(map[string]any{"sub": "x"}, nil, "not-a-pem", "RS256")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no PEM block")
+}

--- a/common/oauth/jwt_test.go
+++ b/common/oauth/jwt_test.go
@@ -80,6 +80,32 @@ func TestJWTSource(t *testing.T) {
 	assert.NotNil(t, claims["exp"])
 }
 
+// TestJWTSource_ReservedTimeClaims pins that iat/exp in the configured claims
+// are ignored: they're derived from lifetime_sec so they stay in sync with the
+// token's Expiry, and a string value would otherwise produce a spec-invalid exp.
+func TestJWTSource_ReservedTimeClaims(t *testing.T) {
+	cfg := &configpb.Config{
+		Source: &configpb.Config_Jwt{
+			Jwt: &configpb.JWTSource{
+				PrivateKey:  proto.String(rsaKeyPEM(t)),
+				LifetimeSec: proto.Int32(3600),
+				Claims:      map[string]string{"sub": "x", "exp": "not-a-number", "iat": "nope"},
+			},
+		},
+	}
+	ts, err := TokenSourceFromConfig(cfg, &logger.Logger{})
+	require.NoError(t, err)
+	tok, err := ts.Token()
+	require.NoError(t, err)
+
+	claims := jwtClaims(t, tok.AccessToken)
+	// exp/iat must be the numeric derived values, not the user's strings.
+	_, expIsNum := claims["exp"].(float64)
+	_, iatIsNum := claims["iat"].(float64)
+	assert.True(t, expIsNum, "exp must be numeric, got %T", claims["exp"])
+	assert.True(t, iatIsNum, "iat must be numeric, got %T", claims["iat"])
+}
+
 // TestJWTSource_BadKey pins that a bad key fails at construction (verifyToken
 // mints an initial token), so config errors surface early.
 func TestJWTSource_BadKey(t *testing.T) {

--- a/common/oauth/jwt_test.go
+++ b/common/oauth/jwt_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"strings"
+	"testing"
+	"time"
+
+	configpb "github.com/cloudprober/cloudprober/common/oauth/proto"
+	"github.com/cloudprober/cloudprober/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func rsaKeyPEM(t *testing.T) string {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}
+
+func jwtClaims(t *testing.T, token string) map[string]any {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+	cb, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	var claims map[string]any
+	require.NoError(t, json.Unmarshal(cb, &claims))
+	return claims
+}
+
+func TestJWTSource(t *testing.T) {
+	cfg := &configpb.Config{
+		Source: &configpb.Config_Jwt{
+			Jwt: &configpb.JWTSource{
+				PrivateKey:  proto.String(rsaKeyPEM(t)),
+				LifetimeSec: proto.Int32(3600),
+				Claims:      map[string]string{"iss": "acct.user", "sub": "acct.user"},
+				Header:      map[string]string{"kid": "k1"},
+			},
+		},
+	}
+
+	ts, err := TokenSourceFromConfig(cfg, &logger.Logger{})
+	require.NoError(t, err)
+
+	tok, err := ts.Token()
+	require.NoError(t, err)
+	assert.NotEmpty(t, tok.AccessToken)
+	// Expiry is stamped so the cache re-mints before it lapses.
+	assert.WithinDuration(t, time.Now().Add(3600*time.Second), tok.Expiry, 30*time.Second)
+
+	claims := jwtClaims(t, tok.AccessToken)
+	assert.Equal(t, "acct.user", claims["iss"])
+	assert.Equal(t, "acct.user", claims["sub"])
+	assert.NotNil(t, claims["iat"])
+	assert.NotNil(t, claims["exp"])
+}
+
+// TestJWTSource_BadKey pins that a bad key fails at construction (verifyToken
+// mints an initial token), so config errors surface early.
+func TestJWTSource_BadKey(t *testing.T) {
+	cfg := &configpb.Config{
+		Source: &configpb.Config_Jwt{
+			Jwt: &configpb.JWTSource{
+				PrivateKey: proto.String("not-a-pem"),
+				Claims:     map[string]string{"sub": "x"},
+			},
+		},
+	}
+	_, err := TokenSourceFromConfig(cfg, &logger.Logger{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no PEM block")
+}

--- a/common/oauth/proto/config.pb.go
+++ b/common/oauth/proto/config.pb.go
@@ -31,6 +31,7 @@ type Config struct {
 	//	*Config_GceServiceAccount
 	//	*Config_K8SLocalToken
 	//	*Config_GoogleCredentials
+	//	*Config_Jwt
 	//	*Config_BearerToken
 	Source isConfig_Source `protobuf_oneof:"source"`
 	// If auto-refreshing based on token's expiry, how long before the expiry do we
@@ -154,6 +155,15 @@ func (x *Config) GetGoogleCredentials() *GoogleCredentials {
 	return nil
 }
 
+func (x *Config) GetJwt() *JWTSource {
+	if x != nil {
+		if x, ok := x.Source.(*Config_Jwt); ok {
+			return x.Jwt
+		}
+	}
+	return nil
+}
+
 func (x *Config) GetBearerToken() *BearerToken {
 	if x != nil {
 		if x, ok := x.Source.(*Config_BearerToken); ok {
@@ -221,6 +231,14 @@ type Config_GoogleCredentials struct {
 	GoogleCredentials *GoogleCredentials `protobuf:"bytes,8,opt,name=google_credentials,json=googleCredentials,oneof"`
 }
 
+type Config_Jwt struct {
+	// Self-signed JWT, used directly as the access token and re-minted before
+	// it expires. For APIs that take a JWT as the bearer credential (e.g.
+	// Snowflake key-pair auth). For Google service accounts, prefer
+	// google_credentials with jwt_as_access_token.
+	Jwt *JWTSource `protobuf:"bytes,9,opt,name=jwt,oneof"`
+}
+
 type Config_BearerToken struct {
 	// Bearer token (deprecated)
 	// This field is deprecated. Use one of the other source directly. This
@@ -239,6 +257,8 @@ func (*Config_GceServiceAccount) isConfig_Source() {}
 func (*Config_K8SLocalToken) isConfig_Source() {}
 
 func (*Config_GoogleCredentials) isConfig_Source() {}
+
+func (*Config_Jwt) isConfig_Source() {}
 
 func (*Config_BearerToken) isConfig_Source() {}
 
@@ -455,6 +475,99 @@ func (*BearerToken_GceServiceAccount) isBearerToken_Source() {}
 
 func (*BearerToken_K8SLocalToken) isBearerToken_Source() {}
 
+// JWTSource mints a self-signed JWT and uses it directly as the access token.
+// Unlike google_credentials (which is Google-specific), it builds an arbitrary
+// JWT from the provided claims and signs it with the given key. The token is
+// re-minted automatically before it expires.
+type JWTSource struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// PEM-encoded private key for RS* algorithms, or the shared secret for HS*.
+	// Typically provided through the config layer's secret handling (envSecret).
+	PrivateKey *string `protobuf:"bytes,1,opt,name=private_key,json=privateKey" json:"private_key,omitempty"`
+	// Signing algorithm: RS256 (default) or HS256.
+	Algorithm *string `protobuf:"bytes,2,opt,name=algorithm,def=RS256" json:"algorithm,omitempty"`
+	// JWT claims, e.g. iss, sub, aud. "iat" (now) and "exp" (now + lifetime_sec)
+	// are added automatically.
+	Claims map[string]string `protobuf:"bytes,3,rep,name=claims" json:"claims,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Token lifetime in seconds; sets the "exp" claim and drives re-minting.
+	LifetimeSec *int32 `protobuf:"varint,4,opt,name=lifetime_sec,json=lifetimeSec,def=3600" json:"lifetime_sec,omitempty"`
+	// Extra JOSE header fields, e.g. "kid".
+	Header        map[string]string `protobuf:"bytes,5,rep,name=header" json:"header,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+// Default values for JWTSource fields.
+const (
+	Default_JWTSource_Algorithm   = string("RS256")
+	Default_JWTSource_LifetimeSec = int32(3600)
+)
+
+func (x *JWTSource) Reset() {
+	*x = JWTSource{}
+	mi := &file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *JWTSource) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*JWTSource) ProtoMessage() {}
+
+func (x *JWTSource) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use JWTSource.ProtoReflect.Descriptor instead.
+func (*JWTSource) Descriptor() ([]byte, []int) {
+	return file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *JWTSource) GetPrivateKey() string {
+	if x != nil && x.PrivateKey != nil {
+		return *x.PrivateKey
+	}
+	return ""
+}
+
+func (x *JWTSource) GetAlgorithm() string {
+	if x != nil && x.Algorithm != nil {
+		return *x.Algorithm
+	}
+	return Default_JWTSource_Algorithm
+}
+
+func (x *JWTSource) GetClaims() map[string]string {
+	if x != nil {
+		return x.Claims
+	}
+	return nil
+}
+
+func (x *JWTSource) GetLifetimeSec() int32 {
+	if x != nil && x.LifetimeSec != nil {
+		return *x.LifetimeSec
+	}
+	return Default_JWTSource_LifetimeSec
+}
+
+func (x *JWTSource) GetHeader() map[string]string {
+	if x != nil {
+		return x.Header
+	}
+	return nil
+}
+
 // Google credentials in JSON format. We simply use oauth2/google package to
 // use these credentials.
 type GoogleCredentials struct {
@@ -472,7 +585,7 @@ type GoogleCredentials struct {
 
 func (x *GoogleCredentials) Reset() {
 	*x = GoogleCredentials{}
-	mi := &file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_msgTypes[3]
+	mi := &file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -484,7 +597,7 @@ func (x *GoogleCredentials) String() string {
 func (*GoogleCredentials) ProtoMessage() {}
 
 func (x *GoogleCredentials) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_msgTypes[3]
+	mi := &file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -497,7 +610,7 @@ func (x *GoogleCredentials) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GoogleCredentials.ProtoReflect.Descriptor instead.
 func (*GoogleCredentials) Descriptor() ([]byte, []int) {
-	return file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_rawDescGZIP(), []int{3}
+	return file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *GoogleCredentials) GetJsonFile() string {
@@ -532,14 +645,15 @@ var File_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto prot
 
 const file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_rawDesc = "" +
 	"\n" +
-	"Bgithub.com/cloudprober/cloudprober/common/oauth/proto/config.proto\x12\x11cloudprober.oauth\"\xa5\x04\n" +
+	"Bgithub.com/cloudprober/cloudprober/common/oauth/proto/config.proto\x12\x11cloudprober.oauth\"\xd7\x04\n" +
 	"\x06Config\x12\x14\n" +
 	"\x04file\x18\x01 \x01(\tH\x00R\x04file\x12C\n" +
 	"\fhttp_request\x18\x02 \x01(\v2\x1e.cloudprober.oauth.HTTPRequestH\x00R\vhttpRequest\x12\x12\n" +
 	"\x03cmd\x18\x03 \x01(\tH\x00R\x03cmd\x120\n" +
 	"\x13gce_service_account\x18\x04 \x01(\tH\x00R\x11gceServiceAccount\x12(\n" +
 	"\x0fk8s_local_token\x18\x05 \x01(\bH\x00R\rk8sLocalToken\x12U\n" +
-	"\x12google_credentials\x18\b \x01(\v2$.cloudprober.oauth.GoogleCredentialsH\x00R\x11googleCredentials\x12C\n" +
+	"\x12google_credentials\x18\b \x01(\v2$.cloudprober.oauth.GoogleCredentialsH\x00R\x11googleCredentials\x120\n" +
+	"\x03jwt\x18\t \x01(\v2\x1c.cloudprober.oauth.JWTSourceH\x00R\x03jwt\x12C\n" +
 	"\fbearer_token\x18\a \x01(\v2\x1e.cloudprober.oauth.BearerTokenH\x00R\vbearerToken\x12=\n" +
 	"\x19refresh_expiry_buffer_sec\x18\x14 \x01(\x05:\x0260R\x16refreshExpiryBufferSec\x124\n" +
 	"\x14refresh_interval_sec\x18\x15 \x01(\x02:\x0230R\x12refreshIntervalSec\x125\n" +
@@ -559,7 +673,20 @@ const file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_ra
 	"\x13gce_service_account\x18\x03 \x01(\tH\x00R\x11gceServiceAccount\x12(\n" +
 	"\x0fk8s_local_token\x18\x04 \x01(\bH\x00R\rk8sLocalToken\x120\n" +
 	"\x14refresh_interval_sec\x18Z \x01(\x02R\x12refreshIntervalSecB\b\n" +
-	"\x06source\"\x91\x01\n" +
+	"\x06source\"\xf4\x02\n" +
+	"\tJWTSource\x12\x1f\n" +
+	"\vprivate_key\x18\x01 \x01(\tR\n" +
+	"privateKey\x12#\n" +
+	"\talgorithm\x18\x02 \x01(\t:\x05RS256R\talgorithm\x12@\n" +
+	"\x06claims\x18\x03 \x03(\v2(.cloudprober.oauth.JWTSource.ClaimsEntryR\x06claims\x12'\n" +
+	"\flifetime_sec\x18\x04 \x01(\x05:\x043600R\vlifetimeSec\x12@\n" +
+	"\x06header\x18\x05 \x03(\v2(.cloudprober.oauth.JWTSource.HeaderEntryR\x06header\x1a9\n" +
+	"\vClaimsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a9\n" +
+	"\vHeaderEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x91\x01\n" +
 	"\x11GoogleCredentials\x12\x1b\n" +
 	"\tjson_file\x18\x01 \x01(\tR\bjsonFile\x12\x14\n" +
 	"\x05scope\x18\x02 \x03(\tR\x05scope\x12-\n" +
@@ -578,24 +705,30 @@ func file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_raw
 	return file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_rawDescData
 }
 
-var file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_goTypes = []any{
 	(*Config)(nil),            // 0: cloudprober.oauth.Config
 	(*HTTPRequest)(nil),       // 1: cloudprober.oauth.HTTPRequest
 	(*BearerToken)(nil),       // 2: cloudprober.oauth.BearerToken
-	(*GoogleCredentials)(nil), // 3: cloudprober.oauth.GoogleCredentials
-	nil,                       // 4: cloudprober.oauth.HTTPRequest.HeaderEntry
+	(*JWTSource)(nil),         // 3: cloudprober.oauth.JWTSource
+	(*GoogleCredentials)(nil), // 4: cloudprober.oauth.GoogleCredentials
+	nil,                       // 5: cloudprober.oauth.HTTPRequest.HeaderEntry
+	nil,                       // 6: cloudprober.oauth.JWTSource.ClaimsEntry
+	nil,                       // 7: cloudprober.oauth.JWTSource.HeaderEntry
 }
 var file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_depIdxs = []int32{
 	1, // 0: cloudprober.oauth.Config.http_request:type_name -> cloudprober.oauth.HTTPRequest
-	3, // 1: cloudprober.oauth.Config.google_credentials:type_name -> cloudprober.oauth.GoogleCredentials
-	2, // 2: cloudprober.oauth.Config.bearer_token:type_name -> cloudprober.oauth.BearerToken
-	4, // 3: cloudprober.oauth.HTTPRequest.header:type_name -> cloudprober.oauth.HTTPRequest.HeaderEntry
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	4, // 1: cloudprober.oauth.Config.google_credentials:type_name -> cloudprober.oauth.GoogleCredentials
+	3, // 2: cloudprober.oauth.Config.jwt:type_name -> cloudprober.oauth.JWTSource
+	2, // 3: cloudprober.oauth.Config.bearer_token:type_name -> cloudprober.oauth.BearerToken
+	5, // 4: cloudprober.oauth.HTTPRequest.header:type_name -> cloudprober.oauth.HTTPRequest.HeaderEntry
+	6, // 5: cloudprober.oauth.JWTSource.claims:type_name -> cloudprober.oauth.JWTSource.ClaimsEntry
+	7, // 6: cloudprober.oauth.JWTSource.header:type_name -> cloudprober.oauth.JWTSource.HeaderEntry
+	7, // [7:7] is the sub-list for method output_type
+	7, // [7:7] is the sub-list for method input_type
+	7, // [7:7] is the sub-list for extension type_name
+	7, // [7:7] is the sub-list for extension extendee
+	0, // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_init() }
@@ -610,6 +743,7 @@ func file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_ini
 		(*Config_GceServiceAccount)(nil),
 		(*Config_K8SLocalToken)(nil),
 		(*Config_GoogleCredentials)(nil),
+		(*Config_Jwt)(nil),
 		(*Config_BearerToken)(nil),
 	}
 	file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_msgTypes[2].OneofWrappers = []any{
@@ -624,7 +758,7 @@ func file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_ini
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_rawDesc), len(file_github_com_cloudprober_cloudprober_common_oauth_proto_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/common/oauth/proto/config.proto
+++ b/common/oauth/proto/config.proto
@@ -27,6 +27,12 @@ message Config {
     // Google credentials, either from a default source or a JSON file.
     GoogleCredentials google_credentials = 8;
 
+    // Self-signed JWT, used directly as the access token and re-minted before
+    // it expires. For APIs that take a JWT as the bearer credential (e.g.
+    // Snowflake key-pair auth). For Google service accounts, prefer
+    // google_credentials with jwt_as_access_token.
+    JWTSource jwt = 9;
+
     // Bearer token (deprecated)
     // This field is deprecated. Use one of the other source directly. This
     // layer turned out to be unnecessary.
@@ -101,6 +107,29 @@ message BearerToken {
   // every 30s by default. To disable this behavior set refresh_interval_sec to
   // zero.
   optional float refresh_interval_sec = 90;
+}
+
+// JWTSource mints a self-signed JWT and uses it directly as the access token.
+// Unlike google_credentials (which is Google-specific), it builds an arbitrary
+// JWT from the provided claims and signs it with the given key. The token is
+// re-minted automatically before it expires.
+message JWTSource {
+  // PEM-encoded private key for RS* algorithms, or the shared secret for HS*.
+  // Typically provided through the config layer's secret handling (envSecret).
+  optional string private_key = 1;
+
+  // Signing algorithm: RS256 (default) or HS256.
+  optional string algorithm = 2 [default = "RS256"];
+
+  // JWT claims, e.g. iss, sub, aud. "iat" (now) and "exp" (now + lifetime_sec)
+  // are added automatically.
+  map<string, string> claims = 3;
+
+  // Token lifetime in seconds; sets the "exp" claim and drives re-minting.
+  optional int32 lifetime_sec = 4 [default = 3600];
+
+  // Extra JOSE header fields, e.g. "kid".
+  map<string, string> header = 5;
 }
 
 // Google credentials in JSON format. We simply use oauth2/google package to

--- a/common/oauth/tokensource.go
+++ b/common/oauth/tokensource.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloudprober/cloudprober/common/jwt"
 	configpb "github.com/cloudprober/cloudprober/common/oauth/proto"
 	"github.com/cloudprober/cloudprober/internal/file"
 	"github.com/cloudprober/cloudprober/logger"
@@ -76,11 +77,40 @@ func readFromCommand(c *configpb.Config) (*oauth2.Token, error) {
 	return bytesToToken(out), nil
 }
 
+// jwtToken mints a self-signed JWT from the JWTSource config. iat/exp are set
+// from the current time and lifetime, and Expiry is stamped on the token so the
+// cache re-mints it before it expires.
+func jwtToken(c *configpb.Config) (*oauth2.Token, error) {
+	jc := c.GetJwt()
+	now := time.Now()
+	expiry := now.Add(time.Duration(jc.GetLifetimeSec()) * time.Second)
+
+	claims := map[string]any{"iat": now.Unix(), "exp": expiry.Unix()}
+	for k, v := range jc.GetClaims() {
+		claims[k] = v
+	}
+
+	var header map[string]any
+	if len(jc.GetHeader()) > 0 {
+		header = make(map[string]any, len(jc.GetHeader()))
+		for k, v := range jc.GetHeader() {
+			header[k] = v
+		}
+	}
+
+	tok, err := jwt.Encode(claims, header, jc.GetPrivateKey(), jc.GetAlgorithm())
+	if err != nil {
+		return nil, fmt.Errorf("oauth: minting JWT: %v", err)
+	}
+	return &oauth2.Token{AccessToken: tok, Expiry: expiry}, nil
+}
+
 var tokenFunctions = struct {
-	fromFile, fromCmd, fromGCEMetadata, fromK8sTokenFile, fromHTTP func(c *configpb.Config) (*oauth2.Token, error)
+	fromFile, fromCmd, fromGCEMetadata, fromK8sTokenFile, fromHTTP, fromJWT func(c *configpb.Config) (*oauth2.Token, error)
 }{
 	fromFile: readFromFile,
 	fromCmd:  readFromCommand,
+	fromJWT:  jwtToken,
 	fromGCEMetadata: func(c *configpb.Config) (*oauth2.Token, error) {
 		ts := google.ComputeTokenSource(c.GetGceServiceAccount())
 		tok, err := ts.Token()
@@ -155,6 +185,9 @@ func newTokenSource(c *configpb.Config, refreshExpiryBuffer time.Duration, l *lo
 
 	case *configpb.Config_Cmd:
 		ts.getTokenFromBackend = tokenFunctions.fromCmd
+
+	case *configpb.Config_Jwt:
+		ts.getTokenFromBackend = tokenFunctions.fromJWT
 
 	case *configpb.Config_GceServiceAccount:
 		ts.getTokenFromBackend = tokenFunctions.fromGCEMetadata

--- a/common/oauth/tokensource.go
+++ b/common/oauth/tokensource.go
@@ -87,6 +87,12 @@ func jwtToken(c *configpb.Config) (*oauth2.Token, error) {
 
 	claims := map[string]any{"iat": now.Unix(), "exp": expiry.Unix()}
 	for k, v := range jc.GetClaims() {
+		// iat/exp are reserved: they're derived from lifetime_sec and must stay
+		// in sync with the token's Expiry (which drives re-minting). A
+		// user-supplied value would be a string and desync the two.
+		if k == "iat" || k == "exp" {
+			continue
+		}
 		claims[k] = v
 	}
 

--- a/docs/content/docs/how-to/oauth.md
+++ b/docs/content/docs/how-to/oauth.md
@@ -47,7 +47,8 @@ oauth_config: {
 # Run a command to generate the token
 oauth_config: {
   # Token generator could do custom stuff like generate a short-lived token
-  # from a private public key-pair (e.g. for Snowflake API).
+  # from a private public key-pair. For self-signed JWTs (e.g. Snowflake API)
+  # you can now use the built-in "jwt" source instead of a script -- see below.
   cmd: "{{configDir}}/scripts/token_generator.sh"
 }
 ```
@@ -100,6 +101,37 @@ oauth_config: {
   }
 }
 ```
+
+### Self-signed JWT
+
+For APIs that accept a self-signed JWT directly as the bearer credential (for
+example, Snowflake's SQL REST API key-pair auth), use the `jwt` source.
+Cloudprober mints a JWT from the configured claims, signs it with your private
+key, and re-mints it automatically before it expires -- no external token
+endpoint or helper script needed.
+
+```bash
+oauth_config: {
+  jwt: {
+    # PEM-encoded private key. Use envSecret so it stays masked in the
+    # served config. (HS256 uses this field as the shared secret.)
+    private_key: "{{envSecret "SNOWFLAKE_PRIVATE_KEY"}}"
+    algorithm: "RS256"       # default; HS256 also supported
+    lifetime_sec: 3600       # sets "exp" and drives re-minting
+
+    claims { key: "iss" value: "MYACCOUNT.MYUSER.SHA256:<pubkey-fingerprint>" }
+    claims { key: "sub" value: "MYACCOUNT.MYUSER" }
+
+    # Optional extra JOSE header fields, e.g. a key id:
+    # header { key: "kid" value: "..." }
+  }
+}
+```
+
+`iat` and `exp` are added automatically from the current time and
+`lifetime_sec`, so don't set them in `claims`. For Google service accounts,
+prefer `google_credentials` with `jwt_as_access_token` over building the JWT
+by hand.
 
 ## Config Reference
 

--- a/probes/starlark/builtins_jwt.go
+++ b/probes/starlark/builtins_jwt.go
@@ -27,9 +27,7 @@ import (
 // and signs a compact-serialization JWT (via common/jwt). It exists for APIs
 // that take a self-signed JWT directly as the bearer credential — Google
 // service-account JWTs are the driving case, Snowflake's SQL REST API key-pair
-// auth is the other. It is deliberately not part of the oauth module: there is
-// no token exchange here, the script signs its own short-lived token and sends
-// it.
+// auth is the other.
 //
 // The private key (for RS*) comes in as a PEM string, typically via the vars
 // module, e.g. jwt.encode(claims, vars.get("sa_private_key")). Scripts have no

--- a/probes/starlark/builtins_jwt.go
+++ b/probes/starlark/builtins_jwt.go
@@ -15,28 +15,21 @@
 package starlark
 
 import (
-	"crypto"
-	"crypto/hmac"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/sha256"
-	"crypto/x509"
-	"encoding/base64"
-	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"time"
 
+	"github.com/cloudprober/cloudprober/common/jwt"
 	starlarklib "go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 )
 
 // jwt.encode(payload, key, algorithm="RS256", headers=None, lifetime=60) mints
-// and signs a compact-serialization JWT. It exists for APIs that take a
-// self-signed JWT directly as the bearer credential — Google service-account
-// JWTs are the driving case, Snowflake's SQL REST API key-pair auth is the
-// other. It is deliberately not part of the oauth module: there is no token
-// exchange here, the script signs its own short-lived token and sends it.
+// and signs a compact-serialization JWT (via common/jwt). It exists for APIs
+// that take a self-signed JWT directly as the bearer credential — Google
+// service-account JWTs are the driving case, Snowflake's SQL REST API key-pair
+// auth is the other. It is deliberately not part of the oauth module: there is
+// no token exchange here, the script signs its own short-lived token and sends
+// it.
 //
 // The private key (for RS*) comes in as a PEM string, typically via the vars
 // module, e.g. jwt.encode(claims, vars.get("sa_private_key")). Scripts have no
@@ -92,37 +85,19 @@ func jwtEncode(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.T
 		}
 	}
 
-	header := map[string]interface{}{"alg": alg, "typ": "JWT"}
+	var header map[string]any
 	if headersV != starlarklib.None {
-		extra, err := jwtDict(headersV, "headers")
+		header, err = jwtDict(headersV, "headers")
 		if err != nil {
 			return nil, err
 		}
-		// A header alg must never disagree with the algorithm we actually sign
-		// with. An explicit matching alg is fine; a mismatch is an error.
-		if a, ok := extra["alg"]; ok && a != alg {
-			return nil, fmt.Errorf("jwt.encode: headers[\"alg\"]=%v conflicts with algorithm=%q", a, alg)
-		}
-		for k, v := range extra {
-			header[k] = v
-		}
 	}
 
-	headerJSON, err := json.Marshal(header)
-	if err != nil {
-		return nil, fmt.Errorf("jwt.encode: marshaling header: %v", err)
-	}
-	claimsJSON, err := json.Marshal(claims)
-	if err != nil {
-		return nil, fmt.Errorf("jwt.encode: marshaling payload: %v", err)
-	}
-
-	signingInput := jwtBase64(headerJSON) + "." + jwtBase64(claimsJSON)
-	sig, err := jwtSign(alg, []byte(signingInput), key)
+	tok, err := jwt.Encode(claims, header, key, alg)
 	if err != nil {
 		return nil, fmt.Errorf("jwt.encode: %v", err)
 	}
-	return starlarklib.String(signingInput + "." + jwtBase64(sig)), nil
+	return starlarklib.String(tok), nil
 }
 
 // jwtDict converts a Starlark dict argument to a Go map via the shared
@@ -137,53 +112,4 @@ func jwtDict(v starlarklib.Value, name string) (map[string]interface{}, error) {
 		return nil, fmt.Errorf("jwt.encode: %s must be a dict, got %s", name, v.Type())
 	}
 	return m, nil
-}
-
-func jwtBase64(b []byte) string {
-	return base64.RawURLEncoding.EncodeToString(b)
-}
-
-// jwtSign signs signingInput for the given JOSE alg. RS256 (RSA-PKCS1v15 +
-// SHA-256) is the Snowflake/GCP case; HS256 (HMAC-SHA256) is the shared-secret
-// companion. Add more alg entries here as concrete APIs need them.
-func jwtSign(alg string, signingInput []byte, key string) ([]byte, error) {
-	switch alg {
-	case "RS256":
-		priv, err := jwtParseRSAKey(key)
-		if err != nil {
-			return nil, err
-		}
-		h := sha256.Sum256(signingInput)
-		return rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA256, h[:])
-	case "HS256":
-		mac := hmac.New(sha256.New, []byte(key))
-		mac.Write(signingInput)
-		return mac.Sum(nil), nil
-	default:
-		return nil, fmt.Errorf("unsupported algorithm %q (supported: RS256, HS256)", alg)
-	}
-}
-
-func jwtParseRSAKey(pemStr string) (*rsa.PrivateKey, error) {
-	block, _ := pem.Decode([]byte(pemStr))
-	if block == nil {
-		return nil, fmt.Errorf("no PEM block found in key")
-	}
-	if block.Type == "ENCRYPTED PRIVATE KEY" {
-		return nil, fmt.Errorf("encrypted private keys are not supported; provide an unencrypted PEM")
-	}
-	// Snowflake keys are usually PKCS#8 (openssl genpkey); older tooling emits
-	// PKCS#1. Try both.
-	if k, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
-		return k, nil
-	}
-	k, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("parsing RSA private key (tried PKCS1 and PKCS8): %v", err)
-	}
-	rsaKey, ok := k.(*rsa.PrivateKey)
-	if !ok {
-		return nil, fmt.Errorf("key is %T, want an RSA private key for RS256", k)
-	}
-	return rsaKey, nil
 }

--- a/probes/starlark/builtins_jwt_test.go
+++ b/probes/starlark/builtins_jwt_test.go
@@ -16,7 +16,6 @@ package starlark
 
 import (
 	"crypto"
-	"crypto/hmac"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
@@ -35,6 +34,11 @@ import (
 	"github.com/stretchr/testify/require"
 	starlarklib "go.starlark.net/starlark"
 )
+
+// The signing core (RS256/HS256, PEM parsing, base64url, the alg-conflict
+// guard) is tested in common/jwt. These tests cover only what the builtin adds
+// on top: arg handling, the iat/exp auto-fill (scripts have no clock), and the
+// end-to-end script path.
 
 // callJWTEncode invokes the jwt.encode builtin directly (it needs no
 // thread-locals) and returns the token string.
@@ -89,67 +93,8 @@ func genRSAKeyPEM(t *testing.T) (string, *rsa.PublicKey) {
 	return string(pemBytes), &priv.PublicKey
 }
 
-// TestJWTEncode_RS256 signs with an RSA key and verifies the signature and
-// header round-trips end to end — this is the Snowflake path.
-func TestJWTEncode_RS256(t *testing.T) {
-	keyPEM, pub := genRSAKeyPEM(t)
-	payload := dict(t, map[string]starlarklib.Value{
-		"iss": starlarklib.String("ACCT.USER.SHA256:abc"),
-		"sub": starlarklib.String("ACCT.USER"),
-	})
-
-	token, err := callJWTEncode(t, payload, keyPEM)
-	require.NoError(t, err)
-
-	header, claims, signingInput, sig := decodeJWT(t, token)
-	assert.Equal(t, "RS256", header["alg"])
-	assert.Equal(t, "JWT", header["typ"])
-	assert.Equal(t, "ACCT.USER.SHA256:abc", claims["iss"])
-	assert.Equal(t, "ACCT.USER", claims["sub"])
-
-	h := sha256.Sum256([]byte(signingInput))
-	assert.NoError(t, rsa.VerifyPKCS1v15(pub, crypto.SHA256, h[:], sig),
-		"signature must verify against the public key")
-}
-
-// TestJWTEncode_PKCS1Key checks that a legacy PKCS#1 ("RSA PRIVATE KEY") PEM
-// works too, not just PKCS#8.
-func TestJWTEncode_PKCS1Key(t *testing.T) {
-	priv, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
-	pemBytes := pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(priv),
-	})
-	payload := dict(t, map[string]starlarklib.Value{"sub": starlarklib.String("x")})
-
-	token, err := callJWTEncode(t, payload, string(pemBytes))
-	require.NoError(t, err)
-
-	_, _, signingInput, sig := decodeJWT(t, token)
-	h := sha256.Sum256([]byte(signingInput))
-	assert.NoError(t, rsa.VerifyPKCS1v15(&priv.PublicKey, crypto.SHA256, h[:], sig))
-}
-
-// TestJWTEncode_HS256 signs with a shared secret and verifies the HMAC.
-func TestJWTEncode_HS256(t *testing.T) {
-	secret := "s3cret"
-	payload := dict(t, map[string]starlarklib.Value{"sub": starlarklib.String("alice")})
-
-	token, err := callJWTEncode(t, payload, secret,
-		starlarklib.Tuple{starlarklib.String("algorithm"), starlarklib.String("HS256")})
-	require.NoError(t, err)
-
-	header, _, signingInput, sig := decodeJWT(t, token)
-	assert.Equal(t, "HS256", header["alg"])
-
-	mac := hmac.New(sha256.New, []byte(secret))
-	mac.Write([]byte(signingInput))
-	assert.True(t, hmac.Equal(sig, mac.Sum(nil)), "HMAC must verify")
-}
-
 // TestJWTEncode_AutoFillsTimeClaims covers the clock behavior: iat/exp are
-// filled from lifetime when absent, and an explicit exp is left untouched.
+// filled from lifetime when absent, and an explicit iat/exp is left untouched.
 func TestJWTEncode_AutoFillsTimeClaims(t *testing.T) {
 	keyPEM, _ := genRSAKeyPEM(t)
 
@@ -178,45 +123,6 @@ func TestJWTEncode_AutoFillsTimeClaims(t *testing.T) {
 	assert.Equal(t, int64(2000), int64(claims2["exp"].(float64)))
 }
 
-// TestJWTEncode_CustomHeaders checks that extra JOSE header fields (e.g. kid)
-// merge in and can override typ.
-func TestJWTEncode_CustomHeaders(t *testing.T) {
-	keyPEM, _ := genRSAKeyPEM(t)
-	token, err := callJWTEncode(t, dict(t, map[string]starlarklib.Value{"sub": starlarklib.String("x")}), keyPEM,
-		starlarklib.Tuple{starlarklib.String("headers"), dict(t, map[string]starlarklib.Value{
-			"kid": starlarklib.String("key-1"),
-		})})
-	require.NoError(t, err)
-	header, _, _, _ := decodeJWT(t, token)
-	assert.Equal(t, "key-1", header["kid"])
-	assert.Equal(t, "RS256", header["alg"])
-}
-
-// TestJWTEncode_HeaderAlg covers the alg-in-headers rule: a matching explicit
-// alg is allowed, a mismatching one is rejected (header must not lie about the
-// signing algorithm).
-func TestJWTEncode_HeaderAlg(t *testing.T) {
-	keyPEM, _ := genRSAKeyPEM(t)
-	sub := dict(t, map[string]starlarklib.Value{"sub": starlarklib.String("x")})
-
-	// Matching alg is fine.
-	token, err := callJWTEncode(t, sub, keyPEM,
-		starlarklib.Tuple{starlarklib.String("headers"), dict(t, map[string]starlarklib.Value{
-			"alg": starlarklib.String("RS256"),
-		})})
-	require.NoError(t, err)
-	header, _, _, _ := decodeJWT(t, token)
-	assert.Equal(t, "RS256", header["alg"])
-
-	// Mismatching alg is rejected.
-	_, err = callJWTEncode(t, sub, keyPEM,
-		starlarklib.Tuple{starlarklib.String("headers"), dict(t, map[string]starlarklib.Value{
-			"alg": starlarklib.String("none"),
-		})})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "conflicts with algorithm")
-}
-
 // TestJWTEncode_NoneTimeClaim pins that an explicit None iat/exp is treated as
 // unset and auto-filled, not serialized as JSON null.
 func TestJWTEncode_NoneTimeClaim(t *testing.T) {
@@ -234,33 +140,16 @@ func TestJWTEncode_NoneTimeClaim(t *testing.T) {
 	assert.Equal(t, int64(claims["iat"].(float64))+3600, int64(claims["exp"].(float64)))
 }
 
-func TestJWTEncode_Errors(t *testing.T) {
-	keyPEM, _ := genRSAKeyPEM(t)
-	sub := dict(t, map[string]starlarklib.Value{"sub": starlarklib.String("x")})
-
-	t.Run("bad algorithm", func(t *testing.T) {
-		_, err := callJWTEncode(t, sub, keyPEM,
-			starlarklib.Tuple{starlarklib.String("algorithm"), starlarklib.String("XX999")})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unsupported algorithm")
-	})
-
-	t.Run("not a PEM key", func(t *testing.T) {
-		_, err := callJWTEncode(t, sub, "not-a-pem")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no PEM block")
-	})
-
-	t.Run("payload not a dict", func(t *testing.T) {
-		_, err := jwtEncode(nil, nil,
-			starlarklib.Tuple{starlarklib.String("nope"), starlarklib.String(keyPEM)}, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "payload must be a dict")
-	})
+// TestJWTEncode_PayloadNotDict covers the builtin's own argument validation.
+func TestJWTEncode_PayloadNotDict(t *testing.T) {
+	_, err := jwtEncode(nil, nil,
+		starlarklib.Tuple{starlarklib.String("nope"), starlarklib.String("key")}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "payload must be a dict")
 }
 
 // TestJWTEncode_InScript runs the builtin through a real script, exercising the
-// registration and the vars-supplied key path (the Snowflake shape).
+// registration and the vars-supplied key path, and verifies the token signs.
 func TestJWTEncode_InScript(t *testing.T) {
 	keyPEM, pub := genRSAKeyPEM(t)
 	source := `


### PR DESCRIPTION
## Summary
- Add a `jwt` source to the oauth `Config`: mint a self-signed JWT from configured claims + private key, used directly as the access token and re-minted before expiry by the existing token cache. For JWT-bearer APIs (e.g. Snowflake key-pair auth).
- Google service accounts are unchanged — `google_credentials` (with `jwt_as_access_token`) stays its own independent source, so existing configs don't break.
- Extract JWT signing into a shared `common/jwt` package, now used by both the new source and the Starlark `jwt.encode` builtin (single crypto impl).

## Test plan
- `go test ./common/jwt/ ./common/oauth/ ./probes/starlark/` — new `common/jwt` unit tests (RS256/HS256, PKCS#1/#8, alg-conflict), oauth JWT-source test (token minted with expiry, bad key fails at init), and the existing starlark jwt tests still pass on the refactored builtin.