### PR TITLE
[release] Publish tar.gz archives and SHA-256 checksums

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -294,7 +294,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: cloudprober-release-binaries
-          path: cloudprober-*.zip
+          path: |
+            cloudprober-*.zip
+            cloudprober-*.tar.gz
+            cloudprober-*-checksums.txt
 
   build_and_push_docker_multiarch:
     name: Build and push multiarch docker image
@@ -398,15 +401,17 @@ jobs:
         with:
           name: cloudprober-release-binaries
       - run: ls -R *
+      # Rename the versioned archives to "tip" ones, and regenerate checksums
+      # for the renamed files (the shipped checksums.txt refers to the
+      # versioned names).
       - run: |
-          mv cloudprober*-linux-arm64.zip cloudprober-tip-linux-arm64.zip
-          mv cloudprober*-linux-armv7.zip cloudprober-tip-linux-armv7.zip
-          mv cloudprober*-linux-x86_64.zip cloudprober-tip-linux-x86_64.zip
-          mv cloudprober*-macos-arm64.zip cloudprober-tip-macos-arm64.zip
-          mv cloudprober*-macos-x86_64.zip cloudprober-tip-macos-x86_64.zip
-          mv cloudprober*-windows-x86_64.zip cloudprober-tip-windows-x86_64.zip
+          rm -f cloudprober-*-checksums.txt
+          for f in cloudprober-*; do
+            mv "$f" "$(echo "$f" | sed -E 's/^cloudprober-.*-(linux|macos|windows)-/cloudprober-tip-\1-/')"
+          done
+          sha256sum cloudprober-tip-* > cloudprober-tip-checksums.txt
       - uses: pyTooling/Actions/releaser@r0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
-            cloudprober-*.zip
+            cloudprober-tip-*

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -407,9 +407,15 @@ jobs:
       - run: |
           rm -f cloudprober-*-checksums.txt
           for f in cloudprober-*; do
-            mv "$f" "$(echo "$f" | sed -E 's/^cloudprober-.*-(linux|macos|windows)-/cloudprober-tip-\1-/')"
+            tip=$(echo "$f" | sed -E 's/^cloudprober-.*-(linux|macos|windows)-/cloudprober-tip-\1-/')
+            if [[ "$tip" == "$f" ]]; then
+              echo "Unexpected release artifact, can't derive a tip name: $f" >&2
+              exit 1
+            fi
+            mv "$f" "$tip"
           done
-          sha256sum cloudprober-tip-* > cloudprober-tip-checksums.txt
+          sha256sum cloudprober-tip-*.zip cloudprober-tip-*.tar.gz \
+            > cloudprober-tip-checksums.txt
       - uses: pyTooling/Actions/releaser@r0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ SOURCES := $(shell find . -name '*.go')
 VAR_LD_FLAGS := -X main.version=$(VERSION) -X main.buildTimestamp=$(BUILD_DATE) -X main.dirty=$(DIRTY)
 LDFLAGS ?= "$(VAR_LD_FLAGS) -s -w -extldflags -static"
 BINARY_SOURCE ?= "./cmd/cloudprober/."
+# macOS ships shasum, not sha256sum.
+SHA256SUM := $(shell command -v sha256sum >/dev/null 2>&1 && echo sha256sum || echo "shasum -a 256")
 
 LINUX_PLATFORMS := linux-amd64 linux-arm64 linux-armv7
 BINARIES := $(addprefix cloudprober-, $(LINUX_PLATFORMS) macos-amd64 macos-arm64 windows-amd64)
@@ -78,7 +80,7 @@ dist: $(BINARIES)
 	  zip -r $${bindir}.zip $${bindir}/; rm -rf $${bindir}; \
 	done
 	rm -f cloudprober-$(VERSION)-checksums.txt
-	sha256sum cloudprober-$(VERSION)-*.zip cloudprober-$(VERSION)-*.tar.gz \
+	$(SHA256SUM) cloudprober-$(VERSION)-*.zip cloudprober-$(VERSION)-*.tar.gz \
 	  > cloudprober-$(VERSION)-checksums.txt
 
 PYVERSION := $(subst v,,$(VERSION))

--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,16 @@ dist: $(BINARIES)
 	  bindir=cloudprober-$(VERSION)-$${bindir/cloudprober-/}; \
 	  mkdir -p $${bindir}; cp $${bin} $${bindir}/cloudprober; \
 	  chmod a+rx $${bindir}/cloudprober; \
-	  [[ "$${bin}" == *"windows"* ]] && mv $${bindir}/cloudprober{,.exe}; \
+	  if [[ "$${bin}" == *"windows"* ]]; then \
+	    mv $${bindir}/cloudprober{,.exe}; \
+	  else \
+	    tar -czf $${bindir}.tar.gz $${bindir}/; \
+	  fi; \
 	  zip -r $${bindir}.zip $${bindir}/; rm -rf $${bindir}; \
 	done
+	rm -f cloudprober-$(VERSION)-checksums.txt
+	sha256sum cloudprober-$(VERSION)-*.zip cloudprober-$(VERSION)-*.tar.gz \
+	  > cloudprober-$(VERSION)-checksums.txt
 
 PYVERSION := $(subst v,,$(VERSION))
 PYVERSION := $(word 1,$(subst -, ,$(PYVERSION)))-$(word 2,$(subst -, ,$(PYVERSION)))


### PR DESCRIPTION
## Summary

- `make dist` now also builds `.tar.gz` archives for linux/macos (windows stays zip-only), so consumers don't need `unzip`.
- `make dist` emits `cloudprober-<version>-checksums.txt` with SHA-256 sums of every archive.
- The `tip` pre-release job renames all archives (not just zips) and regenerates checksums for the renamed files.

Groundwork for an `install.sh` (follow-up PR).

## Test plan

- Ran `make dist` locally: produced 6 zips + 5 tarballs + checksums; `sha256sum -c` passes; tarball contains `cloudprober-<version>-<platform>/cloudprober`.
- Simulated the `tip` rename + checksum regeneration on the real artifacts; `sha256sum -c` passes on the renamed set.

Note: for tagged releases, `cloudprober-<version>-checksums.txt` needs to be attached to the GitHub release along with the archives.