### PR TITLE
[probes.starlark] Add dns builtin: dns.resolve -> DnsResult

### DIFF
--- a/docs/content/docs/how-to/starlark-probe/index.md
+++ b/docs/content/docs/how-to/starlark-probe/index.md
@@ -112,13 +112,14 @@ target endpoint:
 ## Available builtins
 
 All scripts get a small, fixed set of builtins. No filesystem, network beyond
-`http`, or `exec` -- the probe is sandboxed by Starlark.
+`http` and `dns`, or `exec` -- the probe is sandboxed by Starlark.
 
 | Builtin | Purpose |
 |---|---|
 | `http.get(url, headers=None, max_redirects=N, keep_alive=False, tls=<name>)` | HTTP GET, returns a `Response`. `max_redirects=0` disables following; `max_redirects=N` follows up to N (omit for Go's default of 10). `keep_alive` defaults to `False` to match the HTTP probe -- every call exercises DNS/TCP/TLS setup, which is what you usually want from a prober. Pass `keep_alive=True` to reuse a pooled connection across calls in a chained API flow. `tls=<name>` selects one of the probe's `tls_configs` for this call; omit `tls` for system-default TLS. An empty string or `None` is an error, not a fall-back (see below). |
 | `http.post(url, headers=None, body=None, json=None, max_redirects=N, keep_alive=False, tls=<name>)` | HTTP POST. Pass `json=` for an auto-encoded JSON body (sets `Content-Type`), or `body=` for a raw string/bytes. `max_redirects`, `keep_alive` and `tls` match `http.get`. |
 | `http.put(...)`, `http.patch(...)`, `http.delete(...)` | HTTP PUT/PATCH/DELETE. Same signature and kwargs as `http.post` (`body=`/`json=` accepted for all three). |
+| `dns.resolve(name, type="A", server=None, timeout=None)` | Resolve `name`, returns a `DnsResult`. `type` is one of `A`, `AAAA`, `CNAME`, `MX`, `NS`, `TXT`, `SRV`, `PTR` (case-insensitive). `server=None` resolves the way the host does; pass `server="8.8.8.8"` (port optional) to ask a specific nameserver. `timeout` is in seconds (see below). |
 | `assert.http_status(response, expected)` | Fails the probe if `response.status != expected`. Stamp per-call context onto the failure log line with `log.set_attr` instead of inlining it into the error message. |
 | `vars.get(name, default=None)` | Read values from the probe's `vars` config map (see below). |
 | `state.get(key, default=None)` / `state.set(key, value)` | Per-target key-value store that persists across runs (see below). |
@@ -143,6 +144,58 @@ r.headers    # dict[str,str]; multi-valued headers are ", "-joined
 r.body       # bytes
 r.json()     # parsed JSON (raises on parse error)
 ```
+
+### `dns`
+
+`dns.resolve` is for resolving a name as a *step* in a script -- look up the
+records, branch on them, feed them into an HTTP call:
+
+```python
+def probe(target):
+    r = dns.resolve(target.name, type="A")
+    if not r:
+        fail("%s has no A record" % target.name)
+    if r.latency(unit="ms") > 200:
+        fail("slow resolution: %sms" % r.latency(unit="ms"))
+    http.get("http://%s/healthz" % r.answers[0])
+```
+
+A `DnsResult` carries the answers and how long the lookup took:
+
+```python
+r.answers          # list[str], frozen; [] if nothing was found
+r.name             # the name that was looked up
+r.type             # normalized record type, e.g. "A"
+r.latency()        # float seconds; r.latency(unit="ms") for milliseconds
+if r: ...          # truthy iff r.answers is non-empty
+```
+
+Answers are flat strings, formatted per record type: `A`/`AAAA` are IPs,
+`CNAME`/`NS`/`PTR` are names, `TXT` is the record text, `MX` is
+`"<pref> <host>"`, and `SRV` is `"<priority> <weight> <port> <target>"`.
+
+**Finding nothing is a result, not an error.** A name that doesn't resolve
+gives you an empty `.answers` (and a falsey result), so scripts decide whether
+that's a failure. Every *other* lookup failure -- timeout, SERVFAIL, REFUSED,
+network error, malformed response -- raises and fails the probe. Pass
+`timeout=<seconds>` to bound a single call; without it, the call is bounded by
+the probe timeout.
+
+**`server=None` and `server=<addr>` are not the same lookup.** The default
+resolves exactly the way the host does, honoring `/etc/hosts`, the search list
+and `ndots` -- that's the mode for "what does this machine see?". Naming a
+server dials it directly with Go's pure-Go resolver, which skips `/etc/hosts`
+and the host's resolver choice; it answers "what does that nameserver say?"
+well enough for a probe step, but it is not `dig`.
+
+{{< alert context="info" >}}
+**Use the [`dns` probe type](https://cloudprober.org/docs/config/latest/probes/#cloudprober_probes_dns_ProbeConf) to monitor a DNS server.**
+This builtin is a resolver, not a DNS client: there is no wire rcode, no TTL,
+and no way to tell NODATA ("the name exists, but has no record of this type")
+from NXDOMAIN -- both simply come back with no answers. If you need to assert
+real server behavior -- SERVFAIL vs REFUSED, NODATA vs NXDOMAIN, per-record
+validators, UDP/TCP/TLS -- that's the DNS probe's job.
+{{< /alert >}}
 
 ### TLS configuration
 

--- a/probes/starlark/builtins.go
+++ b/probes/starlark/builtins.go
@@ -18,9 +18,47 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"time"
 
 	starlarklib "go.starlark.net/starlark"
 )
+
+// latencyMethod builds a Starlark method that reports a duration in a
+// caller-chosen unit: latency() -> float seconds (default), latency("ms") ->
+// milliseconds. Shared by result values that expose a measured latency
+// (dns.resolve today; http Response next) so the call shape is identical.
+func latencyMethod(recvName string, d time.Duration) *starlarklib.Builtin {
+	return starlarklib.NewBuiltin(recvName+".latency", func(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
+		unit := "s"
+		if err := starlarklib.UnpackArgs(recvName+".latency", args, kwargs, "unit?", &unit); err != nil {
+			return nil, err
+		}
+		switch unit {
+		case "s":
+			return starlarklib.Float(d.Seconds()), nil
+		case "ms":
+			return starlarklib.Float(float64(d.Nanoseconds()) / 1e6), nil
+		}
+		return nil, fmt.Errorf("%s.latency: unknown unit %q (want \"s\" or \"ms\")", recvName, unit)
+	})
+}
+
+// optionalDurationSeconds converts a Value bound by UnpackArgs (with "??"
+// suffix) into a duration, interpreting the number as seconds. The bool result
+// is false when the kwarg was omitted or None.
+func optionalDurationSeconds(v starlarklib.Value, name string) (time.Duration, bool, error) {
+	if v == nil {
+		return 0, false, nil
+	}
+	switch n := v.(type) {
+	case starlarklib.Int:
+		i, _ := n.Int64()
+		return time.Duration(i) * time.Second, true, nil
+	case starlarklib.Float:
+		return time.Duration(float64(n) * float64(time.Second)), true, nil
+	}
+	return 0, false, fmt.Errorf("%s: expected a number of seconds, got %s", name, v.Type())
+}
 
 // sortedNames returns m's keys in sorted order. Used by the builtins that
 // select a probe-configured thing by name (oauth_configs, tls_configs) to list
@@ -40,6 +78,7 @@ func builtins(vars map[string]string) starlarklib.StringDict {
 		"log":          logModule(),
 		"state":        stateModule(),
 		"oauth":        oauthModule(),
+		"dns":          dnsModule(),
 		"print_metric": starlarklib.NewBuiltin("print_metric", printMetric),
 	}
 }

--- a/probes/starlark/builtins.go
+++ b/probes/starlark/builtins.go
@@ -45,19 +45,29 @@ func latencyMethod(recvName string, d time.Duration) *starlarklib.Builtin {
 
 // optionalDurationSeconds converts a Value bound by UnpackArgs (with "??"
 // suffix) into a duration, interpreting the number as seconds. The bool result
-// is false when the kwarg was omitted or None.
+// is false when the kwarg was omitted or None. Non-positive values are an
+// error: callers use this for timeouts, where 0 or negative would cancel the
+// context immediately with a confusing deadline error.
 func optionalDurationSeconds(v starlarklib.Value, name string) (time.Duration, bool, error) {
-	if v == nil {
-		return 0, false, nil
-	}
+	var d time.Duration
 	switch n := v.(type) {
+	case nil:
+		return 0, false, nil
 	case starlarklib.Int:
-		i, _ := n.Int64()
-		return time.Duration(i) * time.Second, true, nil
+		i, ok := n.Int64()
+		if !ok {
+			return 0, false, fmt.Errorf("%s: int does not fit in int64", name)
+		}
+		d = time.Duration(i) * time.Second
 	case starlarklib.Float:
-		return time.Duration(float64(n) * float64(time.Second)), true, nil
+		d = time.Duration(float64(n) * float64(time.Second))
+	default:
+		return 0, false, fmt.Errorf("%s: expected a number of seconds, got %s", name, v.Type())
 	}
-	return 0, false, fmt.Errorf("%s: expected a number of seconds, got %s", name, v.Type())
+	if d <= 0 {
+		return 0, false, fmt.Errorf("%s: expected a positive number of seconds, got %v", name, v)
+	}
+	return d, true, nil
 }
 
 // sortedNames returns m's keys in sorted order. Used by the builtins that

--- a/probes/starlark/builtins_dns.go
+++ b/probes/starlark/builtins_dns.go
@@ -1,0 +1,232 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package starlark
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	starlarklib "go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+// ----------------------------------------------------------------------------
+// dns module
+//
+// Thin wrapper around Go's net.Resolver (deliberately not a reuse of
+// probes/dns, mirroring how the http builtin stays independent of probes/http).
+// server=None uses the system resolver config; an explicit server routes the
+// pure-Go resolver at that address. A response with an NXDOMAIN/NODATA rcode is
+// a result (empty .answers), not an error -- only transport failures raise.
+
+func dnsModule() *starlarkstruct.Module {
+	return &starlarkstruct.Module{
+		Name: "dns",
+		Members: starlarklib.StringDict{
+			"resolve": starlarklib.NewBuiltin("dns.resolve", dnsResolve),
+		},
+	}
+}
+
+// dnsTypes are the record types net.Resolver can look up. Exotic types (SOA,
+// CAA, ...) are intentionally out of scope for this net.Resolver-based builtin.
+var dnsTypes = map[string]bool{
+	"A": true, "AAAA": true, "CNAME": true, "MX": true,
+	"NS": true, "TXT": true, "SRV": true, "PTR": true,
+}
+
+func dnsResolve(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
+	const fname = "dns.resolve"
+	var name, rtype string
+	var serverArg, timeoutArg starlarklib.Value
+	rtype = "A"
+	if err := starlarklib.UnpackArgs(fname, args, kwargs,
+		"name", &name,
+		"type?", &rtype,
+		"server?", &serverArg,
+		"timeout??", &timeoutArg,
+	); err != nil {
+		return nil, err
+	}
+
+	rtype = strings.ToUpper(rtype)
+	if !dnsTypes[rtype] {
+		return nil, fmt.Errorf("%s: unsupported record type %q (want one of A, AAAA, CNAME, MX, NS, TXT, SRV, PTR)", fname, rtype)
+	}
+
+	server, err := optionalString(serverArg, fname+": server")
+	if err != nil {
+		return nil, err
+	}
+	timeout, hasTimeout, err := optionalDurationSeconds(timeoutArg, fname+": timeout")
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := ctxFromThread(thread)
+	if hasTimeout {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	resolver := &net.Resolver{}
+	if server != nil {
+		addr := normalizeDNSServer(*server)
+		resolver = &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, network, addr)
+			},
+		}
+	}
+
+	start := time.Now()
+	answers, err := dnsLookup(ctx, resolver, rtype, name)
+	latency := time.Since(start)
+
+	rcode := "NOERROR"
+	if err != nil {
+		var dnsErr *net.DNSError
+		if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
+			rcode, answers = "NXDOMAIN", nil
+		} else {
+			return nil, fmt.Errorf("%s: %v", fname, err)
+		}
+	}
+
+	return &dnsResult{name: name, rtype: rtype, answers: answers, rcode: rcode, latency: latency}, nil
+}
+
+// normalizeDNSServer appends the default DNS port when the server has none.
+func normalizeDNSServer(s string) string {
+	if _, _, err := net.SplitHostPort(s); err == nil {
+		return s
+	}
+	return net.JoinHostPort(s, "53")
+}
+
+func dnsLookup(ctx context.Context, r *net.Resolver, rtype, name string) ([]string, error) {
+	switch rtype {
+	case "A", "AAAA":
+		network := "ip4"
+		if rtype == "AAAA" {
+			network = "ip6"
+		}
+		ips, err := r.LookupIP(ctx, network, name)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]string, len(ips))
+		for i, ip := range ips {
+			out[i] = ip.String()
+		}
+		return out, nil
+	case "CNAME":
+		cname, err := r.LookupCNAME(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		return []string{cname}, nil
+	case "MX":
+		mxs, err := r.LookupMX(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]string, len(mxs))
+		for i, mx := range mxs {
+			out[i] = fmt.Sprintf("%d %s", mx.Pref, mx.Host)
+		}
+		return out, nil
+	case "NS":
+		nss, err := r.LookupNS(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]string, len(nss))
+		for i, ns := range nss {
+			out[i] = ns.Host
+		}
+		return out, nil
+	case "TXT":
+		return r.LookupTXT(ctx, name)
+	case "SRV":
+		_, srvs, err := r.LookupSRV(ctx, "", "", name)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]string, len(srvs))
+		for i, srv := range srvs {
+			out[i] = fmt.Sprintf("%d %d %d %s", srv.Priority, srv.Weight, srv.Port, srv.Target)
+		}
+		return out, nil
+	case "PTR":
+		return r.LookupAddr(ctx, name)
+	}
+	// Unreachable: rtype is validated against dnsTypes before we get here.
+	return nil, fmt.Errorf("unsupported record type %q", rtype)
+}
+
+// ----------------------------------------------------------------------------
+// DnsResult value
+
+type dnsResult struct {
+	name    string
+	rtype   string
+	answers []string
+	rcode   string
+	latency time.Duration
+}
+
+var _ starlarklib.Value = (*dnsResult)(nil)
+var _ starlarklib.HasAttrs = (*dnsResult)(nil)
+
+func (r *dnsResult) String() string {
+	return fmt.Sprintf("<dns_result name=%s type=%s rcode=%s answers=%d>", r.name, r.rtype, r.rcode, len(r.answers))
+}
+func (r *dnsResult) Type() string            { return "DnsResult" }
+func (r *dnsResult) Freeze()                 {}
+func (r *dnsResult) Truth() starlarklib.Bool { return starlarklib.Bool(r.rcode == "NOERROR") }
+func (r *dnsResult) Hash() (uint32, error)   { return 0, fmt.Errorf("DnsResult is unhashable") }
+
+func (r *dnsResult) Attr(name string) (starlarklib.Value, error) {
+	switch name {
+	case "name":
+		return starlarklib.String(r.name), nil
+	case "type":
+		return starlarklib.String(r.rtype), nil
+	case "rcode":
+		return starlarklib.String(r.rcode), nil
+	case "answers":
+		elems := make([]starlarklib.Value, len(r.answers))
+		for i, a := range r.answers {
+			elems[i] = starlarklib.String(a)
+		}
+		l := starlarklib.NewList(elems)
+		l.Freeze()
+		return l, nil
+	case "latency":
+		return latencyMethod("DnsResult", r.latency), nil
+	}
+	return nil, nil
+}
+
+func (r *dnsResult) AttrNames() []string {
+	return []string{"answers", "latency", "name", "rcode", "type"}
+}

--- a/probes/starlark/builtins_dns.go
+++ b/probes/starlark/builtins_dns.go
@@ -29,21 +29,31 @@ import (
 // ----------------------------------------------------------------------------
 // dns module
 //
-// Thin wrapper around Go's net.Resolver (deliberately not a reuse of
-// probes/dns, mirroring how the http builtin stays independent of probes/http).
-// server=None uses the system resolver config; an explicit server routes the
-// pure-Go resolver at that address.
+// This builtin resolves a name as one step inside a script -- get the A/TXT
+// records, branch on them, feed them into an http call. Monitoring a DNS
+// *server* (wire rcodes, UDP/TCP/TLS, per-record validators) is the dns probe
+// type's job, and this is deliberately not a second one: it is a thin wrapper
+// around Go's net.Resolver, with no probes/dns or miekg dependency, the same
+// way the http builtin stays independent of probes/http.
 //
-// A name-not-found lookup is a result (empty .answers), not an error; every
-// other lookup failure -- timeout, SERVFAIL, REFUSED, network error, malformed
+// That backend is a resolver, not a DNS client, which bounds what a result can
+// say. There is no wire rcode, no TTL, no authority/additional section, and no
+// way to tell NODATA ("name exists, no records of this type") from NXDOMAIN --
+// net.DNSError.IsNotFound covers both. So a result reports only what it can
+// stand behind: the answers it found, or none. Scripts that must assert real
+// server behavior (SERVFAIL vs REFUSED, NODATA vs NXDOMAIN) want the dns probe
+// type instead; that is a different capability, not a gap to fill in here.
+//
+// Finding nothing is a result (empty .answers), not an error. Every other
+// lookup failure -- timeout, SERVFAIL, REFUSED, network error, malformed
 // response -- raises.
 //
-// .rcode is synthetic, not the wire rcode: net.Resolver never exposes one, so
-// we reconstruct it from the error and it takes exactly two values, "NOERROR"
-// and "NXDOMAIN". NODATA ("name exists, no records of this type") is
-// indistinguishable from true NXDOMAIN through net.DNSError.IsNotFound and is
-// reported as "NXDOMAIN" too. SERVFAIL/REFUSED never appear as an .rcode --
-// they raise. Real wire rcodes would need a real DNS client, not net.Resolver.
+// The two server modes are not interchangeable. server=None resolves the way
+// the host does, honoring /etc/hosts, the search list, ndots and (where it
+// applies) the cgo resolver -- that is the mode for "what does this machine
+// see?". An explicit server forces the pure-Go resolver to dial that address,
+// which skips /etc/hosts and the host's resolver choice; it answers "what does
+// that nameserver say?" well enough for a probe step, but it is not dig.
 
 func dnsModule() *starlarkstruct.Module {
 	return &starlarkstruct.Module{
@@ -111,19 +121,17 @@ func dnsResolve(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlar
 	answers, err := dnsLookup(ctx, resolver, rtype, name)
 	latency := time.Since(start)
 
-	rcode := "NOERROR"
 	if err != nil {
+		// IsNotFound covers NXDOMAIN and NODATA alike; both mean "found
+		// nothing", which is a result with no answers. Anything else raises.
 		var dnsErr *net.DNSError
-		if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
-			// Synthetic: covers NODATA as well as true NXDOMAIN. See the
-			// package comment above.
-			rcode, answers = "NXDOMAIN", nil
-		} else {
+		if !errors.As(err, &dnsErr) || !dnsErr.IsNotFound {
 			return nil, fmt.Errorf("%s: %v", fname, err)
 		}
+		answers = nil
 	}
 
-	return &dnsResult{name: name, rtype: rtype, answers: answers, rcode: rcode, latency: latency}, nil
+	return &dnsResult{name: name, rtype: rtype, answers: answers, latency: latency}, nil
 }
 
 // normalizeDNSServer appends the default DNS port when the server has none.
@@ -208,7 +216,6 @@ type dnsResult struct {
 	name    string
 	rtype   string
 	answers []string
-	rcode   string
 	latency time.Duration
 }
 
@@ -216,12 +223,15 @@ var _ starlarklib.Value = (*dnsResult)(nil)
 var _ starlarklib.HasAttrs = (*dnsResult)(nil)
 
 func (r *dnsResult) String() string {
-	return fmt.Sprintf("<dns_result name=%s type=%s rcode=%s answers=%d>", r.name, r.rtype, r.rcode, len(r.answers))
+	return fmt.Sprintf("<dns_result name=%s type=%s answers=%d>", r.name, r.rtype, len(r.answers))
 }
-func (r *dnsResult) Type() string            { return "DnsResult" }
-func (r *dnsResult) Freeze()                 {}
-func (r *dnsResult) Truth() starlarklib.Bool { return starlarklib.Bool(r.rcode == "NOERROR") }
-func (r *dnsResult) Hash() (uint32, error)   { return 0, fmt.Errorf("DnsResult is unhashable") }
+func (r *dnsResult) Type() string          { return "DnsResult" }
+func (r *dnsResult) Freeze()               {}
+func (r *dnsResult) Hash() (uint32, error) { return 0, fmt.Errorf("DnsResult is unhashable") }
+
+// Truth makes "if r:" mean "found something", so a lookup that resolved to
+// nothing is falsey without the script having to reach for len(r.answers).
+func (r *dnsResult) Truth() starlarklib.Bool { return starlarklib.Bool(len(r.answers) > 0) }
 
 func (r *dnsResult) Attr(name string) (starlarklib.Value, error) {
 	switch name {
@@ -229,8 +239,6 @@ func (r *dnsResult) Attr(name string) (starlarklib.Value, error) {
 		return starlarklib.String(r.name), nil
 	case "type":
 		return starlarklib.String(r.rtype), nil
-	case "rcode":
-		return starlarklib.String(r.rcode), nil
 	case "answers":
 		elems := make([]starlarklib.Value, len(r.answers))
 		for i, a := range r.answers {
@@ -246,5 +254,5 @@ func (r *dnsResult) Attr(name string) (starlarklib.Value, error) {
 }
 
 func (r *dnsResult) AttrNames() []string {
-	return []string{"answers", "latency", "name", "rcode", "type"}
+	return []string{"answers", "latency", "name", "type"}
 }

--- a/probes/starlark/builtins_dns.go
+++ b/probes/starlark/builtins_dns.go
@@ -32,8 +32,18 @@ import (
 // Thin wrapper around Go's net.Resolver (deliberately not a reuse of
 // probes/dns, mirroring how the http builtin stays independent of probes/http).
 // server=None uses the system resolver config; an explicit server routes the
-// pure-Go resolver at that address. A response with an NXDOMAIN/NODATA rcode is
-// a result (empty .answers), not an error -- only transport failures raise.
+// pure-Go resolver at that address.
+//
+// A name-not-found lookup is a result (empty .answers), not an error; every
+// other lookup failure -- timeout, SERVFAIL, REFUSED, network error, malformed
+// response -- raises.
+//
+// .rcode is synthetic, not the wire rcode: net.Resolver never exposes one, so
+// we reconstruct it from the error and it takes exactly two values, "NOERROR"
+// and "NXDOMAIN". NODATA ("name exists, no records of this type") is
+// indistinguishable from true NXDOMAIN through net.DNSError.IsNotFound and is
+// reported as "NXDOMAIN" too. SERVFAIL/REFUSED never appear as an .rcode --
+// they raise. Real wire rcodes would need a real DNS client, not net.Resolver.
 
 func dnsModule() *starlarkstruct.Module {
 	return &starlarkstruct.Module{
@@ -59,7 +69,7 @@ func dnsResolve(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlar
 	if err := starlarklib.UnpackArgs(fname, args, kwargs,
 		"name", &name,
 		"type?", &rtype,
-		"server?", &serverArg,
+		"server??", &serverArg,
 		"timeout??", &timeoutArg,
 	); err != nil {
 		return nil, err
@@ -105,6 +115,8 @@ func dnsResolve(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlar
 	if err != nil {
 		var dnsErr *net.DNSError
 		if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
+			// Synthetic: covers NODATA as well as true NXDOMAIN. See the
+			// package comment above.
 			rcode, answers = "NXDOMAIN", nil
 		} else {
 			return nil, fmt.Errorf("%s: %v", fname, err)
@@ -115,9 +127,15 @@ func dnsResolve(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlar
 }
 
 // normalizeDNSServer appends the default DNS port when the server has none.
+// A port-less IPv6 address is accepted bare ("::1") or bracketed ("[::1]");
+// JoinHostPort re-adds the brackets, so an existing pair has to come off first
+// or we'd emit "[[::1]]:53".
 func normalizeDNSServer(s string) string {
 	if _, _, err := net.SplitHostPort(s); err == nil {
 		return s
+	}
+	if strings.HasPrefix(s, "[") && strings.HasSuffix(s, "]") {
+		s = s[1 : len(s)-1]
 	}
 	return net.JoinHostPort(s, "53")
 }

--- a/probes/starlark/starlark_dns_test.go
+++ b/probes/starlark/starlark_dns_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package starlark
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	starlarklib "go.starlark.net/starlark"
+)
+
+// testDNSServer starts an in-process UDP DNS server with canned answers and
+// returns its host:port. The dns.resolve builtin, given server=<this>, routes
+// Go's pure-Go resolver here, so record logic is exercised without real DNS.
+func testDNSServer(t *testing.T) string {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		q := r.Question[0]
+		switch q.Name {
+		case "good.example.":
+			if q.Qtype == dns.TypeA {
+				rr, _ := dns.NewRR("good.example. 300 IN A 10.0.0.5")
+				m.Answer = append(m.Answer, rr)
+			}
+		case "text.example.":
+			if q.Qtype == dns.TypeTXT {
+				rr, _ := dns.NewRR(`text.example. 300 IN TXT "hello world"`)
+				m.Answer = append(m.Answer, rr)
+			}
+		case "missing.example.":
+			m.SetRcode(r, dns.RcodeNameError) // NXDOMAIN
+		}
+		_ = w.WriteMsg(m)
+	})
+
+	srv := &dns.Server{PacketConn: pc, Handler: handler}
+	go func() { _ = srv.ActivateAndServe() }()
+	t.Cleanup(func() { _ = srv.Shutdown() })
+	return pc.LocalAddr().String()
+}
+
+// runDNSScript runs a one-probe script and returns the single result. The
+// script's server= address is filled from the in-process test DNS server.
+func runDNSScript(t *testing.T, script string) *dnsRunResult {
+	t.Helper()
+	server := testDNSServer(t)
+	source := fmt.Sprintf(script, server)
+	opts := newOpts(t, "example.com", source)
+	p := &Probe{}
+	require.NoError(t, p.Init("dns-test", opts))
+	results := p.RunOnce(context.Background())
+	require.Len(t, results, 1)
+	return &dnsRunResult{success: results[0].Success, err: results[0].Error}
+}
+
+type dnsRunResult struct {
+	success bool
+	err     error
+}
+
+// The scripts below check their expectations inline via fail(), so a
+// successful probe run means the DnsResult had the expected shape. (The assert
+// module has no general assert.true yet -- that's future work.)
+
+func TestDNS_ARecord(t *testing.T) {
+	r := runDNSScript(t, `
+def probe(target):
+    r = dns.resolve("good.example.", server="%s")
+    if r.rcode != "NOERROR": fail("rcode=" + r.rcode)
+    if "10.0.0.5" not in r.answers: fail("answers=%%s" %% r.answers)
+    if r.name != "good.example.": fail("name=" + r.name)
+    if r.type != "A": fail("type=" + r.type)
+    if r.latency() <= 0: fail("latency not positive")
+`)
+	assert.True(t, r.success, "expected success, err=%v", r.err)
+}
+
+func TestDNS_TypeLowercaseNormalized(t *testing.T) {
+	r := runDNSScript(t, `
+def probe(target):
+    r = dns.resolve("text.example.", type="txt", server="%s")
+    if r.type != "TXT": fail("type=" + r.type)
+    if "hello world" not in r.answers: fail("answers=%%s" %% r.answers)
+`)
+	assert.True(t, r.success, "expected success, err=%v", r.err)
+}
+
+func TestDNS_NXDOMAIN_IsResultNotError(t *testing.T) {
+	r := runDNSScript(t, `
+def probe(target):
+    r = dns.resolve("missing.example.", server="%s")
+    if r.rcode != "NXDOMAIN": fail("rcode=" + r.rcode)
+    if len(r.answers) != 0: fail("answers=%%s" %% r.answers)
+`)
+	assert.True(t, r.success, "expected success, err=%v", r.err)
+}
+
+func TestDNS_UnsupportedType(t *testing.T) {
+	r := runDNSScript(t, `
+def probe(target):
+    dns.resolve("good.example.", type="SOA", server="%s")
+`)
+	assert.False(t, r.success)
+	require.Error(t, r.err)
+	assert.Contains(t, r.err.Error(), "unsupported record type")
+}
+
+// TestLatencyMethod covers the shared latency() unit selector directly (dns and
+// http Response both use it), so the float conversions are pinned without
+// depending on any real measured duration.
+func TestLatencyMethod(t *testing.T) {
+	fn := latencyMethod("Test", 1500*time.Millisecond)
+	thread := &starlarklib.Thread{}
+
+	got, err := starlarklib.Call(thread, fn, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, starlarklib.Float(1.5), got)
+
+	got, err = starlarklib.Call(thread, fn, nil, []starlarklib.Tuple{{starlarklib.String("unit"), starlarklib.String("ms")}})
+	require.NoError(t, err)
+	assert.Equal(t, starlarklib.Float(1500), got)
+
+	_, err = starlarklib.Call(thread, fn, nil, []starlarklib.Tuple{{starlarklib.String("unit"), starlarklib.String("us")}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown unit")
+}

--- a/probes/starlark/starlark_dns_test.go
+++ b/probes/starlark/starlark_dns_test.go
@@ -66,8 +66,13 @@ func testDNSServer(t *testing.T) string {
 // script's server= address is filled from the in-process test DNS server.
 func runDNSScript(t *testing.T, script string) *dnsRunResult {
 	t.Helper()
-	server := testDNSServer(t)
-	source := fmt.Sprintf(script, server)
+	return runScript(t, fmt.Sprintf(script, testDNSServer(t)))
+}
+
+// runScript is runDNSScript without the server= substitution, for scripts that
+// never reach a lookup.
+func runScript(t *testing.T, source string) *dnsRunResult {
+	t.Helper()
 	opts := newOpts(t, "example.com", source)
 	p := &Probe{}
 	require.NoError(t, p.Init("dns-test", opts))
@@ -118,6 +123,21 @@ def probe(target):
 	assert.True(t, r.success, "expected success, err=%v", r.err)
 }
 
+// server=None must behave like an omitted kwarg (system resolver config), not
+// be rejected as a non-string. timeout is validated immediately after server
+// and here is deliberately bad, so a timeout complaint proves server=None got
+// through -- and no lookup is attempted, keeping the test off the network.
+func TestDNS_ServerNoneUsesSystemResolver(t *testing.T) {
+	r := runScript(t, `
+def probe(target):
+    dns.resolve("good.example.", server=None, timeout="soon")
+`)
+	assert.False(t, r.success)
+	require.Error(t, r.err)
+	assert.Contains(t, r.err.Error(), "timeout: expected a number of seconds")
+	assert.NotContains(t, r.err.Error(), "server")
+}
+
 func TestDNS_UnsupportedType(t *testing.T) {
 	r := runDNSScript(t, `
 def probe(target):
@@ -126,6 +146,59 @@ def probe(target):
 	assert.False(t, r.success)
 	require.Error(t, r.err)
 	assert.Contains(t, r.err.Error(), "unsupported record type")
+}
+
+func TestNormalizeDNSServer(t *testing.T) {
+	for _, tt := range []struct {
+		in, want string
+	}{
+		{"8.8.8.8", "8.8.8.8:53"},
+		{"8.8.8.8:5353", "8.8.8.8:5353"},
+		{"dns.example.com", "dns.example.com:53"},
+		{"dns.example.com:5353", "dns.example.com:5353"},
+		{"::1", "[::1]:53"},
+		{"[::1]", "[::1]:53"},
+		{"[::1]:5353", "[::1]:5353"},
+		{"2001:4860:4860::8888", "[2001:4860:4860::8888]:53"},
+	} {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeDNSServer(tt.in))
+		})
+	}
+}
+
+// TestOptionalDurationSeconds covers the shared timeout parser (builtins.go),
+// which dns.resolve is the first caller of.
+func TestOptionalDurationSeconds(t *testing.T) {
+	tooBig := starlarklib.MakeInt64(1).Lsh(70) // does not fit in int64
+
+	for _, tt := range []struct {
+		desc    string
+		in      starlarklib.Value
+		want    time.Duration
+		wantOK  bool
+		wantErr string
+	}{
+		{desc: "omitted", in: nil},
+		{desc: "int", in: starlarklib.MakeInt(3), want: 3 * time.Second, wantOK: true},
+		{desc: "float", in: starlarklib.Float(1.5), want: 1500 * time.Millisecond, wantOK: true},
+		{desc: "string", in: starlarklib.String("3"), wantErr: "expected a number of seconds, got string"},
+		{desc: "too big for int64", in: tooBig, wantErr: "does not fit in int64"},
+		{desc: "zero", in: starlarklib.MakeInt(0), wantErr: "expected a positive number of seconds"},
+		{desc: "negative", in: starlarklib.Float(-1), wantErr: "expected a positive number of seconds"},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, ok, err := optionalDurationSeconds(tt.in, "timeout")
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 // TestLatencyMethod covers the shared latency() unit selector directly (dns and

--- a/probes/starlark/starlark_dns_test.go
+++ b/probes/starlark/starlark_dns_test.go
@@ -53,6 +53,10 @@ func testDNSServer(t *testing.T) string {
 		case "missing.example.":
 			m.SetRcode(r, dns.RcodeNameError) // NXDOMAIN
 		}
+		// Without this, Go's pure resolver reads an empty non-authoritative
+		// reply as a lame referral and retries against the system resolvers,
+		// taking the NODATA case off this server entirely.
+		m.Authoritative = true
 		_ = w.WriteMsg(m)
 	})
 
@@ -94,7 +98,7 @@ func TestDNS_ARecord(t *testing.T) {
 	r := runDNSScript(t, `
 def probe(target):
     r = dns.resolve("good.example.", server="%s")
-    if r.rcode != "NOERROR": fail("rcode=" + r.rcode)
+    if not r: fail("expected a truthy result")
     if "10.0.0.5" not in r.answers: fail("answers=%%s" %% r.answers)
     if r.name != "good.example.": fail("name=" + r.name)
     if r.type != "A": fail("type=" + r.type)
@@ -113,14 +117,42 @@ def probe(target):
 	assert.True(t, r.success, "expected success, err=%v", r.err)
 }
 
-func TestDNS_NXDOMAIN_IsResultNotError(t *testing.T) {
+// Nothing found is a result with no answers, not a raised error -- and the
+// result is falsey, so scripts can branch with a plain "if not r:".
+func TestDNS_NotFoundIsResultNotError(t *testing.T) {
 	r := runDNSScript(t, `
 def probe(target):
     r = dns.resolve("missing.example.", server="%s")
-    if r.rcode != "NXDOMAIN": fail("rcode=" + r.rcode)
+    if r: fail("expected a falsey result")
+    if len(r.answers) != 0: fail("answers=%%s" %% r.answers)
+    if r.name != "missing.example.": fail("name=" + r.name)
+`)
+	assert.True(t, r.success, "expected success, err=%v", r.err)
+}
+
+// NODATA -- the name exists but has no record of the requested type -- is
+// indistinguishable from NXDOMAIN through net.Resolver, and the API no longer
+// claims otherwise: both are simply "found nothing".
+func TestDNS_NoDataIsResultNotError(t *testing.T) {
+	r := runDNSScript(t, `
+def probe(target):
+    r = dns.resolve("good.example.", type="TXT", server="%s")
+    if r: fail("expected a falsey result")
     if len(r.answers) != 0: fail("answers=%%s" %% r.answers)
 `)
 	assert.True(t, r.success, "expected success, err=%v", r.err)
+}
+
+// rcode was removed: it could only ever be reconstructed from the error, and
+// was exactly redundant with an empty .answers. Guard against it creeping back.
+func TestDNS_NoRcodeAttr(t *testing.T) {
+	r := runDNSScript(t, `
+def probe(target):
+    dns.resolve("good.example.", server="%s").rcode
+`)
+	assert.False(t, r.success)
+	require.Error(t, r.err)
+	assert.Contains(t, r.err.Error(), "has no .rcode field or method")
 }
 
 // server=None must behave like an omitted kwarg (system resolver config), not


### PR DESCRIPTION
## Summary
- Add a `dns` builtin: `dns.resolve(name, type="A", server=None, timeout=None) -> DnsResult` with `.answers` (flat `list[str]`), `.name`, `.type`, and a `.latency(unit="s")` method (`"s"`/`"ms"`). A result is truthy iff it found something.
- Thin wrapper over Go's `net.Resolver` (no `probes/dns`/`miekg` dep). `server=None` resolves the way the host does; an explicit `server` dials that nameserver with the pure-Go resolver. Finding nothing is a result (empty `.answers`); every other lookup failure raises.
- Deliberately a *resolver*, not a DNS client: no wire rcodes, no TTLs, NODATA indistinguishable from NXDOMAIN. Asserting real server behavior stays the `dns` probe type's job — docs state the split.
- `latencyMethod` helper lives in `builtins.go` so http Response `.latency()` can reuse the same call shape later.

## Test plan
- `go test ./probes/starlark/` — `starlark_dns_test.go` covers A/TXT records, lowercase type normalization, NXDOMAIN and NODATA as results, `server=None`, unsupported-type error, the `normalizeDNSServer` host/port/IPv6 matrix, timeout parsing, and the latency unit selector against an in-process DNS server.
- Docs: `dns.resolve` added to the builtins table plus a `dns` section in the Starlark probe how-to; the example there was run against the test server to verify it works.
