### PR TITLE
[ci] Speed up Go build and test workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -119,7 +119,10 @@ jobs:
         run: tools/test_example_configs.sh
 
       - name: Upload test and coverage reports
-        if: matrix.os == 'ubuntu-latest'
+        # Upload even when an earlier step failed, so that a failing run still
+        # gets analyzed. gotestsum and -coverprofile write these files whether
+        # or not the tests pass.
+        if: always() && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
           name: test-reports
@@ -130,7 +133,12 @@ jobs:
   sonarcloud:
     name: SonarCloud Scan
     needs: [build-and-test]
+    # As a step in build-and-test, this used to run whenever the ubuntu tests
+    # passed, regardless of the other legs. needs: can only wait on a whole
+    # job, so don't gate on its success -- gate on the reports being there
+    # instead, which is what the scan actually needs.
     if: |
+      !cancelled() &&
       github.repository == 'cloudprober/cloudprober' &&
       (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
@@ -144,11 +152,16 @@ jobs:
           fetch-depth: 0
 
       - name: Download test and coverage reports
+        id: reports
+        # If build-and-test died before producing them, there is nothing to
+        # scan; skip rather than fail and add a second red check.
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: test-reports
 
       - name: SonarCloud Scan
+        if: steps.reports.outcome == 'success'
         uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,6 +41,11 @@ jobs:
             race_flag: ""
           - os: macos-latest
             race_flag: "-race"
+            # The race detector sleeps 1s at exit by default (TSAN's
+            # atexit_sleep_ms), which adds up across the ~130 test binaries.
+            # Trying it on macos only for now; ubuntu still runs with the
+            # default.
+            gorace: "atexit_sleep_ms=0"
     steps:
       - name: Check out code into the Go module directory
         if: github.event_name != 'workflow_dispatch'
@@ -92,6 +97,8 @@ jobs:
 
       - name: Test on non-ubuntu
         if: matrix.os != 'ubuntu-latest'
+        env:
+          GORACE: ${{ matrix.gorace }}
         run: |
           go install gotest.tools/gotestsum@v1.13.0
           gotestsum --rerun-fails --packages=./... -- ${{ env.EXTRA_TEST_FLAGS }} ${{ matrix.race_flag }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -179,6 +179,13 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+          # This job builds through the Makefile (CGO_ENABLED=0 cross
+          # compiles), whose artifacts share nothing with a normal build. Keep
+          # it on its own cache key, so that it doesn't win the race to
+          # populate the key build-and-test needs.
+          cache-dependency-path: |
+            go.sum
+            Makefile
         id: go
 
       - run: make cloudprober-linux-{amd64,arm64,armv7}
@@ -224,6 +231,12 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+          # Same as build-binaries: this job's GOCACHE is built with
+          # GOEXPERIMENT=boringcrypto and shares nothing with a normal build,
+          # so keep it off the key build-and-test needs.
+          cache-dependency-path: |
+            go.sum
+            Makefile
         id: go
 
       - run: make cloudprober-fips && mv cloudprober-fips cloudprober-fips-${{ matrix.distname }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-and-test:
     name: Build and Test
@@ -29,6 +33,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          # Race detection is covered by the ubuntu and macos jobs; skipping it
+          # on windows, where it's the slowest, keeps the job off the critical
+          # path.
+          - os: windows-latest
+            race_flag: ""
+          - os: macos-latest
+            race_flag: "-race"
     steps:
       - name: Check out code into the Go module directory
         if: github.event_name != 'workflow_dispatch'
@@ -82,16 +94,7 @@ jobs:
         if: matrix.os != 'ubuntu-latest'
         run: |
           go install gotest.tools/gotestsum@v1.13.0
-          gotestsum --rerun-fails --packages=./... -- ${{ env.EXTRA_TEST_FLAGS }} -race -covermode=atomic
-
-      - name: SonarCloud Scan
-        if: |
-          matrix.os == 'ubuntu-latest' &&
-          github.repository == 'cloudprober/cloudprober' &&
-          (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
-        uses: SonarSource/sonarqube-scan-action@v6
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          gotestsum --rerun-fails --packages=./... -- ${{ env.EXTRA_TEST_FLAGS }} ${{ matrix.race_flag }}
 
       - name: Privileged ping tests.
         if: matrix.os != 'windows-latest'
@@ -111,6 +114,38 @@ jobs:
           path: |
             report.json
             cover.out
+
+  sonarcloud:
+    name: SonarCloud Scan
+    needs: [build-and-test]
+    if: |
+      github.repository == 'cloudprober/cloudprober' &&
+      (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code into the Go module directory
+        if: ${{ !contains(github.event_name, 'workflow_dispatch') }}
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Check out code into the Go module directory
+        if: ${{ contains(github.event_name, 'workflow_dispatch') }}
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.tag }}
+
+      - name: Download test and coverage reports
+        uses: actions/download-artifact@v4
+        with:
+          name: test-reports
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v6
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   build-binaries:
     name: Build binaries
@@ -194,6 +229,7 @@ jobs:
         
   build-dist:
     name: Build cloudprober release
+    if: github.event_name != 'pull_request'
     needs: [build-and-test, build-binaries]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,11 @@ on:
     types: [published]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Only pull requests are collapsed, so that a new push supersedes the run in
+  # flight. Everything else gets a group of its own: GitHub keeps just one
+  # pending run per group, so sharing one would let a burst of pushes to main
+  # cancel a queued workflow_dispatch or an intermediate release build.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -43,8 +47,9 @@ jobs:
             race_flag: "-race"
             # The race detector sleeps 1s at exit by default (TSAN's
             # atexit_sleep_ms), which adds up across the ~130 test binaries.
-            # Trying it on macos only for now; ubuntu still runs with the
-            # default.
+            # That sleep is what lets it catch races on the shutdown path, so
+            # macos is now weaker at those, not just faster. ubuntu keeps the
+            # default and stays the thorough one.
             gorace: "atexit_sleep_ms=0"
     steps:
       - name: Check out code into the Go module directory
@@ -131,18 +136,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # This job only runs for push and same-repo pull_request events, so it
+      # doesn't need the workflow_dispatch checkout the other jobs have.
       - name: Check out code into the Go module directory
-        if: ${{ !contains(github.event_name, 'workflow_dispatch') }}
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
-      - name: Check out code into the Go module directory
-        if: ${{ contains(github.event_name, 'workflow_dispatch') }}
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.inputs.tag }}
 
       - name: Download test and coverage reports
         uses: actions/download-artifact@v4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -230,13 +230,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          cache: true
-          # Same as build-binaries: this job's GOCACHE is built with
-          # GOEXPERIMENT=boringcrypto and shares nothing with a normal build,
-          # so keep it off the key build-and-test needs.
-          cache-dependency-path: |
-            go.sum
-            Makefile
+          # This job's GOCACHE is built with GOEXPERIMENT=boringcrypto and is
+          # useless to every other job, so it doesn't share a cache key with
+          # them. Caching it separately isn't worth it either: the module
+          # download is only a few seconds, and the boringcrypto build gets
+          # recompiled regardless.
+          cache: false
         id: go
 
       - run: make cloudprober-fips && mv cloudprober-fips cloudprober-fips-${{ matrix.distname }}

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -32,7 +32,9 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
-          cache: true
+          # Not worth caching for a docs build, and it would otherwise compete
+          # to populate the Go cache key that go.yml's build-and-test needs.
+          cache: false
         id: go
 
       - name: Setup public worktree

--- a/.github/workflows/latest_config_docs.yml
+++ b/.github/workflows/latest_config_docs.yml
@@ -30,7 +30,9 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: go.mod
-          cache: true
+          # Not worth caching for a docs build, and it would otherwise compete
+          # to populate the Go cache key that go.yml's build-and-test needs.
+          cache: false
         id: go
 
       - name: Setup public worktree

--- a/internal/surfacers/bigquery/bigquery_test.go
+++ b/internal/surfacers/bigquery/bigquery_test.go
@@ -519,11 +519,17 @@ func TestWriteToBQ(t *testing.T) {
 	colTypeMap := map[string]string{
 		"id": "string",
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*11)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 	defer cancel()
 
+	// Tick every second instead of the default 10s, so that writeToBQ gets to
+	// drain the write channel well within the context's deadline.
+	batchTimerSec := int64(1)
+	conf := newSurfacerConfig(colTypeMap)
+	conf.BatchTimerSec = &batchTimerSec
+
 	s := &Surfacer{
-		c:         newSurfacerConfig(colTypeMap),
+		c:         conf,
 		l:         &logger.Logger{},
 		writeChan: make(chan *metrics.EventMetrics, 4500),
 	}


### PR DESCRIPTION
## Summary

- Drop `-covermode=atomic` from the non-ubuntu test run (it implies `-cover`, so windows/macos were paying for coverage instrumentation and discarding it), and skip `-race` on windows, where it's slowest. ubuntu and macos still run with `-race`.
- Move the SonarCloud scan into its own job consuming the uploaded `report.json`/`cover.out`, instead of ~60s serialized inside the ubuntu test job. Also add a `concurrency` group so superseded PR runs get cancelled, and skip `build-dist` on PRs.
- `bigquery.TestWriteToBQ` waited out an 11s context for a single tick of the default 10s batch timer; use a 1s timer and 2s context. Package goes 18.3s -> 5.9s.

## Test plan

- `go test -count=5 -race -run TestWriteToBQ ./internal/surfacers/bigquery/` passes.
- Workflow changes verified by this PR's own run.