### PR TITLE
[common/tlsconfig] Add FromProto helper for building a *tls.Config

### DIFF
--- a/cloudprober.go
+++ b/cloudprober.go
@@ -23,7 +23,6 @@ package cloudprober
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"flag"
 	"fmt"
@@ -75,9 +74,9 @@ const (
 )
 
 var (
-	disableSysMetrics  = flag.Bool("disable_sys_metrics", false, "Disable system metrics probe")
-	logStoreMaxMemMB   = flag.Int("log_store_max_mem_mb", 50, "Max memory in MB for in-memory log store. 0 to disable.")
-	logStoreMinLevel   = flag.String("log_store_min_level", "INFO", "Minimum log level for stored logs. Valid values: DEBUG, INFO, WARNING, ERROR")
+	disableSysMetrics = flag.Bool("disable_sys_metrics", false, "Disable system metrics probe")
+	logStoreMaxMemMB  = flag.Int("log_store_max_mem_mb", 50, "Max memory in MB for in-memory log store. 0 to disable.")
+	logStoreMinLevel  = flag.String("log_store_min_level", "INFO", "Minimum log level for stored logs. Valid values: DEBUG, INFO, WARNING, ERROR")
 )
 
 // Global prober.Prober instance protected by a mutex.
@@ -266,8 +265,8 @@ func initWithConfigSource(configSrc config.ConfigSource) error {
 			var serverOpts []grpc.ServerOption
 
 			if cfg.GetGrpcTlsConfig() != nil {
-				tlsConfig := &tls.Config{}
-				if err := tlsconfig.UpdateTLSConfig(tlsConfig, cfg.GetGrpcTlsConfig()); err != nil {
+				tlsConfig, err := tlsconfig.FromProto(cfg.GetGrpcTlsConfig())
+				if err != nil {
 					return err
 				}
 				tlsConfig.ClientCAs = tlsConfig.RootCAs

--- a/common/tlsconfig/tlsconfig.go
+++ b/common/tlsconfig/tlsconfig.go
@@ -141,3 +141,18 @@ func UpdateTLSConfig(tlsConfig *tls.Config, c *configpb.TLSConfig) error {
 
 	return nil
 }
+
+// FromProto builds a new *tls.Config from the given proto by applying
+// UpdateTLSConfig to a zero-value config. It returns (nil, nil) for a nil
+// proto. Callers that need to modify an existing *tls.Config in place (e.g. a
+// transport's TLSClientConfig) should call UpdateTLSConfig directly.
+func FromProto(c *configpb.TLSConfig) (*tls.Config, error) {
+	if c == nil {
+		return nil, nil
+	}
+	tlsConfig := &tls.Config{}
+	if err := UpdateTLSConfig(tlsConfig, c); err != nil {
+		return nil, err
+	}
+	return tlsConfig, nil
+}

--- a/common/tlsconfig/tlsconfig_test.go
+++ b/common/tlsconfig/tlsconfig_test.go
@@ -185,3 +185,31 @@ func TestUpdateTLSConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestFromProto(t *testing.T) {
+	t.Run("nil proto returns nil config", func(t *testing.T) {
+		tc, err := FromProto(nil)
+		assert.NoError(t, err)
+		assert.Nil(t, tc)
+	})
+
+	t.Run("applies config to a fresh tls.Config", func(t *testing.T) {
+		tc, err := FromProto(&configpb.TLSConfig{
+			DisableCertValidation: proto.Bool(true),
+			ServerName:            proto.String("example.com"),
+		})
+		assert.NoError(t, err)
+		if assert.NotNil(t, tc) {
+			assert.True(t, tc.InsecureSkipVerify)
+			assert.Equal(t, "example.com", tc.ServerName)
+		}
+	})
+
+	t.Run("propagates UpdateTLSConfig error", func(t *testing.T) {
+		tc, err := FromProto(&configpb.TLSConfig{
+			CaCertFile: proto.String("/no/such/ca.pem"),
+		})
+		assert.Error(t, err)
+		assert.Nil(t, tc)
+	})
+}

--- a/internal/rds/client/client.go
+++ b/internal/rds/client/client.go
@@ -19,7 +19,6 @@ package client
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -214,8 +213,8 @@ func (client *Client) initListResourcesFunc() error {
 
 	// Transport security options.
 	if client.serverOpts.GetTlsConfig() != nil {
-		tlsConfig := &tls.Config{}
-		if err := tlsconfig.UpdateTLSConfig(tlsConfig, client.serverOpts.GetTlsConfig()); err != nil {
+		tlsConfig, err := tlsconfig.FromProto(client.serverOpts.GetTlsConfig())
+		if err != nil {
 			return fmt.Errorf("rds/client: error initializing TLS config (%+v): %v", client.serverOpts.GetTlsConfig(), err)
 		}
 		client.dialOpts = append(client.dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))

--- a/probes/grpc/grpc.go
+++ b/probes/grpc/grpc.go
@@ -22,7 +22,6 @@ package grpc
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -180,8 +179,8 @@ func (p *Probe) transportCredentials() (credentials.TransportCredentials, error)
 		return alts.NewClientCreds(altsOpts), nil
 	}
 	if p.c.GetTlsConfig() != nil {
-		tlsCfg := &tls.Config{}
-		if err := tlsconfig.UpdateTLSConfig(tlsCfg, p.c.GetTlsConfig()); err != nil {
+		tlsCfg, err := tlsconfig.FromProto(p.c.GetTlsConfig())
+		if err != nil {
 			return nil, fmt.Errorf("tls_config error: %v", err)
 		}
 		return credentials.NewTLS(tlsCfg), nil

--- a/probes/sql/sql.go
+++ b/probes/sql/sql.go
@@ -142,10 +142,11 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 	}
 
 	if p.c.GetTlsConfig() != nil {
-		p.tlsConfig = &tls.Config{}
-		if err := tlsconfig.UpdateTLSConfig(p.tlsConfig, p.c.GetTlsConfig()); err != nil {
+		tlsConfig, err := tlsconfig.FromProto(p.c.GetTlsConfig())
+		if err != nil {
 			return fmt.Errorf("tls_config error: %v", err)
 		}
+		p.tlsConfig = tlsConfig
 	}
 
 	if p.c.GetResponseMetricsOptions() != nil {

--- a/probes/starlark/starlark.go
+++ b/probes/starlark/starlark.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/cloudprober/cloudprober/common/tlsconfig"
-	tlsconfigpb "github.com/cloudprober/cloudprober/common/tlsconfig/proto"
 	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/metrics"
 	"github.com/cloudprober/cloudprober/metrics/payload"
@@ -118,7 +117,7 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 			if cfgName == "" {
 				return fmt.Errorf("starlark tls_configs: empty config name; every entry must have a non-empty key")
 			}
-			tc, err := tlsConfigFromProto(c)
+			tc, err := tlsconfig.FromProto(c)
 			if err != nil {
 				return fmt.Errorf("starlark tls_configs[%q]: %v", cfgName, err)
 			}
@@ -161,19 +160,6 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 		return fmt.Errorf("payload parser init: %v", err)
 	}
 	return nil
-}
-
-// tlsConfigFromProto turns a TLSConfig proto into a *tls.Config, returning nil
-// for a nil proto (meaning: Go's defaults).
-func tlsConfigFromProto(c *tlsconfigpb.TLSConfig) (*tls.Config, error) {
-	if c == nil {
-		return nil, nil
-	}
-	tc := &tls.Config{}
-	if err := tlsconfig.UpdateTLSConfig(tc, c); err != nil {
-		return nil, err
-	}
-	return tc, nil
 }
 
 func loadSource(c *configpb.ProbeConf) (string, error) {

--- a/probes/tcp/tcp.go
+++ b/probes/tcp/tcp.go
@@ -151,10 +151,11 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 			return fmt.Errorf("tls_config is set, but tls_handshake is false")
 		}
 
-		p.tlsConfig = &tls.Config{}
-		if err := tlsconfig.UpdateTLSConfig(p.tlsConfig, p.c.GetTlsConfig()); err != nil {
+		tlsConfig, err := tlsconfig.FromProto(p.c.GetTlsConfig())
+		if err != nil {
 			return fmt.Errorf("tls_config error: %v", err)
 		}
+		p.tlsConfig = tlsConfig
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Add `tlsconfig.FromProto(c) (*tls.Config, error)`, wrapping the `new &tls.Config{}` + `UpdateTLSConfig` idiom that several call sites open-code. A nil proto returns a nil config.
- Use it in the sites that build a fresh config: grpc, tcp, sql probes, the rds client, the default gRPC server in cloudprober.go, and the starlark probe (which had merged its own private copy of this helper in #1383).
- Sites that update an existing `*tls.Config` in place (http and kubernetes transports, otel) intentionally keep calling `UpdateTLSConfig` directly.

## Test plan

- New `TestFromProto` covers nil to nil, applied fields, and error propagation.
- `go test ./common/tlsconfig/ ./probes/grpc/ ./probes/tcp/ ./probes/sql/ ./probes/starlark/ ./internal/rds/client/ .`