### PR TITLE
[validators] Reject unsupported validators

### DIFF
--- a/probes/options/options.go
+++ b/probes/options/options.go
@@ -90,6 +90,46 @@ var negativeTestSupported = map[configpb.ProbeDef_Type]bool{
 	configpb.ProbeDef_HTTP: true,
 }
 
+var validatorProbeTypes = map[string][]configpb.ProbeDef_Type{
+	"http_validator": {configpb.ProbeDef_HTTP},
+	"dns_validator":  {configpb.ProbeDef_DNS},
+}
+
+var validatorsUnsupported = map[configpb.ProbeDef_Type]bool{
+	configpb.ProbeDef_UDP:          true,
+	configpb.ProbeDef_UDP_LISTENER: true,
+}
+
+func validateValidatorProbeTypes(p *configpb.ProbeDef) error {
+	if len(p.GetValidator()) == 0 {
+		return nil
+	}
+
+	if validatorsUnsupported[p.GetType()] {
+		return fmt.Errorf("validators are not supported by %s probes", p.GetType().String())
+	}
+
+	for _, validator := range p.GetValidator() {
+		if validator == nil {
+			continue
+		}
+
+		message := validator.ProtoReflect()
+		field := message.WhichOneof(message.Descriptor().Oneofs().ByName("type"))
+		if field == nil {
+			continue
+		}
+
+		validatorType := string(field.Name())
+		probeTypes, ok := validatorProbeTypes[validatorType]
+		if ok && !slices.Contains(probeTypes, p.GetType()) {
+			return fmt.Errorf("%s is not supported by %s probes", validatorType, p.GetType().String())
+		}
+	}
+
+	return nil
+}
+
 func defaultStatsExportInterval(p *configpb.ProbeDef, opts *Options) time.Duration {
 	minIntv := opts.Interval
 	if opts.Timeout > opts.Interval {
@@ -198,6 +238,10 @@ func ValidateProbeConfig(p *configpb.ProbeDef) (*Options, error) {
 
 	if p.GetNegativeTest() && !negativeTestSupported[p.GetType()] {
 		return nil, fmt.Errorf("negative_test is not supported by %s probes", p.GetType().String())
+	}
+
+	if err := validateValidatorProbeTypes(p); err != nil {
+		return nil, err
 	}
 
 	opts := &Options{

--- a/probes/options/options.go
+++ b/probes/options/options.go
@@ -28,6 +28,7 @@ import (
 	proberconfigpb "github.com/cloudprober/cloudprober/config/proto"
 	"github.com/cloudprober/cloudprober/internal/alerting"
 	"github.com/cloudprober/cloudprober/internal/validators"
+	validatorpb "github.com/cloudprober/cloudprober/internal/validators/proto"
 	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/metrics"
 	configpb "github.com/cloudprober/cloudprober/probes/proto"
@@ -100,6 +101,16 @@ var validatorsUnsupported = map[configpb.ProbeDef_Type]bool{
 	configpb.ProbeDef_UDP_LISTENER: true,
 }
 
+func validatorTypeName(v *validatorpb.Validator) string {
+	switch v.GetType().(type) {
+	case *validatorpb.Validator_HttpValidator:
+		return "http_validator"
+	case *validatorpb.Validator_DnsValidator:
+		return "dns_validator"
+	}
+	return ""
+}
+
 func validateValidatorProbeTypes(p *configpb.ProbeDef) error {
 	if len(p.GetValidator()) == 0 {
 		return nil
@@ -110,20 +121,10 @@ func validateValidatorProbeTypes(p *configpb.ProbeDef) error {
 	}
 
 	for _, validator := range p.GetValidator() {
-		if validator == nil {
-			continue
-		}
-
-		message := validator.ProtoReflect()
-		field := message.WhichOneof(message.Descriptor().Oneofs().ByName("type"))
-		if field == nil {
-			continue
-		}
-
-		validatorType := string(field.Name())
+		validatorType := validatorTypeName(validator)
 		probeTypes, ok := validatorProbeTypes[validatorType]
 		if ok && !slices.Contains(probeTypes, p.GetType()) {
-			return fmt.Errorf("%s is not supported by %s probes", validatorType, p.GetType().String())
+			return fmt.Errorf("validator %q: %s is not supported by %s probes", validator.GetName(), validatorType, p.GetType().String())
 		}
 	}
 

--- a/probes/options/options.go
+++ b/probes/options/options.go
@@ -91,24 +91,21 @@ var negativeTestSupported = map[configpb.ProbeDef_Type]bool{
 	configpb.ProbeDef_HTTP: true,
 }
 
-var validatorProbeTypes = map[string][]configpb.ProbeDef_Type{
-	"http_validator": {configpb.ProbeDef_HTTP},
-	"dns_validator":  {configpb.ProbeDef_DNS},
-}
-
 var validatorsUnsupported = map[configpb.ProbeDef_Type]bool{
 	configpb.ProbeDef_UDP:          true,
 	configpb.ProbeDef_UDP_LISTENER: true,
 }
 
-func validatorTypeName(v *validatorpb.Validator) string {
+// validatorProbeTypes returns the name of a probe-type-specific validator and
+// the probe types it supports. It returns nil types for generic validators.
+func validatorProbeTypes(v *validatorpb.Validator) (name string, types []configpb.ProbeDef_Type) {
 	switch v.GetType().(type) {
 	case *validatorpb.Validator_HttpValidator:
-		return "http_validator"
+		return "http_validator", []configpb.ProbeDef_Type{configpb.ProbeDef_HTTP}
 	case *validatorpb.Validator_DnsValidator:
-		return "dns_validator"
+		return "dns_validator", []configpb.ProbeDef_Type{configpb.ProbeDef_DNS}
 	}
-	return ""
+	return "", nil
 }
 
 func validateValidatorProbeTypes(p *configpb.ProbeDef) error {
@@ -121,9 +118,8 @@ func validateValidatorProbeTypes(p *configpb.ProbeDef) error {
 	}
 
 	for _, validator := range p.GetValidator() {
-		validatorType := validatorTypeName(validator)
-		probeTypes, ok := validatorProbeTypes[validatorType]
-		if ok && !slices.Contains(probeTypes, p.GetType()) {
+		validatorType, probeTypes := validatorProbeTypes(validator)
+		if probeTypes != nil && !slices.Contains(probeTypes, p.GetType()) {
 			return fmt.Errorf("validator %q: %s is not supported by %s probes", validator.GetName(), validatorType, p.GetType().String())
 		}
 	}

--- a/probes/options/options_test.go
+++ b/probes/options/options_test.go
@@ -680,6 +680,7 @@ func TestValidateProbeConfig(t *testing.T) {
 			probe: &configpb.ProbeDef{
 				Type: configpb.ProbeDef_HTTP.Enum(),
 				Validator: []*validatorpb.Validator{{
+					Name: "http",
 					Type: &validatorpb.Validator_HttpValidator{},
 				}},
 			},
@@ -689,7 +690,28 @@ func TestValidateProbeConfig(t *testing.T) {
 			probe: &configpb.ProbeDef{
 				Type: configpb.ProbeDef_DNS.Enum(),
 				Validator: []*validatorpb.Validator{{
+					Name: "dns",
 					Type: &validatorpb.Validator_DnsValidator{},
+				}},
+			},
+		},
+		{
+			name: "http_generic_validator_supported",
+			probe: &configpb.ProbeDef{
+				Type: configpb.ProbeDef_HTTP.Enum(),
+				Validator: []*validatorpb.Validator{{
+					Name: "regex",
+					Type: &validatorpb.Validator_Regex{Regex: "ok"},
+				}},
+			},
+		},
+		{
+			name: "dns_generic_validator_supported",
+			probe: &configpb.ProbeDef{
+				Type: configpb.ProbeDef_DNS.Enum(),
+				Validator: []*validatorpb.Validator{{
+					Name: "regex",
+					Type: &validatorpb.Validator_Regex{Regex: "ok"},
 				}},
 			},
 		},
@@ -698,20 +720,45 @@ func TestValidateProbeConfig(t *testing.T) {
 			probe: &configpb.ProbeDef{
 				Type: configpb.ProbeDef_DNS.Enum(),
 				Validator: []*validatorpb.Validator{{
+					Name: "http",
 					Type: &validatorpb.Validator_HttpValidator{},
 				}},
 			},
-			wantErr: "http_validator is not supported by DNS probes",
+			wantErr: "validator \"http\": http_validator is not supported by DNS probes",
 		},
 		{
 			name: "dns_validator_unsupported",
 			probe: &configpb.ProbeDef{
 				Type: configpb.ProbeDef_HTTP.Enum(),
 				Validator: []*validatorpb.Validator{{
+					Name: "dns",
 					Type: &validatorpb.Validator_DnsValidator{},
 				}},
 			},
-			wantErr: "dns_validator is not supported by HTTP probes",
+			wantErr: "validator \"dns\": dns_validator is not supported by HTTP probes",
+		},
+		{
+			name: "second_validator_unsupported",
+			probe: &configpb.ProbeDef{
+				Type: configpb.ProbeDef_HTTP.Enum(),
+				Validator: []*validatorpb.Validator{
+					{
+						Name: "regex",
+						Type: &validatorpb.Validator_Regex{Regex: "ok"},
+					},
+					{
+						Name: "dns",
+						Type: &validatorpb.Validator_DnsValidator{},
+					},
+				},
+			},
+			wantErr: "validator \"dns\": dns_validator is not supported by HTTP probes",
+		},
+		{
+			name: "udp_without_validators_supported",
+			probe: &configpb.ProbeDef{
+				Type: configpb.ProbeDef_UDP.Enum(),
+			},
 		},
 		{
 			name: "validators_unsupported_udp",

--- a/probes/options/options_test.go
+++ b/probes/options/options_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cloudprober/cloudprober/common/iputils"
 	"github.com/cloudprober/cloudprober/internal/alerting"
 	alerting_configpb "github.com/cloudprober/cloudprober/internal/alerting/proto"
+	validatorpb "github.com/cloudprober/cloudprober/internal/validators/proto"
 	"github.com/cloudprober/cloudprober/logger"
 	"github.com/cloudprober/cloudprober/metrics"
 	configpb "github.com/cloudprober/cloudprober/probes/proto"
@@ -673,6 +674,64 @@ func TestValidateProbeConfig(t *testing.T) {
 				NegativeTest: proto.Bool(true),
 			},
 			wantErr: "negative_test is not supported",
+		},
+		{
+			name: "http_validator_supported",
+			probe: &configpb.ProbeDef{
+				Type: configpb.ProbeDef_HTTP.Enum(),
+				Validator: []*validatorpb.Validator{{
+					Type: &validatorpb.Validator_HttpValidator{},
+				}},
+			},
+		},
+		{
+			name: "dns_validator_supported",
+			probe: &configpb.ProbeDef{
+				Type: configpb.ProbeDef_DNS.Enum(),
+				Validator: []*validatorpb.Validator{{
+					Type: &validatorpb.Validator_DnsValidator{},
+				}},
+			},
+		},
+		{
+			name: "http_validator_unsupported",
+			probe: &configpb.ProbeDef{
+				Type: configpb.ProbeDef_DNS.Enum(),
+				Validator: []*validatorpb.Validator{{
+					Type: &validatorpb.Validator_HttpValidator{},
+				}},
+			},
+			wantErr: "http_validator is not supported by DNS probes",
+		},
+		{
+			name: "dns_validator_unsupported",
+			probe: &configpb.ProbeDef{
+				Type: configpb.ProbeDef_HTTP.Enum(),
+				Validator: []*validatorpb.Validator{{
+					Type: &validatorpb.Validator_DnsValidator{},
+				}},
+			},
+			wantErr: "dns_validator is not supported by HTTP probes",
+		},
+		{
+			name: "validators_unsupported_udp",
+			probe: &configpb.ProbeDef{
+				Type: configpb.ProbeDef_UDP.Enum(),
+				Validator: []*validatorpb.Validator{{
+					Type: &validatorpb.Validator_Regex{Regex: "ok"},
+				}},
+			},
+			wantErr: "validators are not supported by UDP probes",
+		},
+		{
+			name: "validators_unsupported_udp_listener",
+			probe: &configpb.ProbeDef{
+				Type: configpb.ProbeDef_UDP_LISTENER.Enum(),
+				Validator: []*validatorpb.Validator{{
+					Type: &validatorpb.Validator_Regex{Regex: "ok"},
+				}},
+			},
+			wantErr: "validators are not supported by UDP_LISTENER probes",
 		},
 	}
 


### PR DESCRIPTION
Rejects probe-specific validators when they are configured for incompatible probe types, instead of letting them fail silently at runtime.

The validation runs in `BuildProbeOptions` and covers HTTP, DNS, UDP, and UDP listener combinations.

Tests:
- `go test ./probes/options`
- `go vet ./probes/options`
- `go build ./probes/options`

Fixes #1397