### PR TITLE
[probes.system]: add container mount exclusions and move to dedicated file

### DIFF
--- a/probes/system/exclusions_linux.go
+++ b/probes/system/exclusions_linux.go
@@ -1,0 +1,37 @@
+// Copyright 2025-2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package system
+
+// defaultExcludeMounts is the list of mount points or mount point prefixes
+// that should be excluded from disk usage monitoring by default to avoid
+// virtual mounts, container runtimes, and duplicated overlays.
+var defaultExcludeMounts = []string{
+	"/dev",
+	"/sys",
+	"/proc",
+	"/run/netns",
+	"/run/containerd",
+	"/run/k3s",
+	"/run/docker",
+	"/snap",
+	"/var/lib/docker/overlay2",
+	"/var/lib/docker/overlay",
+	"/var/lib/containerd/io.containerd",
+	"/var/lib/kubelet/pods",
+	"/var/lib/rancher/k3s/agent/containerd",
+}

--- a/probes/system/system_linux.go
+++ b/probes/system/system_linux.go
@@ -296,7 +296,7 @@ func (p *Probe) exportDiskUsageStats(ts time.Time, dataChan chan *metrics.EventM
 
 	for _, mount := range mounts {
 		excluded := false
-		for _, exclude := range []string{"/dev", "/sys", "/proc", "/run/netns", "/run/containerd", "/run/k3s", "/run/docker", "/snap"} {
+		for _, exclude := range defaultExcludeMounts {
 			if mount == exclude || strings.HasPrefix(mount, exclude+"/") {
 				excluded = true
 				break

--- a/probes/system/system_linux_test.go
+++ b/probes/system/system_linux_test.go
@@ -345,7 +345,7 @@ snap /snap/core/123 squashfs ro 0 0
 						}
 					}
 					// Verify no excluded mount points leaked through
-					for _, exclude := range []string{"/dev", "/sys", "/proc", "/run/netns", "/snap"} {
+					for _, exclude := range defaultExcludeMounts {
 						if mp == exclude || strings.HasPrefix(mp, exclude+"/") {
 							t.Errorf("got excluded mount point: %s", mp)
 						}


### PR DESCRIPTION
This PR moves the default mount exclusions to a dedicated package-level variable `defaultExcludeMounts` in `exclusions_linux.go`, and expands the list to include common container runtime folders and overlays (`/var/lib/docker/overlay2`, `/var/lib/docker/overlay`, `/var/lib/containerd/io.containerd`, `/var/lib/kubelet/pods`, and `/var/lib/rancher/k3s/agent/containerd`) to prevent metric duplication and high cardinality.