### PR TITLE
[probes.dns] Add recursion_desired option to DNS probe

### DIFF
--- a/probes/dns/dns.go
+++ b/probes/dns/dns.go
@@ -247,6 +247,7 @@ func (p *Probe) doDNSRequest(ctx context.Context, target string, result *probeRu
 	msg := new(dns.Msg)
 	msg.SetQuestion(p.fqdn, p.queryType)
 	msg.Question[0].Qclass = p.queryClass
+	msg.RecursionDesired = p.c.GetRecursionDesired()
 
 	resp, latency, err := p.client.ExchangeContext(ctx, msg, target)
 

--- a/probes/dns/dns_test.go
+++ b/probes/dns/dns_test.go
@@ -47,12 +47,15 @@ var (
 	globalLog = logger.Logger{}
 )
 
-type mockClient struct{}
+type mockClient struct {
+	lastMsg *dns.Msg
+}
 
 // Exchange implementation that returns an error status if the query is for
 // questionBad[Domain|Type]. This allows us to check if query parameters are
 // populated correctly.
-func (*mockClient) ExchangeContext(ctx context.Context, in *dns.Msg, fullTarget string) (*dns.Msg, time.Duration, error) {
+func (c *mockClient) ExchangeContext(ctx context.Context, in *dns.Msg, fullTarget string) (*dns.Msg, time.Duration, error) {
+	c.lastMsg = in
 	if fullTarget != "8.8.8.8:53" {
 		return nil, 0, fmt.Errorf("unexpected target: %v", fullTarget)
 	}
@@ -293,6 +296,43 @@ func TestAnswerCheck(t *testing.T) {
 	}
 	// expect failure because only one answer returned and two wanted.
 	runProbeAndVerify(t, "toofewanswers", p, 1, 0)
+}
+
+func TestRecursionDesired(t *testing.T) {
+	for _, test := range []struct {
+		description string
+		probeConf   *configpb.ProbeConf
+		want        bool
+	}{
+		{"default", &configpb.ProbeConf{}, true},
+		{"enabled", &configpb.ProbeConf{RecursionDesired: proto.Bool(true)}, true},
+		{"disabled", &configpb.ProbeConf{RecursionDesired: proto.Bool(false)}, false},
+	} {
+		t.Run(test.description, func(t *testing.T) {
+			p := &Probe{}
+			opts := &options.Options{
+				Targets:   targets.StaticTargets("8.8.8.8"),
+				Interval:  2 * time.Second,
+				Timeout:   time.Second,
+				ProbeConf: test.probeConf,
+			}
+			if err := p.Init("dns_recursion_desired_test", opts); err != nil {
+				t.Fatalf("Error creating probe: %v", err)
+			}
+
+			client := new(mockClient)
+			p.client = client
+			p.targets = p.opts.Targets.ListEndpoints()
+			p.runProbe(context.Background(), &sched.RunProbeForTargetRequest{Target: p.targets[0]})
+
+			if client.lastMsg == nil {
+				t.Fatal("no DNS query was sent")
+			}
+			if got := client.lastMsg.RecursionDesired; got != test.want {
+				t.Errorf("got recursion desired: %v, want: %v", got, test.want)
+			}
+		})
+	}
 }
 
 func TestValidator(t *testing.T) {

--- a/probes/dns/dns_test.go
+++ b/probes/dns/dns_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -48,14 +49,26 @@ var (
 )
 
 type mockClient struct {
+	// mu protects lastMsg, which is written by all the requests of a probe
+	// run, and those can run concurrently (requests_per_probe > 1).
+	mu      sync.Mutex
 	lastMsg *dns.Msg
+}
+
+func (c *mockClient) getLastMsg() *dns.Msg {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lastMsg
 }
 
 // Exchange implementation that returns an error status if the query is for
 // questionBad[Domain|Type]. This allows us to check if query parameters are
 // populated correctly.
 func (c *mockClient) ExchangeContext(ctx context.Context, in *dns.Msg, fullTarget string) (*dns.Msg, time.Duration, error) {
+	c.mu.Lock()
 	c.lastMsg = in
+	c.mu.Unlock()
+
 	if fullTarget != "8.8.8.8:53" {
 		return nil, 0, fmt.Errorf("unexpected target: %v", fullTarget)
 	}
@@ -325,10 +338,10 @@ func TestRecursionDesired(t *testing.T) {
 			p.targets = p.opts.Targets.ListEndpoints()
 			p.runProbe(context.Background(), &sched.RunProbeForTargetRequest{Target: p.targets[0]})
 
-			if client.lastMsg == nil {
+			if client.getLastMsg() == nil {
 				t.Fatal("no DNS query was sent")
 			}
-			if got := client.lastMsg.RecursionDesired; got != test.want {
+			if got := client.getLastMsg().RecursionDesired; got != test.want {
 				t.Errorf("got recursion desired: %v, want: %v", got, test.want)
 			}
 		})

--- a/probes/dns/proto/config.pb.go
+++ b/probes/dns/proto/config.pb.go
@@ -317,6 +317,9 @@ type ProbeConf struct {
 	// Minimum number of answers expected. Default behavior is to return success
 	// if DNS response status is NOERROR.
 	MinAnswers *uint32 `protobuf:"varint,4,opt,name=min_answers,json=minAnswers,def=0" json:"min_answers,omitempty"`
+	// Whether to set the RD (Recursion Desired) flag in the query. Set it to
+	// false to probe authoritative DNS servers.
+	RecursionDesired *bool `protobuf:"varint,6,opt,name=recursion_desired,json=recursionDesired,def=1" json:"recursion_desired,omitempty"`
 	// Whether to resolve the target (target is DNS server here) before making
 	// the request. If set to false, we hand over the target directly to the DNS
 	// client. Otherwise, we resolve the target first to an IP address.  By
@@ -350,6 +353,7 @@ const (
 	Default_ProbeConf_ResolvedDomain       = string("www.google.com.")
 	Default_ProbeConf_QueryType            = QueryType_MX
 	Default_ProbeConf_MinAnswers           = uint32(0)
+	Default_ProbeConf_RecursionDesired     = bool(true)
 	Default_ProbeConf_QueryClass           = QueryClass_IN
 	Default_ProbeConf_DnsProto             = DNSProto_UDP
 	Default_ProbeConf_RequestsPerProbe     = int32(1)
@@ -407,6 +411,13 @@ func (x *ProbeConf) GetMinAnswers() uint32 {
 	return Default_ProbeConf_MinAnswers
 }
 
+func (x *ProbeConf) GetRecursionDesired() bool {
+	if x != nil && x.RecursionDesired != nil {
+		return *x.RecursionDesired
+	}
+	return Default_ProbeConf_RecursionDesired
+}
+
 func (x *ProbeConf) GetResolveFirst() bool {
 	if x != nil && x.ResolveFirst != nil {
 		return *x.ResolveFirst
@@ -446,13 +457,14 @@ var File_github_com_cloudprober_cloudprober_probes_dns_proto_config_proto protor
 
 const file_github_com_cloudprober_cloudprober_probes_dns_proto_config_proto_rawDesc = "" +
 	"\n" +
-	"@github.com/cloudprober/cloudprober/probes/dns/proto/config.proto\x12\x16cloudprober.probes.dns\"\xcb\x03\n" +
+	"@github.com/cloudprober/cloudprober/probes/dns/proto/config.proto\x12\x16cloudprober.probes.dns\"\xfe\x03\n" +
 	"\tProbeConf\x128\n" +
 	"\x0fresolved_domain\x18\x01 \x01(\t:\x0fwww.google.com.R\x0eresolvedDomain\x12D\n" +
 	"\n" +
 	"query_type\x18\x03 \x01(\x0e2!.cloudprober.probes.dns.QueryType:\x02MXR\tqueryType\x12\"\n" +
 	"\vmin_answers\x18\x04 \x01(\r:\x010R\n" +
-	"minAnswers\x12#\n" +
+	"minAnswers\x121\n" +
+	"\x11recursion_desired\x18\x06 \x01(\b:\x04trueR\x10recursionDesired\x12#\n" +
 	"\rresolve_first\x18\x05 \x01(\bR\fresolveFirst\x12G\n" +
 	"\vquery_class\x18` \x01(\x0e2\".cloudprober.probes.dns.QueryClass:\x02INR\n" +
 	"queryClass\x12B\n" +

--- a/probes/dns/proto/config.proto
+++ b/probes/dns/proto/config.proto
@@ -71,6 +71,10 @@ message ProbeConf {
   // if DNS response status is NOERROR.
   optional uint32 min_answers = 4 [default = 0];
 
+  // Whether to set the RD (Recursion Desired) flag in the query. Set it to
+  // false to probe authoritative DNS servers.
+  optional bool recursion_desired = 6 [default = true];
+
   // Whether to resolve the target (target is DNS server here) before making
   // the request. If set to false, we hand over the target directly to the DNS
   // client. Otherwise, we resolve the target first to an IP address.  By


### PR DESCRIPTION
## Summary
- Add `recursion_desired` to the DNS probe config (default `true`, i.e. no change in existing behavior); set it to `false` to probe authoritative DNS servers without the RD flag.

Fixes #1193

## Test plan
- New `TestRecursionDesired` in `probes/dns/dns_test.go` verifies the RD bit on the outgoing query for default/enabled/disabled.
- `go test ./probes/dns/...`