### PR TITLE
[metrics/payload] Accept integer jq results in json_metric

### DIFF
--- a/metrics/payload/json_metrics.go
+++ b/metrics/payload/json_metrics.go
@@ -17,6 +17,7 @@ package payload
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"sort"
 
 	"github.com/cloudprober/cloudprober/metrics"
@@ -83,6 +84,18 @@ func jqValToMetricValue(v any) (metrics.Value, error) {
 		return metrics.NewString(v), nil
 	case float64:
 		return metrics.NewFloat(v), nil
+	// gojq returns integer literals and integer-valued results (e.g. length,
+	// add) as int, and *big.Int for values that overflow int.
+	case int:
+		return metrics.NewInt(int64(v)), nil
+	case *big.Int:
+		// metrics.Int is int64-backed; values that overflow it fall back to
+		// float, matching how large JSON numbers decode (via float64).
+		if v.IsInt64() {
+			return metrics.NewInt(v.Int64()), nil
+		}
+		f, _ := new(big.Float).SetInt(v).Float64()
+		return metrics.NewFloat(f), nil
 	case bool:
 		return metrics.NewInt(map[bool]int64{true: 1, false: 0}[v]), nil
 	default:

--- a/metrics/payload/json_metrics_test.go
+++ b/metrics/payload/json_metrics_test.go
@@ -122,6 +122,42 @@ func TestJSONMetrics(t *testing.T) {
 			},
 		},
 		{
+			name: "integer-valued jq results",
+			input: `{
+				"items": [1, 2, 3]
+			}`,
+			config: `
+				json_metric: [{
+					jq_filter: "{\"const\": 1, \"count\": (.items | length)}",
+				}]
+			`,
+			wantJM: []*jsonMetric{
+				{
+					metricsJQ: testMustJQParse("{\"const\": 1, \"count\": (.items | length)}"),
+				},
+			},
+			wantEMs: []string{
+				"labels= const=1 count=3",
+			},
+		},
+		{
+			name: "big integer jq literal",
+			config: `
+				json_metric: [{
+					jq_filter: "{\"big\": 10000000000000000000}",
+				}]
+			`,
+			input: "{}",
+			wantJM: []*jsonMetric{
+				{
+					metricsJQ: testMustJQParse("{\"big\": 10000000000000000000}"),
+				},
+			},
+			wantEMs: []string{
+				"labels= big=10000000000000000000.000",
+			},
+		},
+		{
 			name: "bad filter",
 			config: `
 			json_metric: [{


### PR DESCRIPTION
## Summary
- `jqValToMetricValue` only handled `float64`, but gojq returns integer literals and integer-valued results (`length`, `add`, counts) as `int` (and `*big.Int` on overflow). Filters like `{wh: 1}` or `{n: (.x | length)}` failed with an "unexpected value type" error.
- Handle `int` and `*big.Int` (float fallback when it overflows int64, matching how large JSON numbers already decode).

## Test plan
- New table cases in `json_metrics_test.go` for integer literals, `length`, and a big-int literal; `go test ./metrics/payload/` passes.