### PR TITLE
[probes.browser] Count browser-launch timeouts as internal_errors

### DIFF
--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -60,9 +60,10 @@ const playwrightReportDir = "_playwright_report"
 //     doesn't exist at ..." error,
 //   - an unresolvable Playwright package -- npx's "could not determine
 //     executable to run" error, and
-//   - a browser that never launched -- the cloudprober reporter emits
+//   - a browser that failed to launch -- the cloudprober reporter emits
 //     "[cloudprober-internal-error]" from onEnd when the suite hits the global
-//     timeout before the browser launched (see cloudprober-reporter.ts).
+//     timeout while the browser launch was in progress (see
+//     cloudprober-reporter.ts).
 var internalErrorRe = regexp.MustCompile(`Executable doesn't exist|could not determine executable to run|\[cloudprober-internal-error\]`)
 
 // Probe holds aggregate information about all probe runs, per-target.

--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -53,14 +53,17 @@ import (
 
 const playwrightReportDir = "_playwright_report"
 
-// internalErrorRe matches process-output signatures that indicate an
+// internalErrorRe matches process-output (stderr) signatures that indicate an
 // environment/infra problem rather than a target failure, so the run is
 // counted as an internal_error:
 //   - a missing browser binary -- Playwright's "browserType.launch: Executable
-//     doesn't exist at ..." error, and
+//     doesn't exist at ..." error,
 //   - an unresolvable Playwright package -- npx's "could not determine
-//     executable to run" error.
-var internalErrorRe = regexp.MustCompile(`Executable doesn't exist|could not determine executable to run`)
+//     executable to run" error, and
+//   - a browser that never launched -- the cloudprober reporter emits
+//     "[cloudprober-internal-error]" from onEnd when the suite hits the global
+//     timeout without any test making progress (see cloudprober-reporter.ts).
+var internalErrorRe = regexp.MustCompile(`Executable doesn't exist|could not determine executable to run|\[cloudprober-internal-error\]`)
 
 // Probe holds aggregate information about all probe runs, per-target.
 type Probe struct {
@@ -104,10 +107,11 @@ type probeRunResult struct {
 	total   metrics.Int
 	success metrics.Int
 	// internalErrors counts runs that failed because of environment/infra
-	// problems (a missing browser binary or an unresolvable Playwright package
-	// today; see internalErrorRe) rather than the target being unhealthy. Such
-	// runs still count as failures (total moves, success doesn't);
-	// internal_errors tells "environment broken" apart from "target down".
+	// problems (a missing browser binary, an unresolvable Playwright package, or
+	// a browser that never launched before the global timeout; see
+	// internalErrorRe) rather than the target being unhealthy. Such runs still
+	// count as failures (total moves, success doesn't); internal_errors tells
+	// "environment broken" apart from "target down".
 	internalErrors    metrics.Int
 	latency           metrics.LatencyValue
 	validationFailure *metrics.Map[int64]

--- a/probes/browser/browser.go
+++ b/probes/browser/browser.go
@@ -62,7 +62,7 @@ const playwrightReportDir = "_playwright_report"
 //     executable to run" error, and
 //   - a browser that never launched -- the cloudprober reporter emits
 //     "[cloudprober-internal-error]" from onEnd when the suite hits the global
-//     timeout without any test making progress (see cloudprober-reporter.ts).
+//     timeout before the browser launched (see cloudprober-reporter.ts).
 var internalErrorRe = regexp.MustCompile(`Executable doesn't exist|could not determine executable to run|\[cloudprober-internal-error\]`)
 
 // Probe holds aggregate information about all probe runs, per-target.

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -277,7 +277,7 @@ func TestInternalErrorRe(t *testing.T) {
 	playwrightMissing := "npm error could not determine executable to run"
 	// Emitted by the cloudprober reporter's onEnd on a launch-timeout (see
 	// cloudprober-reporter.ts).
-	launchTimeout := "WARNING [cloudprober-internal-error] test suite timed out before the browser launched"
+	launchTimeout := "WARNING [cloudprober-internal-error] test suite timed out during browser launch"
 
 	assert.True(t, internalErrorRe.MatchString(browserMissing))
 	assert.True(t, internalErrorRe.MatchString(playwrightMissing))
@@ -323,7 +323,14 @@ func TestReporterDecision(t *testing.T) {
 	// and DisableTestMetrics are referenced by this template; the harness only
 	// sends pw:api steps and onEnd, so their values don't affect the outcome.
 	tmpl := template.Must(template.ParseFiles(filepath.Join("templates", "cloudprober-reporter.ts.tmpl")))
-	reporterPath := filepath.Join(t.TempDir(), "cloudprober-reporter.ts")
+	tmpDir := t.TempDir()
+	// node < 22.7 doesn't detect module syntax on its own, and picks the format
+	// from the nearest package.json; without this the stripped reporter's
+	// "export default" would be loaded as CommonJS and fail to parse.
+	if err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(`{"type":"module"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	reporterPath := filepath.Join(tmpDir, "cloudprober-reporter.ts")
 	f, err := os.Create(reporterPath)
 	if err != nil {
 		t.Fatal(err)

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -18,10 +18,13 @@ import (
 	"context"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
+	"text/template"
 	"time"
 
 	"github.com/cloudprober/cloudprober/metrics"
@@ -280,6 +283,63 @@ func TestInternalErrorRe(t *testing.T) {
 	assert.True(t, internalErrorRe.MatchString(playwrightMissing))
 	assert.True(t, internalErrorRe.MatchString(launchTimeout))
 	assert.False(t, internalErrorRe.MatchString("Error: expect(received).toBe(expected)"))
+}
+
+// nodeSupportsStripTypes reports whether the node on PATH can run a TypeScript
+// file directly (import()/strip-types, node >= 22.6). Returns the node path.
+func nodeSupportsStripTypes(t *testing.T) string {
+	t.Helper()
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not found; skipping reporter decision test")
+	}
+	out, err := exec.Command(node, "--version").Output()
+	if err != nil {
+		t.Skipf("node --version failed: %v", err)
+	}
+	// Output looks like "v22.6.0\n".
+	ver := strings.TrimPrefix(strings.TrimSpace(string(out)), "v")
+	parts := strings.Split(ver, ".")
+	if len(parts) < 2 {
+		t.Skipf("unexpected node version %q", ver)
+	}
+	major, _ := strconv.Atoi(parts[0])
+	minor, _ := strconv.Atoi(parts[1])
+	if major < 22 || (major == 22 && minor < 6) {
+		t.Skipf("node %s too old for TypeScript strip-types (need >= 22.6)", ver)
+	}
+	return node
+}
+
+// TestReporterDecision renders the cloudprober Playwright reporter and drives
+// it through synthetic reporter-event streams (testdata harness), asserting the
+// launch-timeout internal-error sentinel fires only when the browser never
+// launched. This covers the reporter's browserReady/onEnd logic -- the novel
+// part of the launch-timeout detection -- which the Go-side regex test cannot.
+func TestReporterDecision(t *testing.T) {
+	node := nodeSupportsStripTypes(t)
+
+	// Render the reporter template to a temp .ts file. Only EnableStepMetrics
+	// and DisableTestMetrics are referenced by this template; the harness only
+	// sends pw:api steps and onEnd, so their values don't affect the outcome.
+	tmpl := template.Must(template.ParseFiles(filepath.Join("templates", "cloudprober-reporter.ts.tmpl")))
+	reporterPath := filepath.Join(t.TempDir(), "cloudprober-reporter.ts")
+	f, err := os.Create(reporterPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpl.Execute(f, struct{ EnableStepMetrics, DisableTestMetrics bool }{}); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	harness := filepath.Join("testdata", "reporter_decision_harness.mjs")
+	cmd := exec.Command(node, "--experimental-strip-types", harness, reporterPath)
+	out, err := cmd.CombinedOutput()
+	t.Logf("harness output:\n%s", out)
+	if err != nil {
+		t.Fatalf("reporter decision harness failed: %v", err)
+	}
 }
 
 func TestProbeOutputDirPath(t *testing.T) {

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -274,7 +274,7 @@ func TestInternalErrorRe(t *testing.T) {
 	playwrightMissing := "npm error could not determine executable to run"
 	// Emitted by the cloudprober reporter's onEnd on a launch-timeout (see
 	// cloudprober-reporter.ts).
-	launchTimeout := "WARNING [cloudprober-internal-error] test suite timed out before the browser made progress"
+	launchTimeout := "WARNING [cloudprober-internal-error] test suite timed out before the browser launched"
 
 	assert.True(t, internalErrorRe.MatchString(browserMissing))
 	assert.True(t, internalErrorRe.MatchString(playwrightMissing))

--- a/probes/browser/browser_test.go
+++ b/probes/browser/browser_test.go
@@ -272,9 +272,13 @@ func TestInternalErrorRe(t *testing.T) {
 	browserMissing := "browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1091/chrome-linux/chrome\n" +
 		"Please run the following command to download new browsers:\nnpx playwright install"
 	playwrightMissing := "npm error could not determine executable to run"
+	// Emitted by the cloudprober reporter's onEnd on a launch-timeout (see
+	// cloudprober-reporter.ts).
+	launchTimeout := "WARNING [cloudprober-internal-error] test suite timed out before the browser made progress"
 
 	assert.True(t, internalErrorRe.MatchString(browserMissing))
 	assert.True(t, internalErrorRe.MatchString(playwrightMissing))
+	assert.True(t, internalErrorRe.MatchString(launchTimeout))
 	assert.False(t, internalErrorRe.MatchString("Error: expect(received).toBe(expected)"))
 }
 

--- a/probes/browser/templates/cloudprober-reporter.ts.tmpl
+++ b/probes/browser/templates/cloudprober-reporter.ts.tmpl
@@ -24,19 +24,27 @@ const testLabels= (test: TestCase) => {
 }
 
 class CloudproberReporter implements Reporter {
-  // browserReady becomes true once any Playwright API call ("pw:api" step)
-  // completes without error. The first such step is the browser launch, so a
-  // successful pw:api step means the browser came up. It's what onEnd uses to
-  // tell a launch failure (browser never came up) apart from a target/page
-  // stall (browser launched, a later navigation hung) when both end in a
-  // global timeout with no onTestEnd. A fresh process (and reporter) is created
-  // per probe run, so this resets each cycle.
+  // launchStarted / browserReady track how far the browser got before a global
+  // timeout, so onEnd can tell a browser-launch failure (an internal error)
+  // apart from a test/target stall (a target failure) -- both end in a global
+  // timeout with no onTestEnd, so we can't rely on test status.
+  //
+  // The browser launch is a Playwright API call, so it shows up as a "pw:api"
+  // step. launchStarted = a pw:api step began; browserReady = a pw:api step
+  // completed without error. Requiring launchStarted (not just !browserReady)
+  // avoids a false positive when the run stalls *before* the browser is ever
+  // touched -- e.g. a beforeAll/hook doing a plain fetch() against a dead
+  // target, which is a target failure, not an internal error. A fresh process
+  // (and reporter) is created per probe run, so these reset each cycle.
   //
   // Confirmed empirically against real Playwright:
   //   - mid-test hang: "Launch browser"/"Create context"/"Create page" pw:api
   //     steps end err=0, then "Navigate to ..." hangs -> browserReady true.
-  //   - launch hang: "Launch browser" pw:api step never ends before onEnd; the
-  //     browser fixture only closes (err=1) during teardown -> browserReady false.
+  //   - launch hang: "Launch browser" pw:api step begins but never ends before
+  //     onEnd -> launchStarted true, browserReady false.
+  //   - pre-launch hang (beforeAll raw fetch): only "hook" steps begin, no
+  //     pw:api step -> launchStarted false.
+  private launchStarted = false;
   private browserReady = false;
 
   onBegin(config: FullConfig, suite: Suite) {
@@ -45,6 +53,12 @@ class CloudproberReporter implements Reporter {
 
   onTestBegin(test: TestCase) {
     info(`Starting test "${test.title}"`);
+  }
+
+  onStepBegin(test: TestCase, result: TestResult, step: TestStep) {
+    if (step.category === 'pw:api') {
+      this.launchStarted = true;
+    }
   }
 
   onStepEnd(test: TestCase, result: TestResult, step: TestStep) {
@@ -75,15 +89,15 @@ class CloudproberReporter implements Reporter {
   }
 
   onEnd(result: FullResult) {
-    // The global timeout (cloudprober's globalTimeout) being reached before the
-    // browser ever launched means the run stalled in the browser environment
-    // -- e.g. a launch failure under resource pressure. Emit a sentinel to
-    // stderr so cloudprober counts it as an internal_error (matched by
-    // internalErrorRe). If the browser did launch (browserReady) and the suite
-    // still timed out, the stall is in the test/target (e.g. a hung
-    // navigation), which is a target failure, not an internal error.
-    if (result.status === "timedout" && !this.browserReady) {
-      warning("[cloudprober-internal-error] test suite timed out before the browser launched");
+    // A global timeout (cloudprober's globalTimeout) where the browser launch
+    // was started but never completed means the run stalled bringing the
+    // browser up -- e.g. a launch failure under resource pressure. Emit a
+    // sentinel to stderr so cloudprober counts it as an internal_error (matched
+    // by internalErrorRe). If the browser launched (browserReady) or the run
+    // never got to launching it (launchStarted false, e.g. a hook hung on a
+    // plain fetch), the stall is in the test/target, which is a target failure.
+    if (result.status === "timedout" && this.launchStarted && !this.browserReady) {
+      warning("[cloudprober-internal-error] test suite timed out during browser launch");
     }
   }
 }

--- a/probes/browser/templates/cloudprober-reporter.ts.tmpl
+++ b/probes/browser/templates/cloudprober-reporter.ts.tmpl
@@ -24,13 +24,20 @@ const testLabels= (test: TestCase) => {
 }
 
 class CloudproberReporter implements Reporter {
-  // madeProgress is set once any test actually executes -- passed, or failed
-  // with a real error. It lets onEnd tell a genuine run that happened to hit
-  // the global timeout (browser worked, tests just took too long) apart from a
-  // run where the browser never made progress (e.g. launch failure under
-  // resource pressure). A fresh process (and reporter) is created per probe
-  // run, so this resets each cycle.
-  private madeProgress = false;
+  // browserReady becomes true once any Playwright API call ("pw:api" step)
+  // completes without error. The first such step is the browser launch, so a
+  // successful pw:api step means the browser came up. It's what onEnd uses to
+  // tell a launch failure (browser never came up) apart from a target/page
+  // stall (browser launched, a later navigation hung) when both end in a
+  // global timeout with no onTestEnd. A fresh process (and reporter) is created
+  // per probe run, so this resets each cycle.
+  //
+  // Confirmed empirically against real Playwright:
+  //   - mid-test hang: "Launch browser"/"Create context"/"Create page" pw:api
+  //     steps end err=0, then "Navigate to ..." hangs -> browserReady true.
+  //   - launch hang: "Launch browser" pw:api step never ends before onEnd; the
+  //     browser fixture only closes (err=1) during teardown -> browserReady false.
+  private browserReady = false;
 
   onBegin(config: FullConfig, suite: Suite) {
     info(`Starting the suite "${suite.title}" with ${suite.allTests().length} tests`);
@@ -41,6 +48,9 @@ class CloudproberReporter implements Reporter {
   }
 
   onStepEnd(test: TestCase, result: TestResult, step: TestStep) {
+    if (step.category === 'pw:api' && !step.error) {
+      this.browserReady = true;
+    }
     if (step.category === 'test.step') {
       if (result.status !== "passed" && result.status !== "skipped") {
         warning(`Test step "${step.title}" of test "${test.title}" failed with error: ${JSON.stringify(step.error)}`);
@@ -55,13 +65,6 @@ class CloudproberReporter implements Reporter {
   }
   
   onTestEnd(test: TestCase, result: TestResult) {
-    // A genuine execution is a pass, or a failure with a real error. A
-    // timeout-aborted test shows up as "failed" with an empty errors array
-    // (errors.length === 0), so it does not count as progress.
-    if (result.status === "passed" ||
-        (result.status === "failed" && result.errors.length > 0)) {
-      this.madeProgress = true;
-    }
     if (result.status !== "passed" && result.status !== "skipped") {
       warning(`Test "${test.title}" failed with errors: ${JSON.stringify(result.errors)}`);
     }
@@ -72,14 +75,15 @@ class CloudproberReporter implements Reporter {
   }
 
   onEnd(result: FullResult) {
-    // The global timeout (cloudprober's globalTimeout) being reached with no
-    // test having made progress means the run stalled before the browser could
-    // do anything -- e.g. a browser launch failure under resource pressure.
-    // Emit a sentinel to stderr so cloudprober counts it as an internal_error
-    // (matched by internalErrorRe). A genuine but slow run (madeProgress) that
-    // hits the same timeout is a target/config issue, not an internal error.
-    if (result.status === "timedout" && !this.madeProgress) {
-      warning("[cloudprober-internal-error] test suite timed out before the browser made progress");
+    // The global timeout (cloudprober's globalTimeout) being reached before the
+    // browser ever launched means the run stalled in the browser environment
+    // -- e.g. a launch failure under resource pressure. Emit a sentinel to
+    // stderr so cloudprober counts it as an internal_error (matched by
+    // internalErrorRe). If the browser did launch (browserReady) and the suite
+    // still timed out, the stall is in the test/target (e.g. a hung
+    // navigation), which is a target failure, not an internal error.
+    if (result.status === "timedout" && !this.browserReady) {
+      warning("[cloudprober-internal-error] test suite timed out before the browser launched");
     }
   }
 }

--- a/probes/browser/templates/cloudprober-reporter.ts.tmpl
+++ b/probes/browser/templates/cloudprober-reporter.ts.tmpl
@@ -1,5 +1,5 @@
 import type {
-  Reporter, FullConfig, Suite, TestCase, TestStep, TestResult
+  Reporter, FullConfig, FullResult, Suite, TestCase, TestStep, TestResult
 } from '@playwright/test/reporter';
 
 const info = (string: string) => process.stderr.write("INFO "+string+'\n');
@@ -24,6 +24,14 @@ const testLabels= (test: TestCase) => {
 }
 
 class CloudproberReporter implements Reporter {
+  // madeProgress is set once any test actually executes -- passed, or failed
+  // with a real error. It lets onEnd tell a genuine run that happened to hit
+  // the global timeout (browser worked, tests just took too long) apart from a
+  // run where the browser never made progress (e.g. launch failure under
+  // resource pressure). A fresh process (and reporter) is created per probe
+  // run, so this resets each cycle.
+  private madeProgress = false;
+
   onBegin(config: FullConfig, suite: Suite) {
     info(`Starting the suite "${suite.title}" with ${suite.allTests().length} tests`);
   }
@@ -47,6 +55,13 @@ class CloudproberReporter implements Reporter {
   }
   
   onTestEnd(test: TestCase, result: TestResult) {
+    // A genuine execution is a pass, or a failure with a real error. A
+    // timeout-aborted test shows up as "failed" with an empty errors array
+    // (errors.length === 0), so it does not count as progress.
+    if (result.status === "passed" ||
+        (result.status === "failed" && result.errors.length > 0)) {
+      this.madeProgress = true;
+    }
     if (result.status !== "passed" && result.status !== "skipped") {
       warning(`Test "${test.title}" failed with errors: ${JSON.stringify(result.errors)}`);
     }
@@ -54,6 +69,18 @@ class CloudproberReporter implements Reporter {
     print(`test_status{${testLabels(test)},status="${result.status}"} 1`);
     print(`test_latency{${testLabels(test)},status="${result.status}"} ${result.duration*1000}`);
     {{ end }}
+  }
+
+  onEnd(result: FullResult) {
+    // The global timeout (cloudprober's globalTimeout) being reached with no
+    // test having made progress means the run stalled before the browser could
+    // do anything -- e.g. a browser launch failure under resource pressure.
+    // Emit a sentinel to stderr so cloudprober counts it as an internal_error
+    // (matched by internalErrorRe). A genuine but slow run (madeProgress) that
+    // hits the same timeout is a target/config issue, not an internal error.
+    if (result.status === "timedout" && !this.madeProgress) {
+      warning("[cloudprober-internal-error] test suite timed out before the browser made progress");
+    }
   }
 }
 export default CloudproberReporter;

--- a/probes/browser/testdata/reporter_decision_harness.mjs
+++ b/probes/browser/testdata/reporter_decision_harness.mjs
@@ -25,28 +25,34 @@ if (!reporterPath) {
 // (e.g. C:\...), which node's ESM loader otherwise reads as a URL scheme.
 const Reporter = (await import(pathToFileURL(reporterPath).href)).default;
 
-// Event helpers. A "pw:api" step that ends without error models a successful
-// browser launch (or context/page creation); with an error it models a failed
-// launch. "end" is onEnd with the given suite status.
-const stepOk = { t: "stepEnd", category: "pw:api", error: undefined };
-const stepErr = { t: "stepEnd", category: "pw:api", error: { message: "boom" } };
+// Event helpers. The browser launch is a Playwright API call ("pw:api" step):
+// its onStepBegin models "launch started", and a matching onStepEnd without
+// error models "browser came up". "hook" models non-Playwright work (e.g. a
+// beforeAll doing a plain fetch). "end" is onEnd with the given suite status.
+const apiBegin = { t: "stepBegin", category: "pw:api" };
+const apiOk = { t: "stepEnd", category: "pw:api", error: undefined };
+const apiErr = { t: "stepEnd", category: "pw:api", error: { message: "boom" } };
+const hookBegin = { t: "stepBegin", category: "hook" };
 const end = (status) => ({ t: "end", status });
 
 const scenarios = [
-  // Launch hang: browser never comes up -> no successful pw:api step before the
+  // Launch hang: launch started (pw:api begins) but never completed before the
   // global timeout. Internal error.
-  { name: "launch_hang_timeout", events: [end("timedout")], wantSentinel: true },
-  // Launch reported an error (still no successful pw:api) then timeout. Internal.
-  { name: "launch_errored_timeout", events: [stepErr, end("timedout")], wantSentinel: true },
+  { name: "launch_hang_timeout", events: [apiBegin, end("timedout")], wantSentinel: true },
+  // Launch started then reported an error (no successful pw:api) then timeout.
+  { name: "launch_errored_timeout", events: [apiBegin, apiErr, end("timedout")], wantSentinel: true },
   // Mid-test hang: browser launched (pw:api ok), a later navigation hung until
   // the global timeout. Target failure, not internal.
-  { name: "midtest_hang_timeout", events: [stepOk, end("timedout")], wantSentinel: false },
+  { name: "midtest_hang_timeout", events: [apiBegin, apiOk, end("timedout")], wantSentinel: false },
   // Multi-test: an earlier test ran (pw:api ok), a later one was in flight at
   // the global timeout. Browser clearly worked -> target failure.
-  { name: "multitest_hang_timeout", events: [stepOk, stepOk, end("timedout")], wantSentinel: false },
+  { name: "multitest_hang_timeout", events: [apiBegin, apiOk, apiOk, end("timedout")], wantSentinel: false },
+  // Pre-launch hang: a hook (e.g. beforeAll raw fetch) hung before the browser
+  // was ever touched -- no pw:api step began. Target failure, not internal.
+  { name: "prelaunch_hook_hang_timeout", events: [hookBegin, end("timedout")], wantSentinel: false },
   // Normal outcomes: not a global timeout at all.
-  { name: "passed", events: [stepOk, end("passed")], wantSentinel: false },
-  { name: "failed_not_timedout", events: [stepOk, end("failed")], wantSentinel: false },
+  { name: "passed", events: [apiBegin, apiOk, end("passed")], wantSentinel: false },
+  { name: "failed_not_timedout", events: [apiBegin, apiOk, end("failed")], wantSentinel: false },
   { name: "interrupted", events: [end("interrupted")], wantSentinel: false },
 ];
 
@@ -57,8 +63,11 @@ function runScenario(s) {
   process.stderr.write = (chunk) => { captured += chunk; return true; };
   try {
     for (const e of s.events) {
-      if (e.t === "stepEnd") {
-        r.onStepEnd({}, {}, { category: e.category, error: e.error, title: "", duration: 0 });
+      const step = { category: e.category, error: e.error, title: "", duration: 0 };
+      if (e.t === "stepBegin") {
+        r.onStepBegin({}, {}, step);
+      } else if (e.t === "stepEnd") {
+        r.onStepEnd({}, {}, step);
       } else if (e.t === "end") {
         r.onEnd({ status: e.status });
       }

--- a/probes/browser/testdata/reporter_decision_harness.mjs
+++ b/probes/browser/testdata/reporter_decision_harness.mjs
@@ -12,6 +12,8 @@
 // real browser): the first Playwright API call is the browser launch, so a
 // "pw:api" step that ends without error means the browser came up.
 
+import { pathToFileURL } from "node:url";
+
 const SENTINEL = "[cloudprober-internal-error]";
 
 const reporterPath = process.argv[2];
@@ -19,7 +21,9 @@ if (!reporterPath) {
   console.error("usage: harness <reporter.ts>");
   process.exit(2);
 }
-const Reporter = (await import(reporterPath)).default;
+// Convert to a file:// URL so dynamic import() accepts a Windows absolute path
+// (e.g. C:\...), which node's ESM loader otherwise reads as a URL scheme.
+const Reporter = (await import(pathToFileURL(reporterPath).href)).default;
 
 // Event helpers. A "pw:api" step that ends without error models a successful
 // browser launch (or context/page creation); with an error it models a failed

--- a/probes/browser/testdata/reporter_decision_harness.mjs
+++ b/probes/browser/testdata/reporter_decision_harness.mjs
@@ -1,0 +1,75 @@
+// reporter_decision_harness.mjs drives the rendered cloudprober Playwright
+// reporter through synthetic reporter-event streams and checks, for each
+// scenario, whether it emits the internal-error sentinel. It exercises the
+// browserReady/onEnd decision without a real browser (which the CI/sandbox
+// can't install), covering the launch-hang vs target-hang distinction that a
+// Go-side regex test can't.
+//
+// Usage: node --experimental-strip-types reporter_decision_harness.mjs <reporter.ts>
+// Exits 0 if every scenario matches its expected outcome, 1 otherwise.
+//
+// The event sequences mirror what real Playwright emits (confirmed against a
+// real browser): the first Playwright API call is the browser launch, so a
+// "pw:api" step that ends without error means the browser came up.
+
+const SENTINEL = "[cloudprober-internal-error]";
+
+const reporterPath = process.argv[2];
+if (!reporterPath) {
+  console.error("usage: harness <reporter.ts>");
+  process.exit(2);
+}
+const Reporter = (await import(reporterPath)).default;
+
+// Event helpers. A "pw:api" step that ends without error models a successful
+// browser launch (or context/page creation); with an error it models a failed
+// launch. "end" is onEnd with the given suite status.
+const stepOk = { t: "stepEnd", category: "pw:api", error: undefined };
+const stepErr = { t: "stepEnd", category: "pw:api", error: { message: "boom" } };
+const end = (status) => ({ t: "end", status });
+
+const scenarios = [
+  // Launch hang: browser never comes up -> no successful pw:api step before the
+  // global timeout. Internal error.
+  { name: "launch_hang_timeout", events: [end("timedout")], wantSentinel: true },
+  // Launch reported an error (still no successful pw:api) then timeout. Internal.
+  { name: "launch_errored_timeout", events: [stepErr, end("timedout")], wantSentinel: true },
+  // Mid-test hang: browser launched (pw:api ok), a later navigation hung until
+  // the global timeout. Target failure, not internal.
+  { name: "midtest_hang_timeout", events: [stepOk, end("timedout")], wantSentinel: false },
+  // Multi-test: an earlier test ran (pw:api ok), a later one was in flight at
+  // the global timeout. Browser clearly worked -> target failure.
+  { name: "multitest_hang_timeout", events: [stepOk, stepOk, end("timedout")], wantSentinel: false },
+  // Normal outcomes: not a global timeout at all.
+  { name: "passed", events: [stepOk, end("passed")], wantSentinel: false },
+  { name: "failed_not_timedout", events: [stepOk, end("failed")], wantSentinel: false },
+  { name: "interrupted", events: [end("interrupted")], wantSentinel: false },
+];
+
+function runScenario(s) {
+  const r = new Reporter();
+  const origWrite = process.stderr.write.bind(process.stderr);
+  let captured = "";
+  process.stderr.write = (chunk) => { captured += chunk; return true; };
+  try {
+    for (const e of s.events) {
+      if (e.t === "stepEnd") {
+        r.onStepEnd({}, {}, { category: e.category, error: e.error, title: "", duration: 0 });
+      } else if (e.t === "end") {
+        r.onEnd({ status: e.status });
+      }
+    }
+  } finally {
+    process.stderr.write = origWrite;
+  }
+  return captured.includes(SENTINEL);
+}
+
+let failures = 0;
+for (const s of scenarios) {
+  const got = runScenario(s);
+  const ok = got === s.wantSentinel;
+  if (!ok) failures++;
+  console.log(`${ok ? "PASS" : "FAIL"}  ${s.name}: sentinel got=${got} want=${s.wantSentinel}`);
+}
+process.exit(failures === 0 ? 0 : 1);

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.go.exclusions=**/vendor/**
 
 sonar.sources=.
 sonar.exclusions=**/*_test.go,examples/**,**.pb.go,**/test_*.py,**_pb*.py
-sonar.coverage.exclusions=examples/**,**.pb.go, **/cmd/*.go,**/test_*.py,**_pb*.py,**/internal/testcerts/**
+sonar.coverage.exclusions=examples/**,**.pb.go, **/cmd/*.go,**/test_*.py,**_pb*.py,**/internal/testcerts/**,probes/browser/testdata/reporter_decision_harness.mjs
 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go


### PR DESCRIPTION
## Summary
- Detect the browser-launch-timeout case (browser can't launch under resource pressure → no progress → hits cloudprober's `globalTimeout`) and count it as `internal_errors` instead of an ordinary failure.
- Reporter `onEnd` emits a stderr sentinel `[cloudprober-internal-error]` when `result.status === "timedout"` **and** no test made real progress; browser.go's existing `internalErrorRe` classifier picks it up.
- `madeProgress` guard (a test passed, or failed with a populated error) prevents false positives — a genuine run that merely exhausted the budget stays a target/config failure.

Stacked on #1388 (PR-1); base is `browser-internal-errors-static`.

## Test plan
- `go test ./probes/browser/` — `TestInternalErrorRe` now covers the sentinel.
- Validated the rendered reporter against **real Playwright** (browserless tests): pass → no sentinel; forced `globalTimeout` with no progress → sentinel; pass-then-timeout → no sentinel (guard holds).