### PR TITLE
[docs] Add install.sh and make it the primary install method

### DIFF
--- a/docs/content/docs/overview/getting-started.md
+++ b/docs/content/docs/overview/getting-started.md
@@ -8,16 +8,25 @@ title: Getting Started
 
 ## Installation
 
-If you have Go installed, you can install cloudprober from source:
-
 ```bash
-go install github.com/cloudprober/cloudprober/cmd/cloudprober@latest
+curl -fsSL https://cloudprober.org/install.sh | sh
 ```
+
+This downloads the latest release for your platform, verifies its SHA-256
+checksum, and installs the binary into `/usr/local/bin` (or `~/.local/bin` if
+that isn't writable). Set `VERSION` or `INSTALL_DIR` to override either
+default. Linux and macOS only.
+
+If you'd rather not pipe a script into a shell -- and it's a good habit not to
+-- read it first at
+[cloudprober.org/install.sh](https://cloudprober.org/install.sh), or use one of
+the methods below.
 
 ##### Other Installation Methods:
 
 | Method             | Instructions                                                                                                                            | Platform              |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| Go                 | `go install github.com/cloudprober/cloudprober/cmd/cloudprober@latest`                                                                  | MacOS, Linux, Windows |
 | Brew               | `brew install cloudprober`                                                                                                              | MacOS, Linux          |
 | Docker Image       | `docker run ghcr.io/cloudprober/cloudprober` ([other docker versions](https://github.com/cloudprober/cloudprober/wiki/Docker-versions)) | Docker                |
 | Helm chart         | [See instructions](https://github.com/cloudprober/helm-charts)                                                                          | Kubernetes            |

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -110,8 +110,17 @@ curl -fsSL -o "${tmpdir}/${archive}" "${base_url}/${archive}" ||
 verify_checksum
 
 tar -xzf "${tmpdir}/${archive}" -C "$tmpdir"
-binary="${tmpdir}/cloudprober-${version}-${platform}/cloudprober"
-[ -f "$binary" ] || err "${archive} doesn't contain a cloudprober binary"
+# The archive holds a single directory, but its name tracks the build version
+# rather than $version ("tip" archives are renamed copies of versioned ones),
+# so find the binary instead of assuming the directory name.
+binary=""
+for f in "$tmpdir"/*/cloudprober; do
+  if [ -f "$f" ]; then
+    binary="$f"
+    break
+  fi
+done
+[ -n "$binary" ] || err "${archive} doesn't contain a cloudprober binary"
 
 pick_install_dir
 cp "$binary" "${install_dir}/cloudprober"

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -1,0 +1,120 @@
+#!/bin/sh
+# Install script for cloudprober (https://cloudprober.org).
+#
+# Usage:
+#   curl -fsSL https://cloudprober.org/install.sh | sh
+#
+# Environment variables:
+#   VERSION      Release to install, e.g. v0.14.5. Defaults to the latest
+#                release. Use "tip" for the build from the main branch.
+#   INSTALL_DIR  Where to put the binary. Defaults to /usr/local/bin, falling
+#                back to $HOME/.local/bin if that's not writable.
+
+set -eu
+
+REPO_URL="https://github.com/cloudprober/cloudprober"
+
+err() {
+  echo "install.sh: $*" >&2
+  exit 1
+}
+
+# Map uname output to the platform names used in release archives.
+detect_platform() {
+  os=$(uname -s)
+  case "$os" in
+    Linux) os="linux" ;;
+    Darwin) os="macos" ;;
+    *) err "unsupported OS '$os'; see ${REPO_URL}/releases for other options" ;;
+  esac
+
+  arch=$(uname -m)
+  case "$arch" in
+    x86_64 | amd64) arch="x86_64" ;;
+    aarch64 | arm64) arch="arm64" ;;
+    armv7l | armv7) arch="armv7" ;;
+    *) err "unsupported architecture '$arch'; see ${REPO_URL}/releases" ;;
+  esac
+
+  platform="${os}-${arch}"
+}
+
+# /releases/latest redirects to /releases/tag/<version>. Reading that redirect
+# avoids the GitHub API's unauthenticated rate limit.
+latest_version() {
+  url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "${REPO_URL}/releases/latest") ||
+    err "couldn't reach GitHub to find the latest version"
+  version="${url##*/}"
+  case "$version" in
+    v*) ;;
+    *) err "couldn't parse a version out of '$url'" ;;
+  esac
+}
+
+verify_checksum() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    got=$(sha256sum "${tmpdir}/${archive}" | cut -d' ' -f1)
+  elif command -v shasum >/dev/null 2>&1; then
+    got=$(shasum -a 256 "${tmpdir}/${archive}" | cut -d' ' -f1)
+  else
+    echo "Warning: no sha256sum or shasum; skipping checksum verification" >&2
+    return
+  fi
+
+  # No -S here: a 404 is an expected case that we report ourselves.
+  if ! curl -fsL -o "${tmpdir}/checksums.txt" "${base_url}/cloudprober-${version}-checksums.txt"; then
+    echo "Warning: ${version} has no published checksums; skipping verification" >&2
+    return
+  fi
+
+  want=$(grep " ${archive}$" "${tmpdir}/checksums.txt" | cut -d' ' -f1)
+  [ -n "$want" ] || err "${archive} is not listed in checksums.txt"
+  [ "$got" = "$want" ] || err "checksum mismatch for ${archive}: got ${got}, want ${want}"
+}
+
+pick_install_dir() {
+  install_dir="${INSTALL_DIR:-}"
+  if [ -z "$install_dir" ]; then
+    if [ -w /usr/local/bin ]; then
+      install_dir="/usr/local/bin"
+    else
+      install_dir="${HOME}/.local/bin"
+    fi
+  fi
+  mkdir -p "$install_dir" || err "couldn't create ${install_dir}"
+  [ -w "$install_dir" ] || err "${install_dir} is not writable; set INSTALL_DIR or re-run with sudo"
+}
+
+command -v curl >/dev/null 2>&1 || err "curl is required"
+
+detect_platform
+
+version="${VERSION:-}"
+[ -n "$version" ] || latest_version
+
+base_url="${REPO_URL}/releases/download/${version}"
+archive="cloudprober-${version}-${platform}.tar.gz"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+echo "Downloading cloudprober ${version} (${platform})..."
+curl -fsSL -o "${tmpdir}/${archive}" "${base_url}/${archive}" ||
+  err "couldn't download ${base_url}/${archive}"
+
+verify_checksum
+
+tar -xzf "${tmpdir}/${archive}" -C "$tmpdir"
+binary="${tmpdir}/cloudprober-${version}-${platform}/cloudprober"
+[ -f "$binary" ] || err "${archive} doesn't contain a cloudprober binary"
+
+pick_install_dir
+cp "$binary" "${install_dir}/cloudprober"
+chmod 755 "${install_dir}/cloudprober"
+
+echo "Installed cloudprober ${version} to ${install_dir}/cloudprober"
+case ":${PATH}:" in
+  *":${install_dir}:"*) ;;
+  *) echo "Note: ${install_dir} is not in your PATH." ;;
+esac
+echo "Run 'cloudprober' to start, or see https://cloudprober.org/docs/overview/getting-started/"

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -68,7 +68,9 @@ verify_checksum() {
   curl -fsSL -o "${tmpdir}/checksums.txt" "${base_url}/cloudprober-${version}-checksums.txt" ||
     err "couldn't download checksums for ${version}; refusing to install unverified"
 
-  want=$(grep " ${archive}$" "${tmpdir}/checksums.txt" | cut -d' ' -f1)
+  # Exact string compare on the filename field: $archive embeds $version, which
+  # comes from the environment, so a regex match could pick the wrong line.
+  want=$(awk -v a="$archive" '$2 == a { print $1; exit }' "${tmpdir}/checksums.txt")
   [ -n "$want" ] || err "${archive} is not listed in checksums.txt"
   [ "$got" = "$want" ] || err "checksum mismatch for ${archive}: got ${got}, want ${want}"
 }

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -87,6 +87,7 @@ pick_install_dir() {
 }
 
 command -v curl >/dev/null 2>&1 || err "curl is required"
+command -v tar >/dev/null 2>&1 || err "tar is required"
 
 detect_platform
 
@@ -97,7 +98,12 @@ base_url="${REPO_URL}/releases/download/${version}"
 archive="cloudprober-${version}-${platform}.tar.gz"
 
 tmpdir=$(mktemp -d)
-trap 'rm -rf "$tmpdir"' EXIT
+tmpbin=""
+cleanup() {
+  rm -rf "$tmpdir"
+  [ -z "$tmpbin" ] || rm -f "$tmpbin"
+}
+trap cleanup EXIT
 
 echo "Downloading cloudprober ${version} (${platform})..."
 curl -fsSL -o "${tmpdir}/${archive}" "${base_url}/${archive}" ||
@@ -119,8 +125,14 @@ done
 [ -n "$binary" ] || err "${archive} doesn't contain a cloudprober binary"
 
 pick_install_dir
-cp "$binary" "${install_dir}/cloudprober"
-chmod 755 "${install_dir}/cloudprober"
+# Install by rename: an interrupted copy can't leave a half-written binary in
+# place, and replacing a cloudprober that's currently running won't fail with
+# ETXTBSY.
+tmpbin="${install_dir}/.cloudprober.$$"
+cp "$binary" "$tmpbin"
+chmod 755 "$tmpbin"
+mv "$tmpbin" "${install_dir}/cloudprober"
+tmpbin=""
 
 echo "Installed cloudprober ${version} to ${install_dir}/cloudprober"
 case ":${PATH}:" in

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+#
+# Copyright 2026 The Cloudprober Authors.
+# Licensed under the Apache License, Version 2.0:
+# https://github.com/cloudprober/cloudprober/blob/main/LICENSE
+#
 # Install script for cloudprober (https://cloudprober.org).
 #
 # Usage:

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -62,15 +62,11 @@ verify_checksum() {
   elif command -v shasum >/dev/null 2>&1; then
     got=$(shasum -a 256 "${tmpdir}/${archive}" | cut -d' ' -f1)
   else
-    echo "Warning: no sha256sum or shasum; skipping checksum verification" >&2
-    return
+    err "need sha256sum or shasum to verify the download; install either one, or grab a release manually from ${REPO_URL}/releases"
   fi
 
-  # No -S here: a 404 is an expected case that we report ourselves.
-  if ! curl -fsL -o "${tmpdir}/checksums.txt" "${base_url}/cloudprober-${version}-checksums.txt"; then
-    echo "Warning: ${version} has no published checksums; skipping verification" >&2
-    return
-  fi
+  curl -fsSL -o "${tmpdir}/checksums.txt" "${base_url}/cloudprober-${version}-checksums.txt" ||
+    err "couldn't download checksums for ${version}; refusing to install unverified"
 
   want=$(grep " ${archive}$" "${tmpdir}/checksums.txt" | cut -d' ' -f1)
   [ -n "$want" ] || err "${archive} is not listed in checksums.txt"

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -57,13 +57,7 @@ latest_version() {
 }
 
 verify_checksum() {
-  if command -v sha256sum >/dev/null 2>&1; then
-    got=$(sha256sum "${tmpdir}/${archive}" | cut -d' ' -f1)
-  elif command -v shasum >/dev/null 2>&1; then
-    got=$(shasum -a 256 "${tmpdir}/${archive}" | cut -d' ' -f1)
-  else
-    err "need sha256sum or shasum to verify the download; install either one, or grab a release manually from ${REPO_URL}/releases"
-  fi
+  got=$($sha256_cmd "${tmpdir}/${archive}" | cut -d' ' -f1)
 
   curl -fsSL -o "${tmpdir}/checksums.txt" "${base_url}/cloudprober-${version}-checksums.txt" ||
     err "couldn't download checksums for ${version}; refusing to install unverified"
@@ -80,8 +74,10 @@ pick_install_dir() {
   if [ -z "$install_dir" ]; then
     if [ -w /usr/local/bin ]; then
       install_dir="/usr/local/bin"
-    else
+    elif [ -n "${HOME:-}" ]; then
       install_dir="${HOME}/.local/bin"
+    else
+      err "/usr/local/bin isn't writable and HOME isn't set; set INSTALL_DIR"
     fi
   fi
   mkdir -p "$install_dir" || err "couldn't create ${install_dir}"
@@ -90,6 +86,16 @@ pick_install_dir() {
 
 command -v curl >/dev/null 2>&1 || err "curl is required"
 command -v tar >/dev/null 2>&1 || err "tar is required"
+
+# Resolve the hashing tool up front rather than after the download: macOS ships
+# shasum, not sha256sum.
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256_cmd="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  sha256_cmd="shasum -a 256"
+else
+  err "need sha256sum or shasum to verify the download; install either one, or grab a release manually from ${REPO_URL}/releases"
+fi
 
 detect_platform
 
@@ -106,6 +112,10 @@ cleanup() {
   [ -z "$tmpbin" ] || rm -f "$tmpbin"
 }
 trap cleanup EXIT
+# dash doesn't run the EXIT trap when the shell is killed by a signal, so Ctrl-C
+# would otherwise leave the temp dir (and possibly a half-copied binary) behind.
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM HUP
 
 echo "Downloading cloudprober ${version} (${platform})..."
 curl -fsSL -o "${tmpdir}/${archive}" "${base_url}/${archive}" ||


### PR DESCRIPTION
Stacked on #1402.

## Summary

- Adds `docs/static/install.sh`, served at `https://cloudprober.org/install.sh`. Detects platform, resolves the latest version from the `/releases/latest` redirect (no GitHub API rate limit), downloads the tarball, verifies its SHA-256, installs to `/usr/local/bin` or `~/.local/bin`. `VERSION` and `INSTALL_DIR` override the defaults.
- Getting Started leads with the one-liner; `go install` moves into the other-methods table.

## Test plan

- Served a fake release layout over localhost and ran the script end to end: downloads, verifies checksum, installs, installed binary reports the right `--version`.
- Failure paths: missing checksum file or checksum mismatch aborts before installing; missing archive gives a clear error.
- Verified the `/releases/latest` redirect resolves to `v0.14.4`.
- `sh -n` clean; confirmed `docs/static` is mounted to the site root in `docs/config/_default/module.toml`.
