### PR TITLE
[probes/browser] Add internal_errors metric for browser-harness failures

### DIFF
--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -52,6 +52,11 @@ import (
 
 const playwrightReportDir = "_playwright_report"
 
+// internalErrorMarkerFile is written into the playwright report dir by the
+// cloudprober reporter when a run fails because of the browser harness itself
+// (browser missing, browser failed to launch/crashed) rather than the target.
+const internalErrorMarkerFile = "cloudprober_internal_error"
+
 // Probe holds aggregate information about all probe runs, per-target.
 type Probe struct {
 	name string
@@ -93,6 +98,7 @@ var templates embed.FS
 type probeRunResult struct {
 	total             metrics.Int
 	success           metrics.Int
+	internalErrors    metrics.Int
 	latency           metrics.LatencyValue
 	validationFailure *metrics.Map[int64]
 }
@@ -118,6 +124,7 @@ func (prr probeRunResult) Metrics(ts time.Time, _ int64, opts *options.Options) 
 	em := metrics.NewEventMetrics(ts).
 		AddMetric("total", &prr.total).
 		AddMetric("success", &prr.success).
+		AddMetric("internal_errors", &prr.internalErrors).
 		AddMetric(opts.LatencyMetricName, prr.latency.Clone()).
 		AddLabel("ptype", "browser")
 
@@ -157,21 +164,23 @@ func (p *Probe) initTemplateFile(templates embed.FS, fileName string, data any) 
 func (p *Probe) initTemplates() error {
 	// Set up playwright config in workdir
 	data := struct {
-		TestDir            string
-		GlobalTimeoutMsec  int64
-		Screenshot         string
-		Trace              string
-		EnableStepMetrics  bool
-		DisableTestMetrics bool
-		Retries            int32
+		TestDir                 string
+		GlobalTimeoutMsec       int64
+		Screenshot              string
+		Trace                   string
+		EnableStepMetrics       bool
+		DisableTestMetrics      bool
+		Retries                 int32
+		InternalErrorMarkerFile string
 	}{
-		TestDir:            p.testDirPath(),
-		GlobalTimeoutMsec:  p.playwrightGlobalTimeoutMsec(),
-		Screenshot:         "only-on-failure",
-		Trace:              "off",
-		EnableStepMetrics:  p.c.GetTestMetricsOptions().GetEnableStepMetrics(),
-		DisableTestMetrics: p.c.GetTestMetricsOptions().GetDisableTestMetrics(),
-		Retries:            p.c.GetRetries(),
+		TestDir:                 p.testDirPath(),
+		GlobalTimeoutMsec:       p.playwrightGlobalTimeoutMsec(),
+		Screenshot:              "only-on-failure",
+		Trace:                   "off",
+		EnableStepMetrics:       p.c.GetTestMetricsOptions().GetEnableStepMetrics(),
+		DisableTestMetrics:      p.c.GetTestMetricsOptions().GetDisableTestMetrics(),
+		Retries:                 p.c.GetRetries(),
+		InternalErrorMarkerFile: internalErrorMarkerFile,
 	}
 	if p.c.GetSaveScreenshotsForSuccess() {
 		data.Screenshot = "on"
@@ -458,6 +467,13 @@ func (p *Probe) runPWTest(ctx context.Context, runReq *sched.RunProbeForTargetRe
 		}
 	}
 
+	// The cloudprober reporter writes internalErrorMarkerFile when the run
+	// failed because of the browser harness (browser missing/failed to launch)
+	// rather than the target. The process has fully exited by now, so the marker
+	// (if any) is on disk.
+	_, markerErr := os.Stat(filepath.Join(reportDir, internalErrorMarkerFile))
+	internalError := markerErr == nil
+
 	// We use startCtx here to make sure artifactsHandler keeps running (if
 	// required) even after this probe run.
 	p.artifactsHandler.Handle(p.startCtx, reportDir)
@@ -470,6 +486,9 @@ func (p *Probe) runPWTest(ctx context.Context, runReq *sched.RunProbeForTargetRe
 	}
 
 	runReq.LastRun.Set(err == nil, latency, err)
+	if internalError {
+		result.internalErrors.Inc()
+	}
 	if err != nil {
 		return
 	}

--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -23,6 +23,7 @@ import (
 	"embed"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -323,6 +324,10 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 		return fmt.Errorf("playwrightDir is not provided through config or PLAYWRIGHT_DIR env variable")
 	}
 
+	if err := preflightFn(p.c.GetNpxPath(), p.playwrightDir); err != nil {
+		return fmt.Errorf("browser harness preflight failed: %v", err)
+	}
+
 	p.workdir = p.c.GetWorkdir()
 	if p.c.GetWorkdir() == "" {
 		d, err := os.MkdirTemp("", "cloudprober_"+p.name)
@@ -464,6 +469,28 @@ func (p *Probe) prepareCommand(target endpoint.Endpoint, ts time.Time) (*command
 	}
 
 	return cmd, reportDir
+}
+
+// preflightFn verifies the browser harness's static dependencies at Init. It is
+// a package var so tests exercising other Init paths can stub it.
+var preflightFn = defaultPreflight
+
+// defaultPreflight fails loudly at Init when a misconfigured deployment is
+// missing the browser harness, rather than silently emitting internal_errors on
+// every run. It checks that npx resolves and the Playwright test package is
+// installed under playwrightDir. Browser-binary availability is intentionally
+// not checked here -- Playwright's versioned cache dirs make a static check
+// unreliable, and a missing/broken browser is caught per-run via the
+// internal_errors metric.
+func defaultPreflight(npxPath, playwrightDir string) error {
+	if _, err := exec.LookPath(npxPath); err != nil {
+		return fmt.Errorf("npx not found (npx_path=%q): %v", npxPath, err)
+	}
+	pwPkg := filepath.Join(playwrightDir, "node_modules", "@playwright", "test")
+	if _, err := os.Stat(pwPkg); err != nil {
+		return fmt.Errorf("playwright test package not found at %s (is Playwright installed in playwrightDir?): %v", pwPkg, err)
+	}
+	return nil
 }
 
 // classifyInternalError decides whether a failed browser run is an internal

--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -57,6 +57,13 @@ const playwrightReportDir = "_playwright_report"
 // (browser missing, browser failed to launch/crashed) rather than the target.
 const internalErrorMarkerFile = "cloudprober_internal_error"
 
+// harnessStartedMarkerFile is written into the playwright report dir by the
+// cloudprober reporter's onBegin hook, i.e. once Playwright has started running
+// the suite. Its absence on a failed run means the harness never got that far
+// (npx/Playwright missing, config load error, or the process was killed before
+// onBegin), which we classify as an internal error.
+const harnessStartedMarkerFile = "cloudprober_harness_started"
+
 // Probe holds aggregate information about all probe runs, per-target.
 type Probe struct {
 	name string
@@ -164,23 +171,25 @@ func (p *Probe) initTemplateFile(templates embed.FS, fileName string, data any) 
 func (p *Probe) initTemplates() error {
 	// Set up playwright config in workdir
 	data := struct {
-		TestDir                 string
-		GlobalTimeoutMsec       int64
-		Screenshot              string
-		Trace                   string
-		EnableStepMetrics       bool
-		DisableTestMetrics      bool
-		Retries                 int32
-		InternalErrorMarkerFile string
+		TestDir                  string
+		GlobalTimeoutMsec        int64
+		Screenshot               string
+		Trace                    string
+		EnableStepMetrics        bool
+		DisableTestMetrics       bool
+		Retries                  int32
+		InternalErrorMarkerFile  string
+		HarnessStartedMarkerFile string
 	}{
-		TestDir:                 p.testDirPath(),
-		GlobalTimeoutMsec:       p.playwrightGlobalTimeoutMsec(),
-		Screenshot:              "only-on-failure",
-		Trace:                   "off",
-		EnableStepMetrics:       p.c.GetTestMetricsOptions().GetEnableStepMetrics(),
-		DisableTestMetrics:      p.c.GetTestMetricsOptions().GetDisableTestMetrics(),
-		Retries:                 p.c.GetRetries(),
-		InternalErrorMarkerFile: internalErrorMarkerFile,
+		TestDir:                  p.testDirPath(),
+		GlobalTimeoutMsec:        p.playwrightGlobalTimeoutMsec(),
+		Screenshot:               "only-on-failure",
+		Trace:                    "off",
+		EnableStepMetrics:        p.c.GetTestMetricsOptions().GetEnableStepMetrics(),
+		DisableTestMetrics:       p.c.GetTestMetricsOptions().GetDisableTestMetrics(),
+		Retries:                  p.c.GetRetries(),
+		InternalErrorMarkerFile:  internalErrorMarkerFile,
+		HarnessStartedMarkerFile: harnessStartedMarkerFile,
 	}
 	if p.c.GetSaveScreenshotsForSuccess() {
 		data.Screenshot = "on"
@@ -426,7 +435,11 @@ func (p *Probe) prepareCommand(target endpoint.Endpoint, ts time.Time) (*command
 		"test",
 		"--config=" + p.playwrightConfigPath,
 		"--output=" + filepath.Join(outputDir, "results"),
-		"--reporter=html," + p.reporterPath,
+		// The cloudprober reporter is listed before html so that, on a tight
+		// timeout teardown, its tiny marker write in onEnd runs before html's
+		// (potentially slow) report serialization -- and before the probe's
+		// SIGKILL lands.
+		"--reporter=" + p.reporterPath + ",html",
 	}
 	cmdLine = append(cmdLine, p.testSpecArgs...)
 
@@ -453,6 +466,25 @@ func (p *Probe) prepareCommand(target endpoint.Endpoint, ts time.Time) (*command
 	return cmd, reportDir
 }
 
+// classifyInternalError decides whether a failed browser run is an internal
+// (harness/infra) error rather than a target failure, from the reporter markers
+// left in reportDir. Two signals cover the two harness-failure regions:
+//  1. internalErrorMarkerFile present: the reporter saw a browser launch/crash
+//     failure while the harness was running.
+//  2. harnessStartedMarkerFile absent: the harness never reached onBegin
+//     (npx/Playwright missing, config load error, or killed before start).
+//
+// A successful run (err == nil) is never an internal error, even if a stale or
+// spurious marker is present.
+func classifyInternalError(reportDir string, err error) bool {
+	if err == nil {
+		return false
+	}
+	_, launchMarkerErr := os.Stat(filepath.Join(reportDir, internalErrorMarkerFile))
+	_, startedErr := os.Stat(filepath.Join(reportDir, harnessStartedMarkerFile))
+	return launchMarkerErr == nil || startedErr != nil
+}
+
 func (p *Probe) runPWTest(ctx context.Context, runReq *sched.RunProbeForTargetRequest, resultMu *sync.Mutex) {
 	target, result := runReq.Target, runReq.Result.(*probeRunResult)
 	startTime := time.Now()
@@ -467,12 +499,8 @@ func (p *Probe) runPWTest(ctx context.Context, runReq *sched.RunProbeForTargetRe
 		}
 	}
 
-	// The cloudprober reporter writes internalErrorMarkerFile when the run
-	// failed because of the browser harness (browser missing/failed to launch)
-	// rather than the target. The process has fully exited by now, so the marker
-	// (if any) is on disk.
-	_, markerErr := os.Stat(filepath.Join(reportDir, internalErrorMarkerFile))
-	internalError := markerErr == nil
+	// The process has fully exited by now, so any reporter markers are on disk.
+	internalError := classifyInternalError(reportDir, err)
 
 	// We use startCtx here to make sure artifactsHandler keeps running (if
 	// required) even after this probe run.

--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -58,11 +58,9 @@ const playwrightReportDir = "_playwright_report"
 // (browser missing, browser failed to launch/crashed) rather than the target.
 const internalErrorMarkerFile = "cloudprober_internal_error"
 
-// harnessStartedMarkerFile is written into the playwright report dir by the
-// cloudprober reporter's onBegin hook, i.e. once Playwright has started running
-// the suite. Its absence on a failed run means the harness never got that far
-// (npx/Playwright missing, config load error, or the process was killed before
-// onBegin), which we classify as an internal error.
+// harnessStartedMarkerFile is written by the reporter's onBegin hook, once the
+// suite starts running. Its absence on a failed run means the harness never
+// started. See classifyInternalError.
 const harnessStartedMarkerFile = "cloudprober_harness_started"
 
 // Probe holds aggregate information about all probe runs, per-target.
@@ -440,10 +438,8 @@ func (p *Probe) prepareCommand(target endpoint.Endpoint, ts time.Time) (*command
 		"test",
 		"--config=" + p.playwrightConfigPath,
 		"--output=" + filepath.Join(outputDir, "results"),
-		// The cloudprober reporter is listed before html so that, on a tight
-		// timeout teardown, its tiny marker write in onEnd runs before html's
-		// (potentially slow) report serialization -- and before the probe's
-		// SIGKILL lands.
+		// cloudprober reporter before html: on a tight timeout teardown its
+		// small onEnd marker write should land before html's slow serialization.
 		"--reporter=" + p.reporterPath + ",html",
 	}
 	cmdLine = append(cmdLine, p.testSpecArgs...)
@@ -475,13 +471,11 @@ func (p *Probe) prepareCommand(target endpoint.Endpoint, ts time.Time) (*command
 // a package var so tests exercising other Init paths can stub it.
 var preflightFn = defaultPreflight
 
-// defaultPreflight fails loudly at Init when a misconfigured deployment is
-// missing the browser harness, rather than silently emitting internal_errors on
-// every run. It checks that npx resolves and the Playwright test package is
-// installed under playwrightDir. Browser-binary availability is intentionally
-// not checked here -- Playwright's versioned cache dirs make a static check
-// unreliable, and a missing/broken browser is caught per-run via the
-// internal_errors metric.
+// defaultPreflight fails Init loudly when the browser harness is missing (npx
+// unresolvable, or @playwright/test not installed under playwrightDir), instead
+// of emitting internal_errors on every run. Browser-binary availability is left
+// to the per-run internal_errors signal: Playwright's versioned cache dirs make
+// a static check unreliable.
 func defaultPreflight(npxPath, playwrightDir string) error {
 	if _, err := exec.LookPath(npxPath); err != nil {
 		return fmt.Errorf("npx not found (npx_path=%q): %v", npxPath, err)
@@ -494,22 +488,18 @@ func defaultPreflight(npxPath, playwrightDir string) error {
 }
 
 // classifyInternalError decides whether a failed browser run is an internal
-// (harness/infra) error rather than a target failure, from the reporter markers
-// left in reportDir. Two signals cover the two harness-failure regions:
-//  1. internalErrorMarkerFile present: the reporter saw a browser launch/crash
-//     failure while the harness was running.
-//  2. harnessStartedMarkerFile absent: the harness never reached onBegin
-//     (npx/Playwright missing, config load error, or killed before start).
-//
-// A successful run (err == nil) is never an internal error, even if a stale or
-// spurious marker is present.
+// (harness) error rather than a target failure, from the reporter markers in
+// reportDir. A run is internal if the reporter flagged a browser launch/crash
+// (internalErrorMarkerFile present), or the harness never started
+// (harnessStartedMarkerFile absent). A successful run is never internal,
+// regardless of a stale or spurious marker.
 func classifyInternalError(reportDir string, err error) bool {
 	if err == nil {
 		return false
 	}
 	_, launchMarkerErr := os.Stat(filepath.Join(reportDir, internalErrorMarkerFile))
-	_, startedErr := os.Stat(filepath.Join(reportDir, harnessStartedMarkerFile))
-	return launchMarkerErr == nil || startedErr != nil
+	_, heartbeatErr := os.Stat(filepath.Join(reportDir, harnessStartedMarkerFile))
+	return launchMarkerErr == nil || heartbeatErr != nil
 }
 
 func (p *Probe) runPWTest(ctx context.Context, runReq *sched.RunProbeForTargetRequest, resultMu *sync.Mutex) {

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -15,6 +15,7 @@
 package browser
 
 import (
+	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -41,7 +42,7 @@ func TestProbePrepareCommand(t *testing.T) {
 	}
 
 	cmdLine := func(npxPath string) []string {
-		return []string{npxPath, "playwright", "test", "--config={WORKDIR}/playwright.config.ts", "--output=${OUTPUT_DIR}/results", "--reporter=html,{WORKDIR}/cloudprober-reporter.ts"}
+		return []string{npxPath, "playwright", "test", "--config={WORKDIR}/playwright.config.ts", "--output=${OUTPUT_DIR}/results", "--reporter={WORKDIR}/cloudprober-reporter.ts,html"}
 	}
 
 	baseWantEMLabels := [][2]string{{"ptype", "browser"}, {"probe", "test_browser"}, {"dst", ""}}
@@ -164,12 +165,12 @@ func TestProbePrepareCommand(t *testing.T) {
 
 func TestProbeOutputDirPath(t *testing.T) {
 	tests := []struct {
-		name       string
-		outputDir  string
-		target     endpoint.Endpoint
-		targets    []endpoint.Endpoint
-		ts         time.Time
-		want       string
+		name      string
+		outputDir string
+		target    endpoint.Endpoint
+		targets   []endpoint.Endpoint
+		ts        time.Time
+		want      string
 	}{
 		{
 			name:      "default",
@@ -370,8 +371,10 @@ func TestProbeInitTemplates(t *testing.T) {
 			}
 
 			// Internal-error detection is always wired up, regardless of the
-			// test/step metric options.
-			for _, want := range []string{"onError(error: TestError)", internalErrorMarkerFile} {
+			// test/step metric options: onError + launch-error marker for
+			// in-run harness failures, and the onBegin heartbeat marker whose
+			// absence flags a harness that never started.
+			for _, want := range []string{"onError(error: TestError)", internalErrorMarkerFile, harnessStartedMarkerFile, "this.writeMarker(\"" + harnessStartedMarkerFile + "\")"} {
 				assert.Contains(t, string(got), want, "reporter file should contain: %s", want)
 			}
 		})
@@ -561,6 +564,45 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 				assert.Equal(t, tt.wantArgs, got)
 			}
 		})
+	}
+}
+
+func TestClassifyInternalError(t *testing.T) {
+	runErr := errors.New("playwright failed")
+	for _, tt := range []struct {
+		name          string
+		err           error
+		launchMarker  bool // internalErrorMarkerFile present
+		startedMarker bool // harnessStartedMarkerFile present (heartbeat)
+		want          bool
+	}{
+		// Successful run is never internal, even with a stale marker.
+		{name: "success_no_markers", err: nil, want: false},
+		{name: "success_with_launch_marker", err: nil, launchMarker: true, want: false},
+		// Failed run, harness started: target failure vs. reporter-flagged launch.
+		{name: "fail_target_failure", err: runErr, startedMarker: true, want: false},
+		{name: "fail_launch_after_start", err: runErr, startedMarker: true, launchMarker: true, want: true},
+		// Failed run, no heartbeat: harness never started (npx/PW missing, etc.).
+		{name: "fail_harness_never_started", err: runErr, want: true},
+		{name: "fail_no_heartbeat_with_launch_marker", err: runErr, launchMarker: true, want: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			reportDir := t.TempDir()
+			if tt.launchMarker {
+				writeTestMarker(t, reportDir, internalErrorMarkerFile)
+			}
+			if tt.startedMarker {
+				writeTestMarker(t, reportDir, harnessStartedMarkerFile)
+			}
+			assert.Equal(t, tt.want, classifyInternalError(reportDir, tt.err))
+		})
+	}
+}
+
+func writeTestMarker(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("1"), 0644); err != nil {
+		t.Fatalf("writing marker %s: %v", name, err)
 	}
 }
 

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -377,19 +377,15 @@ func TestProbeInitTemplates(t *testing.T) {
 			}
 
 			// Internal-error detection is always wired up, regardless of the
-			// test/step metric options: onError + launch-error marker for
-			// in-run harness failures, and the onBegin heartbeat marker whose
-			// absence flags a harness that never started.
+			// test/step metric options.
 			for _, want := range []string{
 				"onError(error: TestError)",
 				internalErrorMarkerFile,
-				harnessStartedMarkerFile,
-				"this.writeMarker(\"" + harnessStartedMarkerFile + "\")",
-				// Narrowed, filtered classification (layer 3):
-				`"browserType.launch"`,         // narrow launch signature kept
-				`"Target crashed"`,             // narrow crash signature kept
-				"isLaunchError(error.message)", // onError is filtered, not blanket
-				`outcome() === "unexpected"`,   // onEnd decides from final outcomes
+				"this.writeMarker(\"" + harnessStartedMarkerFile + "\")", // heartbeat
+				`"browserType.launch"`,                                   // narrow launch signature kept
+				`"Target crashed"`,                                       // narrow crash signature kept
+				"isLaunchError(error.message)",                           // onError is filtered, not blanket
+				`outcome() === "unexpected"`,                             // onEnd decides from final outcomes
 			} {
 				assert.Contains(t, string(got), want, "reporter file should contain: %s", want)
 			}

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -368,6 +368,12 @@ func TestProbeInitTemplates(t *testing.T) {
 			for _, want := range tt.reporterNotContains {
 				assert.NotContains(t, string(got), want, "reporter file should not contain: %s", want)
 			}
+
+			// Internal-error detection is always wired up, regardless of the
+			// test/step metric options.
+			for _, want := range []string{"onError(error: TestError)", internalErrorMarkerFile} {
+				assert.Contains(t, string(got), want, "reporter file should contain: %s", want)
+			}
 		})
 	}
 }
@@ -555,5 +561,20 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 				assert.Equal(t, tt.wantArgs, got)
 			}
 		})
+	}
+}
+
+func TestProbeRunResultMetrics(t *testing.T) {
+	prr := &probeRunResult{latency: metrics.NewFloat(0)}
+	prr.total.IncBy(2)
+	prr.success.Inc()
+	prr.internalErrors.Inc()
+
+	ems := prr.Metrics(time.Now(), 0, options.DefaultOptions())
+	if assert.Len(t, ems, 1) {
+		em := ems[0]
+		assert.Equal(t, "2", em.Metric("total").String())
+		assert.Equal(t, "1", em.Metric("success").String())
+		assert.Equal(t, "1", em.Metric("internal_errors").String())
 	}
 }

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -37,6 +37,12 @@ func TestProbePrepareCommand(t *testing.T) {
 	os.Setenv("PLAYWRIGHT_DIR", "/playwright")
 	defer os.Unsetenv("PLAYWRIGHT_DIR")
 
+	// This test exercises command construction, not harness validation, and
+	// uses fake playwright/npx paths that don't exist on disk. Stub the Init
+	// preflight so those paths don't trip it.
+	defer func(orig func(string, string) error) { preflightFn = orig }(preflightFn)
+	preflightFn = func(_, _ string) error { return nil }
+
 	baseEnvVars := func(pwDir string) []string {
 		return []string{"NODE_PATH=" + pwDir + "/node_modules", "PLAYWRIGHT_HTML_REPORT={OUTPUT_DIR}/" + playwrightReportDir, "PLAYWRIGHT_HTML_OPEN=never"}
 	}
@@ -565,6 +571,37 @@ func TestProbeComputeTestSpecArgs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDefaultPreflight(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake npx executable bit / LookPath semantics differ on Windows")
+	}
+
+	// A resolvable npx: a real executable file addressed by absolute path.
+	binDir := t.TempDir()
+	npx := filepath.Join(binDir, "npx")
+	if err := os.WriteFile(npx, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A playwrightDir with @playwright/test installed.
+	pwDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(pwDir, "node_modules", "@playwright", "test"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("ok", func(t *testing.T) {
+		assert.NoError(t, defaultPreflight(npx, pwDir))
+	})
+	t.Run("npx_missing", func(t *testing.T) {
+		err := defaultPreflight(filepath.Join(binDir, "does-not-exist"), pwDir)
+		assert.ErrorContains(t, err, "npx not found")
+	})
+	t.Run("playwright_not_installed", func(t *testing.T) {
+		err := defaultPreflight(npx, t.TempDir())
+		assert.ErrorContains(t, err, "playwright test package not found")
+	})
 }
 
 func TestClassifyInternalError(t *testing.T) {

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -380,9 +380,22 @@ func TestProbeInitTemplates(t *testing.T) {
 			// test/step metric options: onError + launch-error marker for
 			// in-run harness failures, and the onBegin heartbeat marker whose
 			// absence flags a harness that never started.
-			for _, want := range []string{"onError(error: TestError)", internalErrorMarkerFile, harnessStartedMarkerFile, "this.writeMarker(\"" + harnessStartedMarkerFile + "\")"} {
+			for _, want := range []string{
+				"onError(error: TestError)",
+				internalErrorMarkerFile,
+				harnessStartedMarkerFile,
+				"this.writeMarker(\"" + harnessStartedMarkerFile + "\")",
+				// Narrowed, filtered classification (layer 3):
+				`"browserType.launch"`,         // narrow launch signature kept
+				`"Target crashed"`,             // narrow crash signature kept
+				"isLaunchError(error.message)", // onError is filtered, not blanket
+				`result.status === "passed"`,   // onEnd gated on final outcome
+			} {
 				assert.Contains(t, string(got), want, "reporter file should contain: %s", want)
 			}
+			// The over-broad signature is dropped to avoid misclassifying
+			// ordinary target failures as internal errors.
+			assert.NotContains(t, string(got), `"Browser has been closed"`, "over-broad signature should be dropped")
 		})
 	}
 }

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -389,7 +389,7 @@ func TestProbeInitTemplates(t *testing.T) {
 				`"browserType.launch"`,         // narrow launch signature kept
 				`"Target crashed"`,             // narrow crash signature kept
 				"isLaunchError(error.message)", // onError is filtered, not blanket
-				`result.status === "passed"`,   // onEnd gated on final outcome
+				`outcome() === "unexpected"`,   // onEnd decides from final outcomes
 			} {
 				assert.Contains(t, string(got), want, "reporter file should contain: %s", want)
 			}

--- a/probes/browser/templates/cloudprober-reporter.ts.tmpl
+++ b/probes/browser/templates/cloudprober-reporter.ts.tmpl
@@ -45,8 +45,28 @@ class CloudproberReporter implements Reporter {
   // onError, or a browser-launch failure attached to a test's before-hooks.
   private internalError = false;
 
+  // writeMarker writes a zero-content marker file into the playwright report
+  // dir that the probe (Go side) reads after the process exits.
+  private writeMarker(filename: string) {
+    const reportDir = process.env.PLAYWRIGHT_HTML_REPORT;
+    if (!reportDir) {
+      warning(`PLAYWRIGHT_HTML_REPORT not set; cannot write ${filename}`);
+      return;
+    }
+    try {
+      fs.mkdirSync(reportDir, { recursive: true });
+      fs.writeFileSync(path.join(reportDir, filename), "1");
+    } catch (e) {
+      warning(`Failed to write ${filename}: ${e}`);
+    }
+  }
+
   onBegin(config: FullConfig, suite: Suite) {
     info(`Starting the suite "${suite.title}" with ${suite.allTests().length} tests`);
+    // Heartbeat: records that the harness got far enough to start running the
+    // suite. Its absence on a failed run tells the probe the harness never
+    // started (npx/Playwright missing, config load error, early kill).
+    this.writeMarker("{{ .HarnessStartedMarkerFile }}");
   }
 
   onError(error: TestError) {
@@ -89,17 +109,7 @@ class CloudproberReporter implements Reporter {
     if (!this.internalError) {
       return;
     }
-    const reportDir = process.env.PLAYWRIGHT_HTML_REPORT;
-    if (!reportDir) {
-      warning("PLAYWRIGHT_HTML_REPORT not set; cannot write internal error marker");
-      return;
-    }
-    try {
-      fs.mkdirSync(reportDir, { recursive: true });
-      fs.writeFileSync(path.join(reportDir, "{{ .InternalErrorMarkerFile }}"), "1");
-    } catch (e) {
-      warning(`Failed to write internal error marker: ${e}`);
-    }
+    this.writeMarker("{{ .InternalErrorMarkerFile }}");
   }
 }
 export default CloudproberReporter;

--- a/probes/browser/templates/cloudprober-reporter.ts.tmpl
+++ b/probes/browser/templates/cloudprober-reporter.ts.tmpl
@@ -9,17 +9,14 @@ const warning = (string: string) => process.stderr.write("WARNING "+string+'\n')
 
 const print = (string: string) => process.stdout.write(string+'\n');
 
-// Error substrings that indicate the browser harness itself failed (browser
-// missing, browser failed to launch, browser crashed) rather than the target
-// under test failing. A matching run is still a failed run; the marker only
-// tells the probe to also count it as an internal_error. In-test failures
-// (e.g. a locator/navigation timeout) do not match any of these and are
-// treated as normal failures.
+// Error substrings that mean the browser harness failed (missing / failed to
+// launch / crashed) rather than the target. A match is still a failed run; it
+// only adds the internal_error count. In-test failures (locator/navigation
+// timeouts) don't match and stay normal failures.
 //
-// Signatures are kept narrow to avoid diluting the metric. Notably "Browser
-// has been closed" is excluded: Playwright reports "Target page, context or
-// browser has been closed" for ordinary use-after-close / teardown races in
-// non-harness failures, so it would misclassify many target failures.
+// Kept narrow to avoid diluting the metric. Playwright's browser-has-been-closed
+// message is deliberately not a signature: it fires for ordinary target failures
+// (use-after-close / teardown races), not just harness failures.
 const launchErrorSignatures = [
   "browserType.launch",
   "Executable doesn't exist",
@@ -48,10 +45,9 @@ const testLabels= (test: TestCase) => {
 class CloudproberReporter implements Reporter {
   // A run-level (onError) error whose message matched a launch/crash signature.
   private runLevelInternal = false;
-  // Tests that hit a launch/crash error on a failing attempt. At onEnd we count
-  // the run internal only if one of these FINALLY failed (outcome
-  // "unexpected"); a crash that a retry recovered from (outcome "flaky") does
-  // not count, and an unrelated normal failure is never in this set.
+  // Tests that hit a launch/crash error on a failing attempt. Counted at onEnd
+  // only if the test finally failed ("unexpected"); a retry-recovered crash
+  // ("flaky") does not count.
   private launchFailedTests = new Set<TestCase>();
 
   // writeMarker writes a zero-content marker file into the playwright report
@@ -72,18 +68,16 @@ class CloudproberReporter implements Reporter {
 
   onBegin(config: FullConfig, suite: Suite) {
     info(`Starting the suite "${suite.title}" with ${suite.allTests().length} tests`);
-    // Heartbeat: records that the harness got far enough to start running the
-    // suite. Its absence on a failed run tells the probe the harness never
-    // started (npx/Playwright missing, config load error, early kill).
+    // Heartbeat: marks that the harness started running the suite; its absence
+    // on a failed run tells the probe the harness never started.
     this.writeMarker("{{ .HarnessStartedMarkerFile }}");
   }
 
   onError(error: TestError) {
     warning(`Run-level error (not attached to a test): ${JSON.stringify(error)}`);
-    // onError fires for any global/worker error, including test-author bugs and
-    // config mistakes. Only treat it as internal if it looks like a browser
-    // launch/crash; other run-level failures are already a failed run and, if
-    // the harness never started, are caught by the missing heartbeat instead.
+    // onError fires for any global/worker error, including test-author bugs.
+    // Only a launch/crash message counts as internal; a never-started harness
+    // is caught by the missing heartbeat instead.
     if (isLaunchError(error.message)) {
       this.runLevelInternal = true;
     }
@@ -121,12 +115,9 @@ class CloudproberReporter implements Reporter {
   }
 
   onEnd(result: FullResult) {
-    // Decide from final outcomes, not a sticky flag: count the run internal only
-    // if a launch/crash-failing test ultimately failed, or a run-level launch
-    // error was seen. A crash a retry recovered from ("flaky") does not count,
-    // and an ordinary target failure is never in launchFailedTests. There is no
-    // status gate: the Go side only counts internal_errors on a non-zero exit,
-    // so a passed/exit-0 run is already never counted.
+    // Mark internal only if a launch/crash-failing test finally failed, or a
+    // run-level launch error was seen. Retry-recovered crashes ("flaky") and
+    // ordinary target failures don't qualify.
     const testCausedInternal =
       Array.from(this.launchFailedTests).some((t) => t.outcome() === "unexpected");
     if (!this.runLevelInternal && !testCausedInternal) {

--- a/probes/browser/templates/cloudprober-reporter.ts.tmpl
+++ b/probes/browser/templates/cloudprober-reporter.ts.tmpl
@@ -1,11 +1,28 @@
 import type {
-  Reporter, FullConfig, Suite, TestCase, TestStep, TestResult
+  Reporter, FullConfig, FullResult, Suite, TestCase, TestError, TestStep, TestResult
 } from '@playwright/test/reporter';
+import * as fs from 'fs';
+import * as path from 'path';
 
 const info = (string: string) => process.stderr.write("INFO "+string+'\n');
 const warning = (string: string) => process.stderr.write("WARNING "+string+'\n');
 
 const print = (string: string) => process.stdout.write(string+'\n');
+
+// Error substrings that indicate the browser harness itself failed (browser
+// missing, browser failed to launch, browser crashed) rather than the target
+// under test failing. These map to an internal_error rather than a probe
+// failure. In-test failures (e.g. a locator/navigation timeout) do not match
+// any of these and are treated as normal failures.
+const launchErrorSignatures = [
+  "browserType.launch",
+  "Executable doesn't exist",
+  "Browser has been closed",
+  "Target crashed",
+];
+
+const isLaunchError = (message?: string) =>
+  message != null && launchErrorSignatures.some((sig) => message.includes(sig));
 
 const testLabels= (test: TestCase) => {
     var titleLabel = `test="${test.title.replace(/ /g,"_")}"`;
@@ -24,8 +41,17 @@ const testLabels= (test: TestCase) => {
 }
 
 class CloudproberReporter implements Reporter {
+  // Set when the run fails outside the test body: a run-level error reported via
+  // onError, or a browser-launch failure attached to a test's before-hooks.
+  private internalError = false;
+
   onBegin(config: FullConfig, suite: Suite) {
     info(`Starting the suite "${suite.title}" with ${suite.allTests().length} tests`);
+  }
+
+  onError(error: TestError) {
+    warning(`Run-level error (not attached to a test): ${JSON.stringify(error)}`);
+    this.internalError = true;
   }
 
   onTestBegin(test: TestCase) {
@@ -50,10 +76,30 @@ class CloudproberReporter implements Reporter {
     if (result.status !== "passed" && result.status !== "skipped") {
       warning(`Test "${test.title}" failed with errors: ${JSON.stringify(result.errors)}`);
     }
+    if ((result.errors || []).some((e) => isLaunchError(e.message))) {
+      this.internalError = true;
+    }
     {{ if not .DisableTestMetrics }}
     print(`test_status{${testLabels(test)},status="${result.status}"} 1`);
     print(`test_latency{${testLabels(test)},status="${result.status}"} ${result.duration*1000}`);
     {{ end }}
+  }
+
+  onEnd(result: FullResult) {
+    if (!this.internalError) {
+      return;
+    }
+    const reportDir = process.env.PLAYWRIGHT_HTML_REPORT;
+    if (!reportDir) {
+      warning("PLAYWRIGHT_HTML_REPORT not set; cannot write internal error marker");
+      return;
+    }
+    try {
+      fs.mkdirSync(reportDir, { recursive: true });
+      fs.writeFileSync(path.join(reportDir, "{{ .InternalErrorMarkerFile }}"), "1");
+    } catch (e) {
+      warning(`Failed to write internal error marker: ${e}`);
+    }
   }
 }
 export default CloudproberReporter;

--- a/probes/browser/templates/cloudprober-reporter.ts.tmpl
+++ b/probes/browser/templates/cloudprober-reporter.ts.tmpl
@@ -46,10 +46,13 @@ const testLabels= (test: TestCase) => {
 }
 
 class CloudproberReporter implements Reporter {
-  // Set only for harness failures: a run-level error whose message matches a
-  // launch/crash signature, or a browser-launch failure attached to a test.
-  // Ordinary test-author bugs surfaced via onError do not set it.
-  private internalError = false;
+  // A run-level (onError) error whose message matched a launch/crash signature.
+  private runLevelInternal = false;
+  // Tests that hit a launch/crash error on a failing attempt. At onEnd we count
+  // the run internal only if one of these FINALLY failed (outcome
+  // "unexpected"); a crash that a retry recovered from (outcome "flaky") does
+  // not count, and an unrelated normal failure is never in this set.
+  private launchFailedTests = new Set<TestCase>();
 
   // writeMarker writes a zero-content marker file into the playwright report
   // dir that the probe (Go side) reads after the process exits.
@@ -82,7 +85,7 @@ class CloudproberReporter implements Reporter {
     // launch/crash; other run-level failures are already a failed run and, if
     // the harness never started, are caught by the missing heartbeat instead.
     if (isLaunchError(error.message)) {
-      this.internalError = true;
+      this.runLevelInternal = true;
     }
   }
 
@@ -108,8 +111,8 @@ class CloudproberReporter implements Reporter {
     if (result.status !== "passed" && result.status !== "skipped") {
       warning(`Test "${test.title}" failed with errors: ${JSON.stringify(result.errors)}`);
     }
-    if ((result.errors || []).some((e) => isLaunchError(e.message))) {
-      this.internalError = true;
+    if (result.status !== "passed" && (result.errors || []).some((e) => isLaunchError(e.message))) {
+      this.launchFailedTests.add(test);
     }
     {{ if not .DisableTestMetrics }}
     print(`test_status{${testLabels(test)},status="${result.status}"} 1`);
@@ -118,10 +121,15 @@ class CloudproberReporter implements Reporter {
   }
 
   onEnd(result: FullResult) {
-    // Gate on the final outcome as well as the sticky flag: with retries, a
-    // launch failure on one attempt can set internalError while a later attempt
-    // passes. Don't mark a run the suite ultimately reports as passed.
-    if (!this.internalError || result.status === "passed") {
+    // Decide from final outcomes, not a sticky flag: count the run internal only
+    // if a launch/crash-failing test ultimately failed, or a run-level launch
+    // error was seen. A crash a retry recovered from ("flaky") does not count,
+    // and an ordinary target failure is never in launchFailedTests. There is no
+    // status gate: the Go side only counts internal_errors on a non-zero exit,
+    // so a passed/exit-0 run is already never counted.
+    const testCausedInternal =
+      Array.from(this.launchFailedTests).some((t) => t.outcome() === "unexpected");
+    if (!this.runLevelInternal && !testCausedInternal) {
       return;
     }
     this.writeMarker("{{ .InternalErrorMarkerFile }}");

--- a/probes/browser/templates/cloudprober-reporter.ts.tmpl
+++ b/probes/browser/templates/cloudprober-reporter.ts.tmpl
@@ -11,13 +11,18 @@ const print = (string: string) => process.stdout.write(string+'\n');
 
 // Error substrings that indicate the browser harness itself failed (browser
 // missing, browser failed to launch, browser crashed) rather than the target
-// under test failing. These map to an internal_error rather than a probe
-// failure. In-test failures (e.g. a locator/navigation timeout) do not match
-// any of these and are treated as normal failures.
+// under test failing. A matching run is still a failed run; the marker only
+// tells the probe to also count it as an internal_error. In-test failures
+// (e.g. a locator/navigation timeout) do not match any of these and are
+// treated as normal failures.
+//
+// Signatures are kept narrow to avoid diluting the metric. Notably "Browser
+// has been closed" is excluded: Playwright reports "Target page, context or
+// browser has been closed" for ordinary use-after-close / teardown races in
+// non-harness failures, so it would misclassify many target failures.
 const launchErrorSignatures = [
   "browserType.launch",
   "Executable doesn't exist",
-  "Browser has been closed",
   "Target crashed",
 ];
 
@@ -41,8 +46,9 @@ const testLabels= (test: TestCase) => {
 }
 
 class CloudproberReporter implements Reporter {
-  // Set when the run fails outside the test body: a run-level error reported via
-  // onError, or a browser-launch failure attached to a test's before-hooks.
+  // Set only for harness failures: a run-level error whose message matches a
+  // launch/crash signature, or a browser-launch failure attached to a test.
+  // Ordinary test-author bugs surfaced via onError do not set it.
   private internalError = false;
 
   // writeMarker writes a zero-content marker file into the playwright report
@@ -71,7 +77,13 @@ class CloudproberReporter implements Reporter {
 
   onError(error: TestError) {
     warning(`Run-level error (not attached to a test): ${JSON.stringify(error)}`);
-    this.internalError = true;
+    // onError fires for any global/worker error, including test-author bugs and
+    // config mistakes. Only treat it as internal if it looks like a browser
+    // launch/crash; other run-level failures are already a failed run and, if
+    // the harness never started, are caught by the missing heartbeat instead.
+    if (isLaunchError(error.message)) {
+      this.internalError = true;
+    }
   }
 
   onTestBegin(test: TestCase) {
@@ -106,7 +118,10 @@ class CloudproberReporter implements Reporter {
   }
 
   onEnd(result: FullResult) {
-    if (!this.internalError) {
+    // Gate on the final outcome as well as the sticky flag: with retries, a
+    // launch failure on one attempt can set internalError while a later attempt
+    // passes. Don't mark a run the suite ultimately reports as passed.
+    if (!this.internalError || result.status === "passed") {
       return;
     }
     this.writeMarker("{{ .InternalErrorMarkerFile }}");


### PR DESCRIPTION
## Summary
- Add an `internal_errors` metric on the browser probe: runs that fail because of the browser harness (missing / failed-to-launch / crashed browser, or the harness never starting) rather than the target — mirroring `EXTERNAL_GRPC`. It's still a failed run; `internal_errors` is an extra signal.
- Classification: an `onBegin` heartbeat marker (absent ⇒ harness never started) plus narrow launch/crash error signatures decided from final test outcomes; the probe reads marker files after the run and only counts on a non-zero exit. An `Init` preflight fails fast when `npx` or `@playwright/test` isn't installed.
- Not counted (documented limitation): non-launch worker crashes after the suite starts, and the pre-existing `outputDir`/`runID` reportDir-collision race under `requests_per_probe > 1`.

## Test plan
- `go test ./probes/browser/`