### PR TITLE
[docs] Bump CI Node to 20 for @xhmikosr/decompress

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
           cache: 'npm'
           cache-dependency-path: 'docs/package-lock.json'
 

--- a/.github/workflows/latest_config_docs.yml
+++ b/.github/workflows/latest_config_docs.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
           cache: 'npm'
           cache-dependency-path: 'docs/package-lock.json'
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -38,7 +38,7 @@
         "stylelint-config-standard-scss": "^4.0"
       },
       "engines": {
-        "node": ">=16.16.0"
+        "node": ">=20"
       }
     },
     "node_modules/@babel/cli": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "description": "Doks child theme",
   "version": "0.5.0",
   "engines": {
-    "node": ">=16.16.0"
+    "node": ">=20"
   },
   "browserslist": [
     "defaults"


### PR DESCRIPTION
## Summary
- Follow-up to #1378: `@xhmikosr/decompress@11` requires Node >=20
- Bump docs workflows (`hugo.yml`, `latest_config_docs.yml`) from Node 16 → 20
- Update `docs/package.json` engines to `>=20`

## Test plan
- [x] Clean `npm ci` in `docs/` succeeds and hugo-installer extracts the binary
- [x] `npm audit` reports 0 vulnerabilities
- [ ] GitHub Actions docs build passes