### PR TITLE
[probes.browser] Add internal_errors metric for missing-toolchain failures

### DIFF
--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -53,11 +53,14 @@ import (
 
 const playwrightReportDir = "_playwright_report"
 
-// browserMissingRe matches Playwright's error when the browser binary is not
-// installed, e.g. "browserType.launch: Executable doesn't exist at
-// /path/to/chromium... Please run the following command to download new
-// browsers: npx playwright install". We treat this as an internal error.
-var browserMissingRe = regexp.MustCompile(`Executable doesn't exist`)
+// internalErrorRe matches process-output signatures that indicate an
+// environment/infra problem rather than a target failure, so the run is
+// counted as an internal_error:
+//   - a missing browser binary -- Playwright's "browserType.launch: Executable
+//     doesn't exist at ..." error, and
+//   - an unresolvable Playwright package -- npx's "could not determine
+//     executable to run" error.
+var internalErrorRe = regexp.MustCompile(`Executable doesn't exist|could not determine executable to run`)
 
 // Probe holds aggregate information about all probe runs, per-target.
 type Probe struct {
@@ -319,14 +322,19 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 		return fmt.Errorf("playwrightDir is not provided through config or PLAYWRIGHT_DIR env variable")
 	}
 
-	// Preflight: npx and the Playwright package are static install-time
-	// dependencies -- if they're missing the probe can never run, so fail here
-	// (fatal) with a clear message rather than silently failing every run.
+	// Preflight: npx must be resolvable -- it's the command we exec, so a
+	// missing npx means the probe can never run. Fail here (fatal) with a clear
+	// message rather than silently failing every run.
 	if _, err := exec.LookPath(p.c.GetNpxPath()); err != nil {
 		return fmt.Errorf("npx not found (npx_path=%q): %v", p.c.GetNpxPath(), err)
 	}
+	// The Playwright package's location isn't guaranteed to be under
+	// playwrightDir: Node resolves it via NODE_PATH, the cwd walk-up, or a
+	// global install. So this is only a heads-up warning; if it's genuinely
+	// unresolvable at runtime, the run is counted as an internal_error (see
+	// internalErrorRe).
 	if _, err := os.Stat(filepath.Join(p.playwrightDir, "node_modules", "@playwright", "test")); err != nil {
-		return fmt.Errorf("playwright is not installed in %s (missing node_modules/@playwright/test): %v", p.playwrightDir, err)
+		p.l.Warningf("Playwright package not found under %s (node_modules/@playwright/test); relying on Node module resolution at runtime", p.playwrightDir)
 	}
 
 	p.workdir = p.c.GetWorkdir()
@@ -474,12 +482,12 @@ func (p *Probe) runPWTest(ctx context.Context, runReq *sched.RunProbeForTargetRe
 
 	cmd, reportDir := p.prepareCommand(target, startTime)
 
-	// browserMissing is set from the stderr streaming goroutine. cmd.Execute
+	// internalErr is set from the stderr streaming goroutine. cmd.Execute
 	// drains all stderr before returning, so it's safe to read afterwards.
-	var browserMissing bool
+	var internalErr bool
 	cmd.ProcessStderr = func(line []byte) {
-		if browserMissingRe.Match(line) {
-			browserMissing = true
+		if internalErrorRe.Match(line) {
+			internalErr = true
 		}
 	}
 
@@ -505,7 +513,7 @@ func (p *Probe) runPWTest(ctx context.Context, runReq *sched.RunProbeForTargetRe
 
 	runReq.LastRun.Set(err == nil, latency, err)
 	if err != nil {
-		if browserMissing {
+		if internalErr {
 			result.internalErrors.Inc()
 		}
 		return

--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -104,10 +104,10 @@ type probeRunResult struct {
 	total   metrics.Int
 	success metrics.Int
 	// internalErrors counts runs that failed because of environment/infra
-	// problems (a missing browser binary today) rather than the target being
-	// unhealthy. Such runs still count as failures (total moves, success
-	// doesn't); internal_errors tells "environment broken" apart from "target
-	// down".
+	// problems (a missing browser binary or an unresolvable Playwright package
+	// today; see internalErrorRe) rather than the target being unhealthy. Such
+	// runs still count as failures (total moves, success doesn't);
+	// internal_errors tells "environment broken" apart from "target down".
 	internalErrors    metrics.Int
 	latency           metrics.LatencyValue
 	validationFailure *metrics.Map[int64]

--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -23,6 +23,7 @@ import (
 	"embed"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -51,6 +52,12 @@ import (
 )
 
 const playwrightReportDir = "_playwright_report"
+
+// browserMissingRe matches Playwright's error when the browser binary is not
+// installed, e.g. "browserType.launch: Executable doesn't exist at
+// /path/to/chromium... Please run the following command to download new
+// browsers: npx playwright install". We treat this as an internal error.
+var browserMissingRe = regexp.MustCompile(`Executable doesn't exist`)
 
 // Probe holds aggregate information about all probe runs, per-target.
 type Probe struct {
@@ -91,8 +98,14 @@ var templates embed.FS
 // (see documentation with statsKeeper below). That's the reason we use metrics.Int
 // types instead of metrics.AtomicInt.
 type probeRunResult struct {
-	total             metrics.Int
-	success           metrics.Int
+	total   metrics.Int
+	success metrics.Int
+	// internalErrors counts runs that failed because of environment/infra
+	// problems (a missing browser binary today) rather than the target being
+	// unhealthy. Such runs still count as failures (total moves, success
+	// doesn't); internal_errors tells "environment broken" apart from "target
+	// down".
+	internalErrors    metrics.Int
 	latency           metrics.LatencyValue
 	validationFailure *metrics.Map[int64]
 }
@@ -118,6 +131,7 @@ func (prr probeRunResult) Metrics(ts time.Time, _ int64, opts *options.Options) 
 	em := metrics.NewEventMetrics(ts).
 		AddMetric("total", &prr.total).
 		AddMetric("success", &prr.success).
+		AddMetric("internal_errors", &prr.internalErrors).
 		AddMetric(opts.LatencyMetricName, prr.latency.Clone()).
 		AddLabel("ptype", "browser")
 
@@ -305,6 +319,16 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 		return fmt.Errorf("playwrightDir is not provided through config or PLAYWRIGHT_DIR env variable")
 	}
 
+	// Preflight: npx and the Playwright package are static install-time
+	// dependencies -- if they're missing the probe can never run, so fail here
+	// (fatal) with a clear message rather than silently failing every run.
+	if _, err := exec.LookPath(p.c.GetNpxPath()); err != nil {
+		return fmt.Errorf("npx not found (npx_path=%q): %v", p.c.GetNpxPath(), err)
+	}
+	if _, err := os.Stat(filepath.Join(p.playwrightDir, "node_modules", "@playwright", "test")); err != nil {
+		return fmt.Errorf("playwright is not installed in %s (missing node_modules/@playwright/test): %v", p.playwrightDir, err)
+	}
+
 	p.workdir = p.c.GetWorkdir()
 	if p.c.GetWorkdir() == "" {
 		d, err := os.MkdirTemp("", "cloudprober_"+p.name)
@@ -449,6 +473,16 @@ func (p *Probe) runPWTest(ctx context.Context, runReq *sched.RunProbeForTargetRe
 	startTime := time.Now()
 
 	cmd, reportDir := p.prepareCommand(target, startTime)
+
+	// browserMissing is set from the stderr streaming goroutine. cmd.Execute
+	// drains all stderr before returning, so it's safe to read afterwards.
+	var browserMissing bool
+	cmd.ProcessStderr = func(line []byte) {
+		if browserMissingRe.Match(line) {
+			browserMissing = true
+		}
+	}
+
 	_, err := cmd.Execute(ctx, p.l)
 
 	if err != nil {
@@ -471,6 +505,9 @@ func (p *Probe) runPWTest(ctx context.Context, runReq *sched.RunProbeForTargetRe
 
 	runReq.LastRun.Set(err == nil, latency, err)
 	if err != nil {
+		if browserMissing {
+			result.internalErrors.Inc()
+		}
 		return
 	}
 

--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -482,8 +482,15 @@ func (p *Probe) runPWTest(ctx context.Context, runReq *sched.RunProbeForTargetRe
 
 	cmd, reportDir := p.prepareCommand(target, startTime)
 
-	// internalErr is set from the stderr streaming goroutine. cmd.Execute
-	// drains all stderr before returning, so it's safe to read afterwards.
+	// We classify on stderr, not stdout: in cloudprober's setup the custom
+	// Playwright reporter (--reporter=html,cloudprober-reporter.ts) mirrors
+	// failing test errors to stderr, and npx writes its own errors there too.
+	// (Stock Playwright's default reporter prints test errors to stdout, but
+	// cloudprober replaces that reporter, so that path doesn't apply.) Verified
+	// against production logs for the missing-browser case.
+	//
+	// internalErr is set from the stderr streaming goroutine; cmd.Execute waits
+	// for stderr processing before returning, so it's safe to read afterwards.
 	var internalErr bool
 	cmd.ProcessStderr = func(line []byte) {
 		if internalErrorRe.Match(line) {

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -227,11 +227,17 @@ func TestRunProbeInternalError(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Stub npx: ignore args, emit Playwright's missing-browser error to stderr,
-	// exit non-zero.
+	// exit non-zero. The stderr line mirrors the real shape observed in
+	// production -- the cloudprober reporter's onTestEnd writes
+	// `WARNING Test "..." failed with errors: <JSON>` to stderr, and
+	// JSON.stringify collapses the error's newlines to \n so it's a single line.
 	npx := filepath.Join(dir, "npx")
-	script := "#!/bin/sh\n" +
-		"echo \"browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium/chrome\" 1>&2\n" +
-		"exit 1\n"
+	script := `#!/bin/sh
+cat >&2 <<'EOF'
+WARNING Test "[Smoke] example homepage loads" failed with errors: [{"message":"Error: browserType.launch: Executable doesn't exist at /playwright/.browsers/chromium_headless_shell-1228/chrome-headless-shell-linux64/chrome-headless-shell\n Please run the following command to download new browsers:\n npx playwright install"}]
+EOF
+exit 1
+`
 	if err := os.WriteFile(npx, []byte(script), 0755); err != nil {
 		t.Fatal(err)
 	}

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -33,8 +33,17 @@ import (
 )
 
 func TestProbePrepareCommand(t *testing.T) {
-	os.Setenv("PLAYWRIGHT_DIR", "/playwright")
-	defer os.Unsetenv("PLAYWRIGHT_DIR")
+	// npx is a real, resolvable executable that stands in for npx so the Init
+	// preflight (exec.LookPath) passes. playwrightDir must contain
+	// node_modules/@playwright/test for the preflight to pass too.
+	npx := os.Args[0]
+	pwDir, appDir := t.TempDir(), t.TempDir()
+	for _, d := range []string{pwDir, appDir} {
+		if err := os.MkdirAll(filepath.Join(d, "node_modules", "@playwright", "test"), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PLAYWRIGHT_DIR", pwDir)
 
 	baseEnvVars := func(pwDir string) []string {
 		return []string{"NODE_PATH=" + pwDir + "/node_modules", "PLAYWRIGHT_HTML_REPORT={OUTPUT_DIR}/" + playwrightReportDir, "PLAYWRIGHT_HTML_OPEN=never"}
@@ -51,7 +60,6 @@ func TestProbePrepareCommand(t *testing.T) {
 	tests := []struct {
 		name               string
 		disableAggregation bool
-		npxPath            string
 		playwrightDir      string
 		testSpec           []string
 		target             endpoint.Endpoint
@@ -62,49 +70,41 @@ func TestProbePrepareCommand(t *testing.T) {
 	}{
 		{
 			name:         "default",
-			wantCmdLine:  cmdLine("npx"),
-			wantEnvVars:  baseEnvVars("/playwright"),
-			wantWorkDir:  "/playwright",
+			wantCmdLine:  cmdLine(npx),
+			wantEnvVars:  baseEnvVars(pwDir),
+			wantWorkDir:  pwDir,
 			wantEMLabels: baseWantEMLabels,
 		},
 		{
 			name:         "with_target",
 			target:       endpoint.Endpoint{Name: "test_target", IP: net.ParseIP("12.12.12.12"), Port: 9313, Labels: map[string]string{"env": "prod"}},
-			wantCmdLine:  cmdLine("npx"),
-			wantEnvVars:  append(baseEnvVars("/playwright"), "target_name=test_target", "target_ip=12.12.12.12", "target_port=9313", "target_label_env=prod"),
-			wantWorkDir:  "/playwright",
+			wantCmdLine:  cmdLine(npx),
+			wantEnvVars:  append(baseEnvVars(pwDir), "target_name=test_target", "target_ip=12.12.12.12", "target_port=9313", "target_label_env=prod"),
+			wantWorkDir:  pwDir,
 			wantEMLabels: [][2]string{{"ptype", "browser"}, {"probe", "test_browser"}, {"dst", "test_target:9313"}},
 		},
 		{
 			name:               "disable_aggregation",
 			disableAggregation: true,
-			wantCmdLine:        cmdLine("npx"),
-			wantEnvVars:        baseEnvVars("/playwright"),
-			wantWorkDir:        "/playwright",
+			wantCmdLine:        cmdLine(npx),
+			wantEnvVars:        baseEnvVars(pwDir),
+			wantWorkDir:        pwDir,
 			wantEMLabels:       append(baseWantEMLabels, [2]string{"run_id", "0"}),
 		},
 		{
 			name:          "with_playwright_dir",
-			playwrightDir: "/app",
-			wantCmdLine:   cmdLine("npx"),
-			wantEnvVars:   baseEnvVars("/app"),
-			wantWorkDir:   "/app",
+			playwrightDir: appDir,
+			wantCmdLine:   cmdLine(npx),
+			wantEnvVars:   baseEnvVars(appDir),
+			wantWorkDir:   appDir,
 			wantEMLabels:  baseWantEMLabels,
-		},
-		{
-			name:         "with_npx_path",
-			npxPath:      "/usr/bin/npx",
-			wantCmdLine:  cmdLine("/usr/bin/npx"),
-			wantEnvVars:  baseEnvVars("/playwright"),
-			wantWorkDir:  "/playwright",
-			wantEMLabels: baseWantEMLabels,
 		},
 		{
 			name:         "with_test_spec",
 			testSpec:     []string{"test_spec_1", "test_spec_2"},
-			wantCmdLine:  append(cmdLine("npx"), "^.*/test_spec_1$", "^.*/test_spec_2$"),
-			wantEnvVars:  baseEnvVars("/playwright"),
-			wantWorkDir:  "/playwright",
+			wantCmdLine:  append(cmdLine(npx), "^.*/test_spec_1$", "^.*/test_spec_2$"),
+			wantEnvVars:  baseEnvVars(pwDir),
+			wantWorkDir:  pwDir,
 			wantEMLabels: baseWantEMLabels,
 		},
 	}
@@ -113,15 +113,13 @@ func TestProbePrepareCommand(t *testing.T) {
 			conf := &configpb.ProbeConf{
 				TestSpec: tt.testSpec,
 				TestDir:  &testDir,
+				NpxPath:  proto.String(npx),
 				TestMetricsOptions: &configpb.TestMetricsOptions{
 					DisableAggregation: &tt.disableAggregation,
 				},
 			}
 			if tt.playwrightDir != "" {
 				conf.PlaywrightDir = &tt.playwrightDir
-			}
-			if tt.npxPath != "" {
-				conf.NpxPath = proto.String(filepath.FromSlash(tt.npxPath))
 			}
 
 			opts := options.DefaultOptions()
@@ -162,14 +160,72 @@ func TestProbePrepareCommand(t *testing.T) {
 	}
 }
 
+func TestInitPreflight(t *testing.T) {
+	// A playwright dir that has the @playwright/test package installed.
+	pwOK := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(pwOK, "node_modules", "@playwright", "test"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name          string
+		npxPath       string
+		playwrightDir string
+		wantErr       string
+	}{
+		{
+			name:          "npx_missing",
+			npxPath:       "cloudprober-nonexistent-npx-xyz",
+			playwrightDir: pwOK,
+			wantErr:       "npx not found",
+		},
+		{
+			name:          "playwright_missing",
+			npxPath:       os.Args[0],
+			playwrightDir: t.TempDir(), // no node_modules/@playwright/test
+			wantErr:       "playwright is not installed",
+		},
+		{
+			name:          "ok",
+			npxPath:       os.Args[0],
+			playwrightDir: pwOK,
+			wantErr:       "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := &configpb.ProbeConf{
+				NpxPath:       proto.String(tt.npxPath),
+				PlaywrightDir: proto.String(tt.playwrightDir),
+			}
+			opts := options.DefaultOptions()
+			opts.ProbeConf = conf
+
+			err := (&Probe{}).Init("test_browser", opts)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestBrowserMissingRe(t *testing.T) {
+	missing := "browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1091/chrome-linux/chrome\n" +
+		"Please run the following command to download new browsers:\nnpx playwright install"
+	assert.True(t, browserMissingRe.MatchString(missing))
+	assert.False(t, browserMissingRe.MatchString("Error: expect(received).toBe(expected)"))
+}
+
 func TestProbeOutputDirPath(t *testing.T) {
 	tests := []struct {
-		name       string
-		outputDir  string
-		target     endpoint.Endpoint
-		targets    []endpoint.Endpoint
-		ts         time.Time
-		want       string
+		name      string
+		outputDir string
+		target    endpoint.Endpoint
+		targets   []endpoint.Endpoint
+		ts        time.Time
+		want      string
 	}{
 		{
 			name:      "default",

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -15,6 +15,7 @@
 package browser
 
 import (
+	"context"
 	"net"
 	"os"
 	"path/filepath"
@@ -25,6 +26,7 @@ import (
 
 	"github.com/cloudprober/cloudprober/metrics"
 	configpb "github.com/cloudprober/cloudprober/probes/browser/proto"
+	"github.com/cloudprober/cloudprober/probes/common/sched"
 	"github.com/cloudprober/cloudprober/probes/options"
 	"github.com/cloudprober/cloudprober/state"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
@@ -209,6 +211,55 @@ func TestInitPreflight(t *testing.T) {
 			assert.ErrorContains(t, err, tt.wantErr)
 		})
 	}
+}
+
+// TestRunProbeInternalError drives a full probe run through runProbe with a
+// stub npx that fails with a Playwright missing-browser error on stderr, and
+// asserts the run is counted as an internal_error: total advances, success
+// stays put, internal_errors increments, and LastRun records the failure.
+func TestRunProbeInternalError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stub npx is a /bin/sh script; skip on Windows")
+	}
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "node_modules", "@playwright", "test"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Stub npx: ignore args, emit Playwright's missing-browser error to stderr,
+	// exit non-zero.
+	npx := filepath.Join(dir, "npx")
+	script := "#!/bin/sh\n" +
+		"echo \"browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium/chrome\" 1>&2\n" +
+		"exit 1\n"
+	if err := os.WriteFile(npx, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := options.DefaultOptions()
+	opts.ProbeConf = &configpb.ProbeConf{
+		NpxPath:       proto.String(npx),
+		PlaywrightDir: proto.String(dir),
+	}
+	p := &Probe{}
+	if err := p.Init("test_browser", opts); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	p.startCtx = context.Background()
+	p.dataChan = make(chan *metrics.EventMetrics, 10)
+
+	runReq := &sched.RunProbeForTargetRequest{
+		Target:  endpoint.Endpoint{Name: "t"},
+		LastRun: &sched.LastRunResult{},
+	}
+	p.runProbe(context.Background(), runReq)
+
+	result := runReq.Result.(*probeRunResult)
+	assert.Equal(t, int64(1), result.total.Int64(), "total")
+	assert.Equal(t, int64(0), result.success.Int64(), "success")
+	assert.Equal(t, int64(1), result.internalErrors.Int64(), "internal_errors")
+	assert.False(t, runReq.LastRun.Success, "LastRun.Success")
+	assert.Error(t, runReq.LastRun.Error, "LastRun.Error")
 }
 
 func TestInternalErrorRe(t *testing.T) {

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -180,10 +180,10 @@ func TestInitPreflight(t *testing.T) {
 			wantErr:       "npx not found",
 		},
 		{
-			name:          "playwright_missing",
+			name:          "playwright_missing_is_not_fatal",
 			npxPath:       os.Args[0],
-			playwrightDir: t.TempDir(), // no node_modules/@playwright/test
-			wantErr:       "playwright is not installed",
+			playwrightDir: t.TempDir(), // no node_modules/@playwright/test; warns, doesn't fail
+			wantErr:       "",
 		},
 		{
 			name:          "ok",
@@ -211,11 +211,14 @@ func TestInitPreflight(t *testing.T) {
 	}
 }
 
-func TestBrowserMissingRe(t *testing.T) {
-	missing := "browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1091/chrome-linux/chrome\n" +
+func TestInternalErrorRe(t *testing.T) {
+	browserMissing := "browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1091/chrome-linux/chrome\n" +
 		"Please run the following command to download new browsers:\nnpx playwright install"
-	assert.True(t, browserMissingRe.MatchString(missing))
-	assert.False(t, browserMissingRe.MatchString("Error: expect(received).toBe(expected)"))
+	playwrightMissing := "npm error could not determine executable to run"
+
+	assert.True(t, internalErrorRe.MatchString(browserMissing))
+	assert.True(t, internalErrorRe.MatchString(playwrightMissing))
+	assert.False(t, internalErrorRe.MatchString("Error: expect(received).toBe(expected)"))
 }
 
 func TestProbeOutputDirPath(t *testing.T) {

--- a/probes/common/command/command.go
+++ b/probes/common/command/command.go
@@ -70,9 +70,14 @@ type Command struct {
 }
 
 // setupStreaming wires up stdout/stderr streaming for cmd. It returns a wait
-// function that blocks until all streamed output has been processed; callers
-// must invoke it after the process exits so that ProcessStreamingOutput and
-// ProcessStderr are guaranteed to have seen every line.
+// function that blocks until all stderr has been processed; callers must invoke
+// it after the process exits so that ProcessStderr is guaranteed to have seen
+// every line (e.g. to classify failure signatures). We only wait on stderr:
+// stderr processing is bounded (logging + a caller-supplied matcher), whereas
+// the stdout consumer runs ProcessStreamingOutput, which for our probes writes
+// to a metrics channel and could block on back-pressure -- we don't want
+// Execute's return gated on that. The pipe reads themselves can't hang: cmd.Wait
+// closes the pipe read ends on process exit, unblocking the scanners.
 func (c *Command) setupStreaming(cmd *exec.Cmd, l *logger.Logger) (func(), error) {
 	stdout := make(chan []byte)
 	stdoutR, err := cmd.StdoutPipe()
@@ -102,7 +107,7 @@ func (c *Command) setupStreaming(cmd *exec.Cmd, l *logger.Logger) (func(), error
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(1)
 
 	go func() {
 		defer wg.Done()
@@ -128,7 +133,6 @@ func (c *Command) setupStreaming(cmd *exec.Cmd, l *logger.Logger) (func(), error
 	}()
 
 	go func() {
-		defer wg.Done()
 		for line := range stdout {
 			c.ProcessStreamingOutput(line)
 		}

--- a/probes/common/command/command.go
+++ b/probes/common/command/command.go
@@ -58,7 +58,10 @@ type Command struct {
 	ProcessStreamingOutput func([]byte)
 	// ProcessStderr, if set, is called for each stderr line (in addition to
 	// the usual logging). It lets callers inspect stderr while streaming, e.g.
-	// to classify known failure signatures. Only used in streaming mode.
+	// to classify known failure signatures. Only used in streaming mode. The
+	// passed slice's backing array is reused on the next scan (same as
+	// ProcessStreamingOutput / bufio.Scanner), so callers must not retain it
+	// without copying.
 	ProcessStderr   func([]byte)
 	RawStderrOutput bool
 

--- a/probes/common/command/command.go
+++ b/probes/common/command/command.go
@@ -29,6 +29,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"sync"
 	"time"
 
 	"github.com/cloudprober/cloudprober/logger"
@@ -55,7 +56,11 @@ type Command struct {
 	EnvVars                []string
 	WorkDir                string
 	ProcessStreamingOutput func([]byte)
-	RawStderrOutput        bool
+	// ProcessStderr, if set, is called for each stderr line (in addition to
+	// the usual logging). It lets callers inspect stderr while streaming, e.g.
+	// to classify known failure signatures. Only used in streaming mode.
+	ProcessStderr   func([]byte)
+	RawStderrOutput bool
 
 	// We create a goroutine to wait for child processes to finish. This field
 	// dictates how long will that goroutine wait for child processes to finish
@@ -64,11 +69,15 @@ type Command struct {
 	ChildProcessWaitTime time.Duration
 }
 
-func (c *Command) setupStreaming(cmd *exec.Cmd, l *logger.Logger) error {
+// setupStreaming wires up stdout/stderr streaming for cmd. It returns a wait
+// function that blocks until all streamed output has been processed; callers
+// must invoke it after the process exits so that ProcessStreamingOutput and
+// ProcessStderr are guaranteed to have seen every line.
+func (c *Command) setupStreaming(cmd *exec.Cmd, l *logger.Logger) (func(), error) {
 	stdout := make(chan []byte)
 	stdoutR, err := cmd.StdoutPipe()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	go func() {
 		defer close(stdout)
@@ -89,9 +98,14 @@ func (c *Command) setupStreaming(cmd *exec.Cmd, l *logger.Logger) error {
 	// Capture stderr
 	stderrR, err := cmd.StderrPipe()
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
 	go func() {
+		defer wg.Done()
 		defer stderrR.Close()
 		scanner := bufio.NewScanner(stderrR)
 
@@ -104,6 +118,9 @@ func (c *Command) setupStreaming(cmd *exec.Cmd, l *logger.Logger) error {
 			} else {
 				l.WarningAttrs("process stderr", slog.String("process_stderr", scanner.Text()), slog.String("process_path", c.CmdLine[0]))
 			}
+			if c.ProcessStderr != nil {
+				c.ProcessStderr(scanner.Bytes())
+			}
 		}
 		if err := scanner.Err(); err != nil && !isPipeOrFileClosedError(err) {
 			l.ErrorAttrs(fmt.Sprintf("Error reading from stderr: %v", err), slog.String("process_path", c.CmdLine[0]))
@@ -111,12 +128,13 @@ func (c *Command) setupStreaming(cmd *exec.Cmd, l *logger.Logger) error {
 	}()
 
 	go func() {
+		defer wg.Done()
 		for line := range stdout {
 			c.ProcessStreamingOutput(line)
 		}
 	}()
 
-	return nil
+	return wg.Wait, nil
 }
 
 func (c *Command) Execute(ctx context.Context, l *logger.Logger) (string, error) {
@@ -134,16 +152,22 @@ func (c *Command) Execute(ctx context.Context, l *logger.Logger) (string, error)
 
 	var stdoutBuf, stderrBuf bytes.Buffer
 
+	var waitStreaming func()
 	if c.ProcessStreamingOutput != nil {
-		if err := c.setupStreaming(cmd, l); err != nil {
+		w, err := c.setupStreaming(cmd, l)
+		if err != nil {
 			return "", fmt.Errorf("error setting up stdout/stderr streaming: %v", err)
 		}
+		waitStreaming = w
 	} else {
 		cmd.Stdout, cmd.Stderr = &stdoutBuf, &stderrBuf
 	}
 
 	l.Debugf("Running command: %v", cmd)
 	err := runCommand(ctx, cmd, c.ChildProcessWaitTime)
+	if waitStreaming != nil {
+		waitStreaming()
+	}
 
 	if err != nil {
 		stdout, stderr := stdoutBuf.String(), stderrBuf.String()

--- a/probes/common/command/command_test.go
+++ b/probes/common/command/command_test.go
@@ -154,3 +154,30 @@ func TestCommand(t *testing.T) {
 		})
 	}
 }
+
+// TestProcessStderr verifies that, in streaming mode, ProcessStderr receives
+// the child's stderr lines and that Execute drains them before returning (so
+// reading the captured lines afterwards is race-free). TestShellProcessSuccess
+// writes a "Running test command." line to stderr.
+func TestProcessStderr(t *testing.T) {
+	var stderr []string
+	p := &Command{
+		CmdLine:                []string{os.Args[0], "-test.run=TestShellProcessSuccess", "--", "/test/cmd"},
+		EnvVars:                []string{"GO_CP_TEST_PROCESS=1"},
+		ProcessStreamingOutput: func([]byte) {},
+		ProcessStderr: func(line []byte) {
+			stderr = append(stderr, string(line))
+		},
+	}
+
+	_, err := p.Execute(context.Background(), nil)
+	assert.NoError(t, err)
+
+	found := false
+	for _, line := range stderr {
+		if strings.Contains(line, "Running test command.") {
+			found = true
+		}
+	}
+	assert.True(t, found, "ProcessStderr did not receive the expected stderr line, got: %v", stderr)
+}


### PR DESCRIPTION
## Summary
- Add an `internal_errors` counter to the browser probe (mirrors `external_grpc`): infra/environment failures still count as probe failures but are told apart from target-down.
- Preflight `npx` and the Playwright package in `Init`; missing → fatal error so the prober exits with a clear message (static install-time deps).
- Runtime: classify a missing browser binary (playwright's `Executable doesn't exist`) as `internal_errors`, via a new `ProcessStderr` callback in the command package (which now also drains streamed output before `Execute` returns).

This is PR 1 of 2. PR 2 will cover browser-launch-failure → global timeout, detected via the reporter.

## Test plan
- `go test ./probes/browser/ ./probes/common/command/` — new tests for preflight (npx/playwright missing), the browser-missing signature, and `ProcessStderr` plumbing.