### PR TITLE
[probes.starlark] Add http.put/patch/delete builtins

### DIFF
--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -118,6 +118,7 @@ All scripts get a small, fixed set of builtins. No filesystem, network beyond
 |---|---|
 | `http.get(url, headers=None, max_redirects=N, keep_alive=False)` | HTTP GET, returns a `Response`. `max_redirects=0` disables following; `max_redirects=N` follows up to N (omit for Go's default of 10). `keep_alive` defaults to `False` to match the HTTP probe -- every call exercises DNS/TCP/TLS setup, which is what you usually want from a prober. Pass `keep_alive=True` to reuse a pooled connection across calls in a chained API flow. |
 | `http.post(url, headers=None, body=None, json=None, max_redirects=N, keep_alive=False)` | HTTP POST. Pass `json=` for an auto-encoded JSON body (sets `Content-Type`), or `body=` for a raw string/bytes. `max_redirects` and `keep_alive` match `http.get`. |
+| `http.put(...)`, `http.patch(...)`, `http.delete(...)` | HTTP PUT/PATCH/DELETE. Same signature and kwargs as `http.post` (`body=`/`json=` accepted for all three). |
 | `assert.http_status(response, expected)` | Fails the probe if `response.status != expected`. Stamp per-call context onto the failure log line with `log.set_attr` instead of inlining it into the error message. |
 | `vars.get(name, default=None)` | Read values from the probe's `vars` config map (see below). |
 | `state.get(key, default=None)` / `state.set(key, value)` | Per-target key-value store that persists across runs (see below). |

--- a/probes/starlark/builtins_http.go
+++ b/probes/starlark/builtins_http.go
@@ -34,8 +34,11 @@ func httpModule() *starlarkstruct.Module {
 	return &starlarkstruct.Module{
 		Name: "http",
 		Members: starlarklib.StringDict{
-			"get":  starlarklib.NewBuiltin("http.get", httpGet),
-			"post": starlarklib.NewBuiltin("http.post", httpPost),
+			"get":    starlarklib.NewBuiltin("http.get", httpVerb("GET", false)),
+			"post":   starlarklib.NewBuiltin("http.post", httpVerb("POST", true)),
+			"put":    starlarklib.NewBuiltin("http.put", httpVerb("PUT", true)),
+			"patch":  starlarklib.NewBuiltin("http.patch", httpVerb("PATCH", true)),
+			"delete": starlarklib.NewBuiltin("http.delete", httpVerb("DELETE", true)),
 		},
 	}
 }
@@ -69,46 +72,32 @@ func optionalInt(v starlarklib.Value, name string) (*int, error) {
 	return &out, nil
 }
 
-func httpGet(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
-	var url string
-	var opts reqOpts
-	var maxRedirectsArg starlarklib.Value
-	if err := starlarklib.UnpackArgs("http.get", args, kwargs,
-		"url", &url,
-		"headers?", &opts.headers,
-		"max_redirects??", &maxRedirectsArg,
-		"keep_alive??", &opts.keepAlive,
-	); err != nil {
-		return nil, err
+// httpVerb returns a builtin handler for the given HTTP method. When withBody
+// is true, the handler also accepts "body" and "json" kwargs; GET omits them.
+func httpVerb(method string, withBody bool) func(*starlarklib.Thread, *starlarklib.Builtin, starlarklib.Tuple, []starlarklib.Tuple) (starlarklib.Value, error) {
+	name := "http." + strings.ToLower(method)
+	return func(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
+		var url string
+		var opts reqOpts
+		var maxRedirectsArg starlarklib.Value
+		spec := []interface{}{
+			"url", &url,
+			"headers?", &opts.headers,
+		}
+		if withBody {
+			spec = append(spec, "body?", &opts.body, "json?", &opts.jsonArg)
+		}
+		spec = append(spec, "max_redirects??", &maxRedirectsArg, "keep_alive??", &opts.keepAlive)
+		if err := starlarklib.UnpackArgs(name, args, kwargs, spec...); err != nil {
+			return nil, err
+		}
+		maxRedirects, err := optionalInt(maxRedirectsArg, name+": max_redirects")
+		if err != nil {
+			return nil, err
+		}
+		opts.maxRedirects = maxRedirects
+		return doHTTP(thread, method, url, opts)
 	}
-	maxRedirects, err := optionalInt(maxRedirectsArg, "http.get: max_redirects")
-	if err != nil {
-		return nil, err
-	}
-	opts.maxRedirects = maxRedirects
-	return doHTTP(thread, "GET", url, opts)
-}
-
-func httpPost(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
-	var url string
-	var opts reqOpts
-	var maxRedirectsArg starlarklib.Value
-	if err := starlarklib.UnpackArgs("http.post", args, kwargs,
-		"url", &url,
-		"headers?", &opts.headers,
-		"body?", &opts.body,
-		"json?", &opts.jsonArg,
-		"max_redirects??", &maxRedirectsArg,
-		"keep_alive??", &opts.keepAlive,
-	); err != nil {
-		return nil, err
-	}
-	maxRedirects, err := optionalInt(maxRedirectsArg, "http.post: max_redirects")
-	if err != nil {
-		return nil, err
-	}
-	opts.maxRedirects = maxRedirects
-	return doHTTP(thread, "POST", url, opts)
 }
 
 func doHTTP(thread *starlarklib.Thread, method, url string, opts reqOpts) (starlarklib.Value, error) {

--- a/probes/starlark/starlark_test.go
+++ b/probes/starlark/starlark_test.go
@@ -366,6 +366,53 @@ def probe(target):
 	assert.Equal(t, "raw-body-bytes", gotBody)
 }
 
+// TestHTTP_Verbs covers the put/patch/delete verbs: the method reaches the
+// server, and body-carrying verbs (put/patch) deliver their body.
+func TestHTTP_Verbs(t *testing.T) {
+	for _, tc := range []struct {
+		verb     string
+		wantBody string
+	}{
+		{"put", "raw-put-body"},
+		{"patch", "raw-patch-body"},
+		{"delete", ""},
+	} {
+		t.Run(tc.verb, func(t *testing.T) {
+			var gotMethod, gotBody string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				b, _ := io.ReadAll(r.Body)
+				gotBody = string(b)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			bodyArg := ""
+			if tc.wantBody != "" {
+				bodyArg = fmt.Sprintf(`body = %q,`, tc.wantBody)
+			}
+			source := fmt.Sprintf(`
+def probe(target):
+    r = http.%s(
+        url = "http://%%s:%%d/" %% (target.name, target.port),
+        %s
+    )
+    assert.http_status(r, 200)
+`, tc.verb, bodyArg)
+			opts := newOpts(t, hostFromServer(t, srv), source)
+			p := &Probe{}
+			if err := p.Init("script-verb-"+tc.verb, opts); err != nil {
+				t.Fatalf("Init: %v", err)
+			}
+
+			results := p.RunOnce(context.Background())
+			assert.True(t, results[0].Success, "err=%v", results[0].Error)
+			assert.Equal(t, strings.ToUpper(tc.verb), gotMethod)
+			assert.Equal(t, tc.wantBody, gotBody)
+		})
+	}
+}
+
 // TestHTTP_ResponseHeadersVisible covers reading response.headers from script.
 func TestHTTP_ResponseHeadersVisible(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Add `http.put`, `http.patch`, `http.delete` to the Starlark probe's `http` module.
- Refactor the duplicate `get`/`post` handlers into a shared `httpVerb` factory (no behavior change to existing verbs).

## Test plan
- New `TestHTTP_Verbs` asserts method + body reach the server for put/patch/delete.
- `go test ./probes/starlark/` passes.