### PR TITLE
[probes.grpcext] Add TLS/mTLS support for sidecar connections

### DIFF
--- a/examples/external_grpc/README.md
+++ b/examples/external_grpc/README.md
@@ -43,6 +43,23 @@ increment `internal_errors`, so you can tell a broken sidecar apart from a
 broken target; the failure reason is in cloudprober's logs. Try killing the
 sidecar to see it in action.
 
+## Serving over TLS / mTLS
+
+The unix-socket default is meant for a co-located sidecar. To reach one over
+the network, serve over TLS so probe configs (which may carry credentials)
+aren't sent in the clear. The example takes cert flags:
+
+```sh
+go run ./sidecar --addr=:9314 \
+  --tls_cert=server.crt --tls_key=server.key --client_ca=ca.crt
+```
+
+Passing `--client_ca` requires clients to present a cert signed by that CA
+(mutual TLS), so only cloudprober can send probes. On the cloudprober side,
+set `tls_config` in the probe (`ca_cert_file`, plus `tls_cert_file` /
+`tls_key_file` for the client cert). Omitting `--client_ca` serves plain
+server-side TLS.
+
 ## Writing your own sidecar
 
 A probe type is one struct — config in, result + metrics out; the SDK owns

--- a/examples/external_grpc/README.md
+++ b/examples/external_grpc/README.md
@@ -55,10 +55,36 @@ go run ./sidecar --addr=:9314 \
 ```
 
 Passing `--client_ca` requires clients to present a cert signed by that CA
-(mutual TLS), so only cloudprober can send probes. On the cloudprober side,
-set `tls_config` in the probe (`ca_cert_file`, plus `tls_cert_file` /
-`tls_key_file` for the client cert). Omitting `--client_ca` serves plain
-server-side TLS.
+(mutual TLS), so only cloudprober can send probes. Omitting `--client_ca`
+serves plain server-side TLS.
+
+On the cloudprober side, set `tls_config` in the probe:
+
+```
+probe {
+  name: "web_via_sidecar"
+  type: EXTERNAL_GRPC
+  targets { host_names: "cloudprober.org" }
+  external_grpc_probe {
+    server: "sidecar.example:9314"  # the sidecar, not the target
+    probe_type: "http"
+    tls_config {
+      ca_cert_file: "ca.crt"      # verifies the sidecar's server cert
+      tls_cert_file: "client.crt" # client cert (for mTLS)
+      tls_key_file: "client.key"
+      # server_name: "sidecar.example"
+    }
+  }
+}
+```
+
+`server_name` overrides the name checked against the sidecar's server cert.
+Set it when `server` is an IP or otherwise doesn't match a name/IP SAN on the
+cert (gRPC otherwise derives the expected name from the dial target, and
+verification fails) — e.g. `server: "10.0.0.5:9314"` with a cert issued for
+`sidecar.example` needs `server_name: "sidecar.example"`. Avoid
+`disable_cert_validation`: it skips verification entirely, which defeats the
+point of protecting credential-bearing probe configs on the wire.
 
 ## Writing your own sidecar
 

--- a/examples/external_grpc/sidecar/main.go
+++ b/examples/external_grpc/sidecar/main.go
@@ -112,6 +112,12 @@ func main() {
 	clientCA := flag.String("client_ca", "", "CA file to verify client certs. If set, clients must present a cert signed by it (mutual TLS).")
 	flag.Parse()
 
+	// Guard against a half-configured TLS setup silently serving plaintext:
+	// -client_ca / -tls_key only mean anything with a server cert.
+	if *tlsCert == "" && (*tlsKey != "" || *clientCA != "") {
+		log.Fatal("-tls_key/-client_ca require -tls_cert; not serving plaintext by accident")
+	}
+
 	opts := []sidecar.Option{
 		sidecar.Listen(*addr),
 		sidecar.Register("http", httpProbe),

--- a/examples/external_grpc/sidecar/main.go
+++ b/examples/external_grpc/sidecar/main.go
@@ -107,11 +107,19 @@ var tcpProbe = sidecar.ProbeType[tcpConfig, any]{
 
 func main() {
 	addr := flag.String("addr", "unix:/tmp/cloudprober-sidecar.sock", "Address to listen on: unix:/path/to/socket (portable form, see sidecar.Listen) or a TCP address like :9314")
+	tlsCert := flag.String("tls_cert", "", "Server certificate file. If set, the sidecar serves over TLS.")
+	tlsKey := flag.String("tls_key", "", "Server private key file (required with -tls_cert).")
+	clientCA := flag.String("client_ca", "", "CA file to verify client certs. If set, clients must present a cert signed by it (mutual TLS).")
 	flag.Parse()
 
-	log.Fatal(sidecar.Serve(
+	opts := []sidecar.Option{
 		sidecar.Listen(*addr),
 		sidecar.Register("http", httpProbe),
 		sidecar.Register("tcp", tcpProbe),
-	))
+	}
+	if *tlsCert != "" {
+		opts = append(opts, sidecar.TLS(*tlsCert, *tlsKey, *clientCA))
+	}
+
+	log.Fatal(sidecar.Serve(opts...))
 }

--- a/internal/testcerts/testcerts.go
+++ b/internal/testcerts/testcerts.go
@@ -1,0 +1,109 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testcerts generates throwaway TLS certificates for tests.
+package testcerts
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Generate writes a throwaway CA and one leaf certificate into dir and
+// returns their PEM file paths. The leaf is valid for localhost/127.0.0.1 and
+// usable as both a server and a client cert (server+client ExtKeyUsage), so a
+// single pair suffices for an mTLS test: the server presents the leaf, the
+// client presents the same leaf, and each trusts the CA.
+func Generate(dir string) (caFile, certFile, keyFile string, err error) {
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", "", "", err
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		return "", "", "", err
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", "", "", err
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		return "", "", "", err
+	}
+	leafKeyDER, err := x509.MarshalPKCS8PrivateKey(leafKey)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	caFile = filepath.Join(dir, "ca.pem")
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+	for _, f := range []struct {
+		path      string
+		blockType string
+		der       []byte
+	}{
+		{caFile, "CERTIFICATE", caDER},
+		{certFile, "CERTIFICATE", leafDER},
+		{keyFile, "PRIVATE KEY", leafKeyDER},
+	} {
+		if err := writePEM(f.path, f.blockType, f.der); err != nil {
+			return "", "", "", err
+		}
+	}
+	return caFile, certFile, keyFile, nil
+}
+
+func writePEM(path, blockType string, der []byte) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return pem.Encode(f, &pem.Block{Type: blockType, Bytes: der})
+}

--- a/pkg/sidecar/server.go
+++ b/pkg/sidecar/server.go
@@ -103,6 +103,9 @@ func TLS(certFile, keyFile, clientCAFile string) Option {
 }
 
 func loadServerTLS(certFile, keyFile, clientCAFile string) (credentials.TransportCredentials, error) {
+	if certFile == "" || keyFile == "" {
+		return nil, fmt.Errorf("TLS requires both certFile and keyFile")
+	}
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("loading TLS cert/key: %v", err)

--- a/pkg/sidecar/server.go
+++ b/pkg/sidecar/server.go
@@ -117,11 +117,7 @@ func TLS(certFile, keyFile, clientCAFile string) Option {
 			return
 		}
 		s.creds = creds
-		if clientCAFile != "" {
-			s.tlsMode = "mTLS"
-		} else {
-			s.tlsMode = "TLS"
-		}
+		s.mtls = clientCAFile != ""
 	}
 }
 
@@ -197,7 +193,7 @@ type server struct {
 	initErrs   []error
 	ctx        context.Context
 	creds      credentials.TransportCredentials
-	tlsMode    string // "", "TLS", or "mTLS" — for startup log only
+	mtls       bool // requires a client cert; for the startup log only
 
 	mu       sync.Mutex
 	sessions map[string]*session // keyed by state handle
@@ -273,11 +269,14 @@ func Serve(opts ...Option) error {
 	}
 
 	mode := "plaintext"
-	if s.tlsMode != "" {
-		mode = s.tlsMode
+	if s.creds != nil {
+		mode = "TLS"
+		if s.mtls {
+			mode = "mTLS"
+		}
 	}
 	log.Printf("cloudprober sidecar: serving probe types %v on %s (%s)", s.typeNames(), s.addr, mode)
-	if _, isUnix := unixSocketPath(s.addr); s.tlsMode == "" && !isUnix && !isLoopbackListen(s.addr) {
+	if _, isUnix := unixSocketPath(s.addr); s.creds == nil && !isUnix && !isLoopbackListen(s.addr) {
 		log.Printf("cloudprober sidecar: WARNING serving plaintext on non-loopback address %s; "+
 			"probe configs may carry credentials — use sidecar.TLS()", s.addr)
 	}

--- a/pkg/sidecar/server.go
+++ b/pkg/sidecar/server.go
@@ -111,17 +111,30 @@ func IdleTTL(d time.Duration) Option {
 // the sidecar serves plaintext (fine for a co-located unix socket).
 func TLS(certFile, keyFile, clientCAFile string) Option {
 	return func(s *server) {
-		creds, err := loadServerTLS(certFile, keyFile, clientCAFile)
+		cfg, err := loadServerTLS(certFile, keyFile, clientCAFile)
 		if err != nil {
 			s.initErrs = append(s.initErrs, err)
 			return
 		}
-		s.creds = creds
-		s.mtls = clientCAFile != ""
+		s.tlsCfg = cfg
 	}
 }
 
-func loadServerTLS(certFile, keyFile, clientCAFile string) (credentials.TransportCredentials, error) {
+// TLSConfig serves with a caller-supplied tls.Config, for cases the simple
+// TLS option doesn't cover: automatic certificate reload (via
+// cfg.GetCertificate), non-default TLS versions, SPIFFE, etc. The config is
+// used as-is. For mutual TLS, set cfg.ClientCAs and
+// cfg.ClientAuth = tls.RequireAndVerifyClientCert.
+//
+// This is the escape hatch that keeps the SDK dependency-free: e.g. a
+// cloudprober user can build cfg with common/tlsconfig (which supports cert
+// reload) in their own main and pass it here, rather than the SDK pulling
+// that machinery in for everyone.
+func TLSConfig(cfg *tls.Config) Option {
+	return func(s *server) { s.tlsCfg = cfg }
+}
+
+func loadServerTLS(certFile, keyFile, clientCAFile string) (*tls.Config, error) {
 	if certFile == "" || keyFile == "" {
 		return nil, fmt.Errorf("TLS requires both certFile and keyFile")
 	}
@@ -142,7 +155,7 @@ func loadServerTLS(certFile, keyFile, clientCAFile string) (credentials.Transpor
 		cfg.ClientCAs = pool
 		cfg.ClientAuth = tls.RequireAndVerifyClientCert
 	}
-	return credentials.NewTLS(cfg), nil
+	return cfg, nil
 }
 
 // ShutdownOn makes Serve stop gracefully when ctx is canceled: it stops
@@ -192,8 +205,7 @@ type server struct {
 	probeTypes map[string]handler
 	initErrs   []error
 	ctx        context.Context
-	creds      credentials.TransportCredentials
-	mtls       bool // requires a client cert; for the startup log only
+	tlsCfg     *tls.Config // nil => serve plaintext
 
 	mu       sync.Mutex
 	sessions map[string]*session // keyed by state handle
@@ -243,8 +255,8 @@ func Serve(opts ...Option) error {
 	defer s.closeAllSessions()
 
 	var serverOpts []grpc.ServerOption
-	if s.creds != nil {
-		serverOpts = append(serverOpts, grpc.Creds(s.creds))
+	if s.tlsCfg != nil {
+		serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(s.tlsCfg)))
 	}
 	grpcServer := grpc.NewServer(serverOpts...)
 	pb.RegisterProberServer(grpcServer, s)
@@ -269,14 +281,14 @@ func Serve(opts ...Option) error {
 	}
 
 	mode := "plaintext"
-	if s.creds != nil {
+	if s.tlsCfg != nil {
 		mode = "TLS"
-		if s.mtls {
+		if s.tlsCfg.ClientAuth == tls.RequireAndVerifyClientCert {
 			mode = "mTLS"
 		}
 	}
 	log.Printf("cloudprober sidecar: serving probe types %v on %s (%s)", s.typeNames(), s.addr, mode)
-	if _, isUnix := unixSocketPath(s.addr); s.creds == nil && !isUnix && !isLoopbackListen(s.addr) {
+	if _, isUnix := unixSocketPath(s.addr); s.tlsCfg == nil && !isUnix && !isLoopbackListen(s.addr) {
 		log.Printf("cloudprober sidecar: WARNING serving plaintext on non-loopback address %s; "+
 			"probe configs may carry credentials — use sidecar.TLS()", s.addr)
 	}

--- a/pkg/sidecar/server.go
+++ b/pkg/sidecar/server.go
@@ -17,6 +17,8 @@ package sidecar
 import (
 	"context"
 	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"log"
@@ -32,6 +34,7 @@ import (
 	pb "github.com/cloudprober/cloudprober/probes/grpcext/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
@@ -76,6 +79,48 @@ func unixSocketPath(addr string) (path string, ok bool) {
 // sessions when targets disappear on the cloudprober side.
 func IdleTTL(d time.Duration) Option {
 	return func(s *server) { s.idleTTL = d }
+}
+
+// TLS makes the sidecar serve over TLS, presenting the certificate in
+// certFile/keyFile. If clientCAFile is non-empty, clients must present a
+// certificate signed by a CA in that file (mutual TLS) — the recommended
+// setup for a sidecar reachable over the network, so only cloudprober can
+// send it probe configs. An empty clientCAFile serves plain server-side TLS
+// (encrypts the connection but doesn't authenticate the caller).
+//
+// Whether to require a client cert is left to the sidecar author: wire
+// clientCAFile to a flag and mTLS is on when it's set. Without this option
+// the sidecar serves plaintext (fine for a co-located unix socket).
+func TLS(certFile, keyFile, clientCAFile string) Option {
+	return func(s *server) {
+		creds, err := loadServerTLS(certFile, keyFile, clientCAFile)
+		if err != nil {
+			s.initErrs = append(s.initErrs, err)
+			return
+		}
+		s.creds = creds
+	}
+}
+
+func loadServerTLS(certFile, keyFile, clientCAFile string) (credentials.TransportCredentials, error) {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("loading TLS cert/key: %v", err)
+	}
+	cfg := &tls.Config{Certificates: []tls.Certificate{cert}}
+	if clientCAFile != "" {
+		caPEM, err := os.ReadFile(clientCAFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading client CA file %s: %v", clientCAFile, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caPEM) {
+			return nil, fmt.Errorf("no certificates found in client CA file %s", clientCAFile)
+		}
+		cfg.ClientCAs = pool
+		cfg.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+	return credentials.NewTLS(cfg), nil
 }
 
 // ShutdownOn makes Serve stop gracefully when ctx is canceled: it stops
@@ -125,6 +170,7 @@ type server struct {
 	probeTypes map[string]handler
 	initErrs   []error
 	ctx        context.Context
+	creds      credentials.TransportCredentials
 
 	mu       sync.Mutex
 	sessions map[string]*session // keyed by state handle
@@ -173,7 +219,11 @@ func Serve(opts ...Option) error {
 	// leak until the process exits.
 	defer s.closeAllSessions()
 
-	grpcServer := grpc.NewServer()
+	var serverOpts []grpc.ServerOption
+	if s.creds != nil {
+		serverOpts = append(serverOpts, grpc.Creds(s.creds))
+	}
+	grpcServer := grpc.NewServer(serverOpts...)
 	pb.RegisterProberServer(grpcServer, s)
 	healthServer := health.NewServer()
 	healthpb.RegisterHealthServer(grpcServer, healthServer)

--- a/pkg/sidecar/server.go
+++ b/pkg/sidecar/server.go
@@ -70,6 +70,24 @@ func unixSocketPath(addr string) (path string, ok bool) {
 	return strings.CutPrefix(addr, "unix:")
 }
 
+// isLoopbackListen reports whether a TCP listen address binds only to
+// loopback, so plaintext traffic there never leaves the host. An empty host
+// (e.g. ":9314") binds all interfaces and is treated as non-loopback, as is
+// any hostname other than "localhost" (it may resolve anywhere).
+func isLoopbackListen(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
 // IdleTTL overrides how long an unused per-target session is kept before
 // being evicted and Closed. Default is 10 minutes; a zero or negative value
 // disables idle eviction entirely. Sessions of probes that report their
@@ -99,6 +117,11 @@ func TLS(certFile, keyFile, clientCAFile string) Option {
 			return
 		}
 		s.creds = creds
+		if clientCAFile != "" {
+			s.tlsMode = "mTLS"
+		} else {
+			s.tlsMode = "TLS"
+		}
 	}
 }
 
@@ -174,6 +197,7 @@ type server struct {
 	initErrs   []error
 	ctx        context.Context
 	creds      credentials.TransportCredentials
+	tlsMode    string // "", "TLS", or "mTLS" — for startup log only
 
 	mu       sync.Mutex
 	sessions map[string]*session // keyed by state handle
@@ -248,7 +272,15 @@ func Serve(opts ...Option) error {
 		defer stop()
 	}
 
-	log.Printf("cloudprober sidecar: serving probe types %v on %s", s.typeNames(), s.addr)
+	mode := "plaintext"
+	if s.tlsMode != "" {
+		mode = s.tlsMode
+	}
+	log.Printf("cloudprober sidecar: serving probe types %v on %s (%s)", s.typeNames(), s.addr, mode)
+	if _, isUnix := unixSocketPath(s.addr); s.tlsMode == "" && !isUnix && !isLoopbackListen(s.addr) {
+		log.Printf("cloudprober sidecar: WARNING serving plaintext on non-loopback address %s; "+
+			"probe configs may carry credentials — use sidecar.TLS()", s.addr)
+	}
 	serveErr := make(chan error, 1)
 	go func() { serveErr <- grpcServer.Serve(lis) }()
 	select {

--- a/pkg/sidecar/sidecar_test.go
+++ b/pkg/sidecar/sidecar_test.go
@@ -577,6 +577,46 @@ func TestServeMutualTLS(t *testing.T) {
 	require.Error(t, err, "probe without a client cert should be rejected")
 }
 
+// TestServeServerTLS covers the server-only TLS mode (empty client CA): a
+// client that presents no client cert is still accepted, and the channel is
+// encrypted/authenticated against the server cert.
+func TestServeServerTLS(t *testing.T) {
+	caFile, certFile, keyFile := writeTestCerts(t)
+	addr := freeTCPAddr(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		err := Serve(
+			Listen(addr),
+			ShutdownOn(ctx),
+			TLS(certFile, keyFile, ""), // empty client CA => no client cert required
+			Register("counter", counterProbe),
+		)
+		log.Println("Serve returned:", err)
+	}()
+
+	caPEM, err := os.ReadFile(caFile)
+	require.NoError(t, err)
+	pool := x509.NewCertPool()
+	require.True(t, pool.AppendCertsFromPEM(caPEM))
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+		RootCAs:    pool,
+		ServerName: "localhost",
+	})))
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	client := pb.NewProberClient(conn)
+
+	require.Eventually(t, func() bool {
+		rpcCtx, c := context.WithTimeout(context.Background(), time.Second)
+		defer c()
+		_, err := client.Probe(rpcCtx, probeReq("counter", "", nil))
+		return err == nil
+	}, 5*time.Second, 50*time.Millisecond, "server-TLS probe never succeeded")
+}
+
 func TestTLSOptionError(t *testing.T) {
 	err := Serve(
 		Listen(freeTCPAddr(t)),
@@ -585,4 +625,14 @@ func TestTLSOptionError(t *testing.T) {
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "loading TLS cert/key")
+}
+
+func TestTLSOptionEmptyPaths(t *testing.T) {
+	err := Serve(
+		Listen(freeTCPAddr(t)),
+		TLS("cert.pem", "", ""),
+		Register("counter", counterProbe),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires both certFile and keyFile")
 }

--- a/pkg/sidecar/sidecar_test.go
+++ b/pkg/sidecar/sidecar_test.go
@@ -636,3 +636,18 @@ func TestTLSOptionEmptyPaths(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "requires both certFile and keyFile")
 }
+
+func TestIsLoopbackListen(t *testing.T) {
+	for addr, want := range map[string]bool{
+		"127.0.0.1:9314":       true,
+		"localhost:9314":       true,
+		"[::1]:9314":           true,
+		":9314":                false, // all interfaces
+		"0.0.0.0:9314":         false,
+		"10.0.0.5:9314":        false,
+		"sidecar.example:9314": false,
+		"not-an-addr":          false, // SplitHostPort error
+	} {
+		assert.Equalf(t, want, isLoopbackListen(addr), "isLoopbackListen(%q)", addr)
+	}
+}

--- a/pkg/sidecar/sidecar_test.go
+++ b/pkg/sidecar/sidecar_test.go
@@ -16,17 +16,11 @@ package sidecar
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"errors"
 	"fmt"
 	"log"
-	"math/big"
 	"net"
 	"os"
 	"path/filepath"
@@ -34,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cloudprober/cloudprober/internal/testcerts"
 	pb "github.com/cloudprober/cloudprober/probes/grpcext/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,63 +40,11 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// writeTestCerts generates a throwaway CA and one leaf certificate usable as
-// both a server and a client cert (valid for localhost/127.0.0.1), writes
-// them to a temp dir, and returns the file paths. Enough for an mTLS test:
-// the server presents the leaf, the client presents the same leaf, and each
-// trusts the CA.
 func writeTestCerts(t *testing.T) (caFile, certFile, keyFile string) {
 	t.Helper()
-
-	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	caFile, certFile, keyFile, err := testcerts.Generate(t.TempDir())
 	require.NoError(t, err)
-	caTmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "test-ca"},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
-		IsCA:                  true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
-		BasicConstraintsValid: true,
-	}
-	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
-	require.NoError(t, err)
-	caCert, err := x509.ParseCertificate(caDER)
-	require.NoError(t, err)
-
-	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	leafTmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(2),
-		Subject:      pkix.Name{CommonName: "localhost"},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
-		DNSNames:     []string{"localhost"},
-		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
-	}
-	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
-	require.NoError(t, err)
-	leafKeyDER, err := x509.MarshalPKCS8PrivateKey(leafKey)
-	require.NoError(t, err)
-
-	dir := t.TempDir()
-	caFile = filepath.Join(dir, "ca.pem")
-	certFile = filepath.Join(dir, "cert.pem")
-	keyFile = filepath.Join(dir, "key.pem")
-	writePEM(t, caFile, "CERTIFICATE", caDER)
-	writePEM(t, certFile, "CERTIFICATE", leafDER)
-	writePEM(t, keyFile, "PRIVATE KEY", leafKeyDER)
 	return caFile, certFile, keyFile
-}
-
-func writePEM(t *testing.T, path, blockType string, der []byte) {
-	t.Helper()
-	f, err := os.Create(path)
-	require.NoError(t, err)
-	defer f.Close()
-	require.NoError(t, pem.Encode(f, &pem.Block{Type: blockType, Bytes: der}))
 }
 
 // freeTCPAddr returns a currently-free loopback TCP address. There's an

--- a/pkg/sidecar/sidecar_test.go
+++ b/pkg/sidecar/sidecar_test.go
@@ -16,9 +16,18 @@ package sidecar
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"log"
+	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -30,10 +39,82 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 )
+
+// writeTestCerts generates a throwaway CA and one leaf certificate usable as
+// both a server and a client cert (valid for localhost/127.0.0.1), writes
+// them to a temp dir, and returns the file paths. Enough for an mTLS test:
+// the server presents the leaf, the client presents the same leaf, and each
+// trusts the CA.
+func writeTestCerts(t *testing.T) (caFile, certFile, keyFile string) {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+	leafKeyDER, err := x509.MarshalPKCS8PrivateKey(leafKey)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	caFile = filepath.Join(dir, "ca.pem")
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+	writePEM(t, caFile, "CERTIFICATE", caDER)
+	writePEM(t, certFile, "CERTIFICATE", leafDER)
+	writePEM(t, keyFile, "PRIVATE KEY", leafKeyDER)
+	return caFile, certFile, keyFile
+}
+
+func writePEM(t *testing.T, path, blockType string, der []byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	require.NoError(t, pem.Encode(f, &pem.Block{Type: blockType, Bytes: der}))
+}
+
+// freeTCPAddr returns a currently-free loopback TCP address. There's an
+// inherent race between releasing it and Serve re-binding, but it's fine for
+// a test — Serve needs a concrete address since it owns the listener.
+func freeTCPAddr(t *testing.T) string {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := lis.Addr().String()
+	require.NoError(t, lis.Close())
+	return addr
+}
 
 type counterConfig struct {
 	FailAfter  int  `json:"fail_after"`
@@ -442,4 +523,66 @@ func TestServeGracefulShutdown(t *testing.T) {
 	}
 	// The session left behind must have been closed on shutdown.
 	assert.Greater(t, closedSessions.Load(), closedBefore, "session was not closed on shutdown")
+}
+
+func TestServeMutualTLS(t *testing.T) {
+	caFile, certFile, keyFile := writeTestCerts(t)
+	addr := freeTCPAddr(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		err := Serve(
+			Listen(addr),
+			ShutdownOn(ctx),
+			TLS(certFile, keyFile, caFile),
+			Register("counter", counterProbe),
+		)
+		log.Println("Serve returned:", err)
+	}()
+
+	caPEM, err := os.ReadFile(caFile)
+	require.NoError(t, err)
+	pool := x509.NewCertPool()
+	require.True(t, pool.AppendCertsFromPEM(caPEM))
+	clientCert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	require.NoError(t, err)
+
+	dial := func(t *testing.T, tlsCfg *tls.Config) pb.ProberClient {
+		conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)))
+		require.NoError(t, err)
+		t.Cleanup(func() { conn.Close() })
+		return pb.NewProberClient(conn)
+	}
+
+	// A client that presents the CA-signed cert succeeds. Retry until the
+	// server is up (also confirms readiness for the negative case below).
+	mtlsClient := dial(t, &tls.Config{
+		Certificates: []tls.Certificate{clientCert},
+		RootCAs:      pool,
+		ServerName:   "localhost",
+	})
+	require.Eventually(t, func() bool {
+		rpcCtx, c := context.WithTimeout(context.Background(), time.Second)
+		defer c()
+		_, err := mtlsClient.Probe(rpcCtx, probeReq("counter", "", nil))
+		return err == nil
+	}, 5*time.Second, 50*time.Millisecond, "mTLS probe never succeeded")
+
+	// A client that omits its certificate is rejected by the handshake.
+	noCertClient := dial(t, &tls.Config{RootCAs: pool, ServerName: "localhost"})
+	rpcCtx, c := context.WithTimeout(context.Background(), 3*time.Second)
+	defer c()
+	_, err = noCertClient.Probe(rpcCtx, probeReq("counter", "", nil))
+	require.Error(t, err, "probe without a client cert should be rejected")
+}
+
+func TestTLSOptionError(t *testing.T) {
+	err := Serve(
+		Listen(freeTCPAddr(t)),
+		TLS("/no/such/cert.pem", "/no/such/key.pem", ""),
+		Register("counter", counterProbe),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "loading TLS cert/key")
 }

--- a/pkg/sidecar/sidecar_test.go
+++ b/pkg/sidecar/sidecar_test.go
@@ -560,6 +560,54 @@ func TestServeServerTLS(t *testing.T) {
 	}, 5*time.Second, 50*time.Millisecond, "server-TLS probe never succeeded")
 }
 
+// TestServeTLSConfigOption covers the TLSConfig escape hatch: the sidecar
+// serves with a caller-built *tls.Config (here requiring a client cert), so
+// authors can plug in reload/versions/etc. the simple TLS option doesn't
+// expose.
+func TestServeTLSConfigOption(t *testing.T) {
+	caFile, certFile, keyFile := writeTestCerts(t)
+	addr := freeTCPAddr(t)
+
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	require.NoError(t, err)
+	caPEM, err := os.ReadFile(caFile)
+	require.NoError(t, err)
+	pool := x509.NewCertPool()
+	require.True(t, pool.AppendCertsFromPEM(caPEM))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		err := Serve(
+			Listen(addr),
+			ShutdownOn(ctx),
+			TLSConfig(&tls.Config{
+				Certificates: []tls.Certificate{cert},
+				ClientCAs:    pool,
+				ClientAuth:   tls.RequireAndVerifyClientCert,
+			}),
+			Register("counter", counterProbe),
+		)
+		log.Println("Serve returned:", err)
+	}()
+
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      pool,
+		ServerName:   "localhost",
+	})))
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	client := pb.NewProberClient(conn)
+
+	require.Eventually(t, func() bool {
+		rpcCtx, c := context.WithTimeout(context.Background(), time.Second)
+		defer c()
+		_, err := client.Probe(rpcCtx, probeReq("counter", "", nil))
+		return err == nil
+	}, 5*time.Second, 50*time.Millisecond, "TLSConfig probe never succeeded")
+}
+
 func TestTLSOptionError(t *testing.T) {
 	err := Serve(
 		Listen(freeTCPAddr(t)),

--- a/probes/grpcext/grpcext.go
+++ b/probes/grpcext/grpcext.go
@@ -23,11 +23,13 @@ package grpcext
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/cloudprober/cloudprober/common/tlsconfig"
 	"github.com/cloudprober/cloudprober/internal/validators"
 	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/metrics"
@@ -39,6 +41,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -121,9 +124,11 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 		return errors.New("external_grpc probe: probe_type must be specified")
 	}
 
-	// Sidecars are expected to be co-located (unix domain socket or
-	// localhost). TODO(manugarg): Add mTLS support for TCP servers.
-	conn, err := grpc.NewClient(p.c.GetServer(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	creds, err := p.transportCredentials()
+	if err != nil {
+		return err
+	}
+	conn, err := grpc.NewClient(p.c.GetServer(), grpc.WithTransportCredentials(creds))
 	if err != nil {
 		return fmt.Errorf("error creating gRPC client for %s: %v", p.c.GetServer(), err)
 	}
@@ -141,6 +146,21 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 		return err
 	}
 	return nil
+}
+
+// transportCredentials builds the gRPC transport credentials for the sidecar
+// connection. If tls_config is set, the connection uses TLS (and mTLS when a
+// client cert is configured); otherwise it's insecure — the expected default
+// for a co-located unix socket or loopback sidecar.
+func (p *Probe) transportCredentials() (credentials.TransportCredentials, error) {
+	if p.c.GetTlsConfig() == nil {
+		return insecure.NewCredentials(), nil
+	}
+	tlsCfg := &tls.Config{}
+	if err := tlsconfig.UpdateTLSConfig(tlsCfg, p.c.GetTlsConfig()); err != nil {
+		return nil, fmt.Errorf("external_grpc probe: tls_config error: %v", err)
+	}
+	return credentials.NewTLS(tlsCfg), nil
 }
 
 // validateConfigWithSidecar asks the sidecar to check probe_type and config

--- a/probes/grpcext/grpcext_test.go
+++ b/probes/grpcext/grpcext_test.go
@@ -16,6 +16,14 @@ package grpcext
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"net"
 	"os"
 	"path/filepath"
@@ -23,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	tlsconfigpb "github.com/cloudprober/cloudprober/common/tlsconfig/proto"
 	"github.com/cloudprober/cloudprober/internal/validators"
 	validatorpb "github.com/cloudprober/cloudprober/internal/validators/proto"
 	"github.com/cloudprober/cloudprober/logger"
@@ -37,6 +46,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -108,6 +118,87 @@ func startFakeSidecar(t *testing.T, f *fakeSidecar) string {
 	go srv.Serve(lis)
 	t.Cleanup(srv.Stop)
 	return addr
+}
+
+// startFakeSidecarTLS runs f over TCP with mTLS (requires a client cert
+// signed by caFile) and returns the server address.
+func startFakeSidecarTLS(t *testing.T, f *fakeSidecar, certFile, keyFile, caFile string) string {
+	t.Helper()
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	require.NoError(t, err)
+	caPEM, err := os.ReadFile(caFile)
+	require.NoError(t, err)
+	pool := x509.NewCertPool()
+	require.True(t, pool.AppendCertsFromPEM(caPEM))
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := grpc.NewServer(grpc.Creds(credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientCAs:    pool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+	})))
+	configpb.RegisterProberServer(srv, f)
+	go srv.Serve(lis)
+	t.Cleanup(srv.Stop)
+	return lis.Addr().String()
+}
+
+// writeTestCerts generates a throwaway CA and one leaf certificate usable as
+// both a server and a client cert (valid for localhost/127.0.0.1), and
+// returns the PEM file paths.
+func writeTestCerts(t *testing.T) (caFile, certFile, keyFile string) {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+	leafKeyDER, err := x509.MarshalPKCS8PrivateKey(leafKey)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	caFile = filepath.Join(dir, "ca.pem")
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+	writePEM(t, caFile, "CERTIFICATE", caDER)
+	writePEM(t, certFile, "CERTIFICATE", leafDER)
+	writePEM(t, keyFile, "PRIVATE KEY", leafKeyDER)
+	return caFile, certFile, keyFile
+}
+
+func writePEM(t *testing.T, path, blockType string, der []byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	require.NoError(t, pem.Encode(f, &pem.Block{Type: blockType, Bytes: der}))
 }
 
 func newOpts(t *testing.T, server string) *options.Options {
@@ -477,4 +568,69 @@ func TestInternalErrorOnHungHandshake(t *testing.T) {
 	result := runReq.Result.(*probeResult)
 	assert.Equal(t, int64(1), result.total)
 	assert.Equal(t, int64(1), result.internalErrors)
+}
+
+func TestProbeMutualTLS(t *testing.T) {
+	caFile, certFile, keyFile := writeTestCerts(t)
+	f := &fakeSidecar{
+		respFn: func(*configpb.ProbeRequest) *configpb.ProbeResponse {
+			return &configpb.ProbeResponse{Success: true, Latency: durationpb.New(time.Millisecond)}
+		},
+	}
+	addr := startFakeSidecarTLS(t, f, certFile, keyFile, caFile)
+
+	opts := newOpts(t, addr)
+	opts.ProbeConf.(*configpb.ProbeConf).TlsConfig = &tlsconfigpb.TLSConfig{
+		CaCertFile:  proto.String(caFile),
+		TlsCertFile: proto.String(certFile),
+		TlsKeyFile:  proto.String(keyFile),
+		ServerName:  proto.String("localhost"),
+	}
+	p := initProbe(t, opts)
+
+	runReq := newRunReq()
+	runProbeOnce(t, p, runReq)
+
+	assert.True(t, runReq.LastRun.Success)
+	result := runReq.Result.(*probeResult)
+	assert.Equal(t, int64(1), result.success)
+	assert.Equal(t, int64(0), result.internalErrors)
+}
+
+// Without a client cert, the mTLS handshake fails; the probe run is reported
+// as an internal error, not a target failure.
+func TestProbeTLSNoClientCertIsInternalError(t *testing.T) {
+	caFile, certFile, keyFile := writeTestCerts(t)
+	f := &fakeSidecar{
+		respFn: func(*configpb.ProbeRequest) *configpb.ProbeResponse {
+			return &configpb.ProbeResponse{Success: true, Latency: durationpb.New(time.Millisecond)}
+		},
+	}
+	addr := startFakeSidecarTLS(t, f, certFile, keyFile, caFile)
+
+	opts := newOpts(t, addr)
+	// CA + server name but no client cert/key: the server requires one.
+	opts.ProbeConf.(*configpb.ProbeConf).TlsConfig = &tlsconfigpb.TLSConfig{
+		CaCertFile: proto.String(caFile),
+		ServerName: proto.String("localhost"),
+	}
+	p := initProbe(t, opts)
+
+	runReq := newRunReq()
+	runProbeOnce(t, p, runReq)
+
+	assert.False(t, runReq.LastRun.Success)
+	result := runReq.Result.(*probeResult)
+	assert.Equal(t, int64(1), result.internalErrors)
+}
+
+func TestTransportCredentialsError(t *testing.T) {
+	opts := newOpts(t, "unix:/tmp/does-not-matter.sock")
+	opts.ProbeConf.(*configpb.ProbeConf).TlsConfig = &tlsconfigpb.TLSConfig{
+		TlsCertFile: proto.String("/no/such/cert.pem"),
+		TlsKeyFile:  proto.String("/no/such/key.pem"),
+	}
+	err := (&Probe{}).Init("test_probe", opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tls_config error")
 }

--- a/probes/grpcext/grpcext_test.go
+++ b/probes/grpcext/grpcext_test.go
@@ -16,14 +16,8 @@ package grpcext
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
-	"math/big"
 	"net"
 	"os"
 	"path/filepath"
@@ -32,6 +26,7 @@ import (
 	"time"
 
 	tlsconfigpb "github.com/cloudprober/cloudprober/common/tlsconfig/proto"
+	"github.com/cloudprober/cloudprober/internal/testcerts"
 	"github.com/cloudprober/cloudprober/internal/validators"
 	validatorpb "github.com/cloudprober/cloudprober/internal/validators/proto"
 	"github.com/cloudprober/cloudprober/logger"
@@ -144,61 +139,11 @@ func startFakeSidecarTLS(t *testing.T, f *fakeSidecar, certFile, keyFile, caFile
 	return lis.Addr().String()
 }
 
-// writeTestCerts generates a throwaway CA and one leaf certificate usable as
-// both a server and a client cert (valid for localhost/127.0.0.1), and
-// returns the PEM file paths.
 func writeTestCerts(t *testing.T) (caFile, certFile, keyFile string) {
 	t.Helper()
-
-	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	caFile, certFile, keyFile, err := testcerts.Generate(t.TempDir())
 	require.NoError(t, err)
-	caTmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "test-ca"},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
-		IsCA:                  true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
-		BasicConstraintsValid: true,
-	}
-	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
-	require.NoError(t, err)
-	caCert, err := x509.ParseCertificate(caDER)
-	require.NoError(t, err)
-
-	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	leafTmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(2),
-		Subject:      pkix.Name{CommonName: "localhost"},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
-		DNSNames:     []string{"localhost"},
-		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
-	}
-	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
-	require.NoError(t, err)
-	leafKeyDER, err := x509.MarshalPKCS8PrivateKey(leafKey)
-	require.NoError(t, err)
-
-	dir := t.TempDir()
-	caFile = filepath.Join(dir, "ca.pem")
-	certFile = filepath.Join(dir, "cert.pem")
-	keyFile = filepath.Join(dir, "key.pem")
-	writePEM(t, caFile, "CERTIFICATE", caDER)
-	writePEM(t, certFile, "CERTIFICATE", leafDER)
-	writePEM(t, keyFile, "PRIVATE KEY", leafKeyDER)
 	return caFile, certFile, keyFile
-}
-
-func writePEM(t *testing.T, path, blockType string, der []byte) {
-	t.Helper()
-	f, err := os.Create(path)
-	require.NoError(t, err)
-	defer f.Close()
-	require.NoError(t, pem.Encode(f, &pem.Block{Type: blockType, Bytes: der}))
 }
 
 func newOpts(t *testing.T, server string) *options.Options {

--- a/probes/grpcext/proto/config.pb.go
+++ b/probes/grpcext/proto/config.pb.go
@@ -7,6 +7,7 @@
 package proto
 
 import (
+	proto1 "github.com/cloudprober/cloudprober/common/tlsconfig/proto"
 	proto "github.com/cloudprober/cloudprober/metrics/payload/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -34,7 +35,9 @@ type ProbeConf struct {
 	// Sidecar server address. Typically a co-located unix domain socket, e.g.
 	// "unix:/var/run/cloudprober/sidecar.sock" (single colon — this form works
 	// for both POSIX and Windows paths; see sidecar.Listen), but any gRPC
-	// target string works, e.g. "localhost:9314".
+	// target string works, e.g. "localhost:9314". For a sidecar reachable over
+	// the network rather than a co-located socket, set tls_config below so the
+	// connection is authenticated and encrypted.
 	Server *string `protobuf:"bytes,1,opt,name=server" json:"server,omitempty"`
 	// Probe type registered on the sidecar, e.g. "snowsql". A single sidecar
 	// process can serve multiple probe types.
@@ -49,8 +52,14 @@ type ProbeConf struct {
 	// options control how they're parsed (metrics kind, aggregation,
 	// distributions, etc.). Same surface as external and http probes.
 	OutputMetricsOptions *proto.OutputMetricsOptions `protobuf:"bytes,4,opt,name=output_metrics_options,json=outputMetricsOptions" json:"output_metrics_options,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// TLS config for the connection to the sidecar. If unset, the connection is
+	// insecure (plaintext) — fine for a co-located unix socket or loopback, but
+	// for a sidecar reached over the network set this so probe configs (which
+	// may carry credentials) aren't sent in the clear. Provide tls_cert_file /
+	// tls_key_file to present a client certificate for mTLS.
+	TlsConfig     *proto1.TLSConfig `protobuf:"bytes,5,opt,name=tls_config,json=tlsConfig" json:"tls_config,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ProbeConf) Reset() {
@@ -111,17 +120,26 @@ func (x *ProbeConf) GetOutputMetricsOptions() *proto.OutputMetricsOptions {
 	return nil
 }
 
+func (x *ProbeConf) GetTlsConfig() *proto1.TLSConfig {
+	if x != nil {
+		return x.TlsConfig
+	}
+	return nil
+}
+
 var File_github_com_cloudprober_cloudprober_probes_grpcext_proto_config_proto protoreflect.FileDescriptor
 
 const file_github_com_cloudprober_cloudprober_probes_grpcext_proto_config_proto_rawDesc = "" +
 	"\n" +
-	"Dgithub.com/cloudprober/cloudprober/probes/grpcext/proto/config.proto\x12\x1acloudprober.probes.grpcext\x1aEgithub.com/cloudprober/cloudprober/metrics/payload/proto/config.proto\"\xc3\x01\n" +
+	"Dgithub.com/cloudprober/cloudprober/probes/grpcext/proto/config.proto\x12\x1acloudprober.probes.grpcext\x1aFgithub.com/cloudprober/cloudprober/common/tlsconfig/proto/config.proto\x1aEgithub.com/cloudprober/cloudprober/metrics/payload/proto/config.proto\"\x84\x02\n" +
 	"\tProbeConf\x12\x16\n" +
 	"\x06server\x18\x01 \x01(\tR\x06server\x12\x1d\n" +
 	"\n" +
 	"probe_type\x18\x02 \x01(\tR\tprobeType\x12\x16\n" +
 	"\x06config\x18\x03 \x01(\tR\x06config\x12g\n" +
-	"\x16output_metrics_options\x18\x04 \x01(\v21.cloudprober.metrics.payload.OutputMetricsOptionsR\x14outputMetricsOptionsB9Z7github.com/cloudprober/cloudprober/probes/grpcext/proto"
+	"\x16output_metrics_options\x18\x04 \x01(\v21.cloudprober.metrics.payload.OutputMetricsOptionsR\x14outputMetricsOptions\x12?\n" +
+	"\n" +
+	"tls_config\x18\x05 \x01(\v2 .cloudprober.tlsconfig.TLSConfigR\ttlsConfigB9Z7github.com/cloudprober/cloudprober/probes/grpcext/proto"
 
 var (
 	file_github_com_cloudprober_cloudprober_probes_grpcext_proto_config_proto_rawDescOnce sync.Once
@@ -139,14 +157,16 @@ var file_github_com_cloudprober_cloudprober_probes_grpcext_proto_config_proto_ms
 var file_github_com_cloudprober_cloudprober_probes_grpcext_proto_config_proto_goTypes = []any{
 	(*ProbeConf)(nil),                  // 0: cloudprober.probes.grpcext.ProbeConf
 	(*proto.OutputMetricsOptions)(nil), // 1: cloudprober.metrics.payload.OutputMetricsOptions
+	(*proto1.TLSConfig)(nil),           // 2: cloudprober.tlsconfig.TLSConfig
 }
 var file_github_com_cloudprober_cloudprober_probes_grpcext_proto_config_proto_depIdxs = []int32{
 	1, // 0: cloudprober.probes.grpcext.ProbeConf.output_metrics_options:type_name -> cloudprober.metrics.payload.OutputMetricsOptions
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	2, // 1: cloudprober.probes.grpcext.ProbeConf.tls_config:type_name -> cloudprober.tlsconfig.TLSConfig
+	2, // [2:2] is the sub-list for method output_type
+	2, // [2:2] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_github_com_cloudprober_cloudprober_probes_grpcext_proto_config_proto_init() }

--- a/probes/grpcext/proto/config.proto
+++ b/probes/grpcext/proto/config.proto
@@ -2,6 +2,7 @@ syntax = "proto2";
 
 package cloudprober.probes.grpcext;
 
+import "github.com/cloudprober/cloudprober/common/tlsconfig/proto/config.proto";
 import "github.com/cloudprober/cloudprober/metrics/payload/proto/config.proto";
 
 option go_package = "github.com/cloudprober/cloudprober/probes/grpcext/proto";
@@ -17,7 +18,9 @@ message ProbeConf {
   // Sidecar server address. Typically a co-located unix domain socket, e.g.
   // "unix:/var/run/cloudprober/sidecar.sock" (single colon — this form works
   // for both POSIX and Windows paths; see sidecar.Listen), but any gRPC
-  // target string works, e.g. "localhost:9314".
+  // target string works, e.g. "localhost:9314". For a sidecar reachable over
+  // the network rather than a co-located socket, set tls_config below so the
+  // connection is authenticated and encrypted.
   optional string server = 1;
 
   // Probe type registered on the sidecar, e.g. "snowsql". A single sidecar
@@ -34,4 +37,11 @@ message ProbeConf {
   // options control how they're parsed (metrics kind, aggregation,
   // distributions, etc.). Same surface as external and http probes.
   optional metrics.payload.OutputMetricsOptions output_metrics_options = 4;
+
+  // TLS config for the connection to the sidecar. If unset, the connection is
+  // insecure (plaintext) — fine for a co-located unix socket or loopback, but
+  // for a sidecar reached over the network set this so probe configs (which
+  // may carry credentials) aren't sent in the clear. Provide tls_cert_file /
+  // tls_key_file to present a client certificate for mTLS.
+  optional tlsconfig.TLSConfig tls_config = 5;
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.go.exclusions=**/vendor/**
 
 sonar.sources=.
 sonar.exclusions=**/*_test.go,examples/**,**.pb.go,**/test_*.py,**_pb*.py
-sonar.coverage.exclusions=examples/**,**.pb.go, **/cmd/*.go,**/test_*.py,**_pb*.py
+sonar.coverage.exclusions=examples/**,**.pb.go, **/cmd/*.go,**/test_*.py,**_pb*.py,**/internal/testcerts/**
 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go


### PR DESCRIPTION
## Summary
- **Client**: `EXTERNAL_GRPC` probe config gets `tls_config` (reuses `common/tlsconfig.TLSConfig`, same surface as the grpc/http/sql probes). Unset ⇒ insecure, the co-located-socket default.
- **SDK**: new `sidecar.TLS(certFile, keyFile, clientCAFile)` option. A non-empty client CA requires a client cert (mTLS); empty serves plain server-side TLS. Author controls strictness via the CA arg (e.g. a flag).
- Runnable example gains `--tls_cert` / `--tls_key` / `--client_ca` flags.

Follow-up to #1363 — closes the plaintext-transport gap noted in that review.

## Test plan
- `go test -race ./probes/grpcext/... ./pkg/sidecar/...`
- New tests: real mTLS handshake end-to-end on both sides (client cert accepted; missing client cert rejected → internal error), plus cert/key load error paths.