### PR TITLE
Added an option to opt out of logging query parameters

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -63,9 +63,10 @@ type Probe struct {
 	redirectFunc  func(req *http.Request, via []*http.Request) error
 
 	// book-keeping params
-	targets []endpoint.Endpoint
-	method  string
-	url     string
+	targets              []endpoint.Endpoint
+	method               string
+	url                  string
+	redactURLQueryInLogs bool
 	// Canonical names of headers whose values change under substitution
 	// (e.g. @uuid@). Empty when no header is dynamic; len() also gates the
 	// per-send clone in prepareRequest.
@@ -199,6 +200,7 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 	if len(p.url) > 0 && p.url[0] != '/' {
 		return fmt.Errorf("invalid relative URL: %s, must begin with '/'", p.url)
 	}
+	p.redactURLQueryInLogs = p.c.GetRedactUrlQueryInLogs()
 
 	body := p.c.GetBody()
 	if len(body) == 0 && p.c.GetBodyFile() != "" {
@@ -309,7 +311,7 @@ func (p *Probe) requestTrace(result *probeResult) *httptrace.ClientTrace {
 
 // doHTTPRequest executes an HTTP request and updates the provided result struct.
 func (p *Probe) doHTTPRequest(req *http.Request, client *http.Client, target endpoint.Endpoint, result *probeResult, resultMu *sync.Mutex) error {
-	l := p.l.WithAttributes(slog.String("target", target.Name), slog.String("url", req.URL.String()))
+	l := p.l.WithAttributes(slog.String("target", target.Name), slog.String("url", p.redactedURL(req.URL)))
 
 	start := time.Now()
 
@@ -336,19 +338,19 @@ func (p *Probe) doHTTPRequest(req *http.Request, client *http.Client, target end
 			result.success++
 			return nil
 		}
-		l.WithAttributes(p.dynamicHeaderAttrs(req)...).Warning(err.Error())
+		l.WithAttributes(p.dynamicHeaderAttrs(req)...).Warning(p.redactedErr(req.URL, err))
 		return err
 	}
 
 	if p.opts.NegativeTest {
 		resp.Body.Close()
-		l.Error("Negative test, but HTTP request succeeded for: ", req.URL.String())
+		l.Error("Negative test, but HTTP request succeeded for: ", p.redactedURL(req.URL))
 		return errors.New("negative test: request succeeded unexpectedly")
 	}
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		l.WithAttributes(p.dynamicHeaderAttrs(req)...).Warning(err.Error())
+		l.WithAttributes(p.dynamicHeaderAttrs(req)...).Warning(p.redactedErr(req.URL, err))
 		return err
 	}
 

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -197,10 +197,10 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 	p.method = p.c.GetMethod().String()
 
 	p.url = p.c.GetRelativeUrl()
-	if len(p.url) > 0 && p.url[0] != '/' {
-		return fmt.Errorf("invalid relative URL: %s, must begin with '/'", p.url)
-	}
 	p.redactURLQueryInLogs = p.c.GetRedactUrlQueryInLogs()
+	if len(p.url) > 0 && p.url[0] != '/' {
+		return fmt.Errorf("invalid relative URL: %s, must begin with '/'", p.redactQuery(rawQuery(p.url), p.url))
+	}
 
 	body := p.c.GetBody()
 	if len(body) == 0 && p.c.GetBodyFile() != "" {
@@ -338,8 +338,8 @@ func (p *Probe) doHTTPRequest(req *http.Request, client *http.Client, target end
 			result.success++
 			return nil
 		}
-		l.WithAttributes(p.dynamicHeaderAttrs(req)...).Warning(p.redactedErr(req.URL, err))
-		return err
+		l.WithAttributes(p.dynamicHeaderAttrs(req)...).Warning(p.redactedErr(req.URL.RawQuery, err))
+		return p.redactErr(req.URL.RawQuery, err)
 	}
 
 	if p.opts.NegativeTest {
@@ -350,8 +350,8 @@ func (p *Probe) doHTTPRequest(req *http.Request, client *http.Client, target end
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		l.WithAttributes(p.dynamicHeaderAttrs(req)...).Warning(p.redactedErr(req.URL, err))
-		return err
+		l.WithAttributes(p.dynamicHeaderAttrs(req)...).Warning(p.redactedErr(req.URL.RawQuery, err))
+		return p.redactErr(req.URL.RawQuery, err)
 	}
 
 	l.Debug("Response: \n" + string(respBody))
@@ -599,9 +599,10 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 	if tgtState.req == nil || (p.c.GetResolveFirst() && tgtState.runCnt%p.opts.StatsExportFrequency() == 0) {
 		req, err := p.httpRequestForTarget(runReq.Target)
 		if err != nil {
-			p.l.Error("Error creating HTTP request for target: ", target.Name, ", err: ", err.Error())
+			q := rawQuery(pathForTarget(runReq.Target, p.url))
+			p.l.Error("Error creating HTTP request for target: ", target.Name, ", err: ", p.redactedErr(q, err))
 			result.total += int64(p.c.GetRequestsPerProbe())
-			runReq.LastRun.Set(false, 0, err)
+			runReq.LastRun.Set(false, 0, p.redactErr(q, err))
 			return
 		}
 		tgtState.req = req

--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -199,7 +199,7 @@ func (p *Probe) Init(name string, opts *options.Options) error {
 	p.url = p.c.GetRelativeUrl()
 	p.redactURLQueryInLogs = p.c.GetRedactUrlQueryInLogs()
 	if len(p.url) > 0 && p.url[0] != '/' {
-		return fmt.Errorf("invalid relative URL: %s, must begin with '/'", p.redactQuery(rawQuery(p.url), p.url))
+		return fmt.Errorf("invalid relative URL: %s, must begin with '/'", p.redactURL(p.url))
 	}
 
 	body := p.c.GetBody()
@@ -338,8 +338,9 @@ func (p *Probe) doHTTPRequest(req *http.Request, client *http.Client, target end
 			result.success++
 			return nil
 		}
-		l.WithAttributes(p.dynamicHeaderAttrs(req)...).Warning(p.redactedErr(req.URL.RawQuery, err))
-		return p.redactErr(req.URL.RawQuery, err)
+		err = p.redactedErr(err)
+		l.WithAttributes(p.dynamicHeaderAttrs(req)...).Warning(err.Error())
+		return err
 	}
 
 	if p.opts.NegativeTest {
@@ -350,8 +351,9 @@ func (p *Probe) doHTTPRequest(req *http.Request, client *http.Client, target end
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		l.WithAttributes(p.dynamicHeaderAttrs(req)...).Warning(p.redactedErr(req.URL.RawQuery, err))
-		return p.redactErr(req.URL.RawQuery, err)
+		err = p.redactedErr(err)
+		l.WithAttributes(p.dynamicHeaderAttrs(req)...).Warning(err.Error())
+		return err
 	}
 
 	l.Debug("Response: \n" + string(respBody))
@@ -599,10 +601,10 @@ func (p *Probe) runProbe(ctx context.Context, runReq *sched.RunProbeForTargetReq
 	if tgtState.req == nil || (p.c.GetResolveFirst() && tgtState.runCnt%p.opts.StatsExportFrequency() == 0) {
 		req, err := p.httpRequestForTarget(runReq.Target)
 		if err != nil {
-			q := rawQuery(pathForTarget(runReq.Target, p.url))
-			p.l.Error("Error creating HTTP request for target: ", target.Name, ", err: ", p.redactedErr(q, err))
+			err = p.redactedErr(err)
+			p.l.Error("Error creating HTTP request for target: ", target.Name, ", err: ", err.Error())
 			result.total += int64(p.c.GetRequestsPerProbe())
-			runReq.LastRun.Set(false, 0, p.redactErr(q, err))
+			runReq.LastRun.Set(false, 0, err)
 			return
 		}
 		tgtState.req = req

--- a/probes/http/proto/config.pb.go
+++ b/probes/http/proto/config.pb.go
@@ -240,6 +240,11 @@ type ProbeConf struct {
 	//
 	// Note that the relative_url should start with a '/'.
 	RelativeUrl *string `protobuf:"bytes,2,opt,name=relative_url,json=relativeUrl" json:"relative_url,omitempty"`
+	// If set, redact the URL query string (everything after '?') in log
+	// messages, replacing it with "?<redacted>". Use this when the relative_url
+	// carries secrets (e.g. passwords) in query parameters. Default is false,
+	// i.e. the full URL is logged.
+	RedactUrlQueryInLogs *bool `protobuf:"varint,25,opt,name=redact_url_query_in_logs,json=redactUrlQueryInLogs" json:"redact_url_query_in_logs,omitempty"`
 	// Port for HTTP requests (Corresponding target field: port)
 	// Default is to use the scheme specific port, but if this field is not
 	// set and discovered target has a port (e.g., k8s services, ingresses),
@@ -433,6 +438,13 @@ func (x *ProbeConf) GetRelativeUrl() string {
 		return *x.RelativeUrl
 	}
 	return ""
+}
+
+func (x *ProbeConf) GetRedactUrlQueryInLogs() bool {
+	if x != nil && x.RedactUrlQueryInLogs != nil {
+		return *x.RedactUrlQueryInLogs
+	}
+	return false
 }
 
 func (x *ProbeConf) GetPort() int32 {
@@ -668,11 +680,12 @@ var File_github_com_cloudprober_cloudprober_probes_http_proto_config_proto proto
 
 const file_github_com_cloudprober_cloudprober_probes_http_proto_config_proto_rawDesc = "" +
 	"\n" +
-	"Agithub.com/cloudprober/cloudprober/probes/http/proto/config.proto\x12\x17cloudprober.probes.http\x1aBgithub.com/cloudprober/cloudprober/common/oauth/proto/config.proto\x1aFgithub.com/cloudprober/cloudprober/common/tlsconfig/proto/config.proto\x1aEgithub.com/cloudprober/cloudprober/metrics/payload/proto/config.proto\"\x9f\x0f\n" +
+	"Agithub.com/cloudprober/cloudprober/probes/http/proto/config.proto\x12\x17cloudprober.probes.http\x1aBgithub.com/cloudprober/cloudprober/common/oauth/proto/config.proto\x1aFgithub.com/cloudprober/cloudprober/common/tlsconfig/proto/config.proto\x1aEgithub.com/cloudprober/cloudprober/metrics/payload/proto/config.proto\"\xd7\x0f\n" +
 	"\tProbeConf\x12M\n" +
 	"\bprotocol\x18\x01 \x01(\x0e2).cloudprober.probes.http.ProbeConf.Scheme:\x04HTTPH\x00R\bprotocol\x12I\n" +
 	"\x06scheme\x18\x15 \x01(\x0e2).cloudprober.probes.http.ProbeConf.Scheme:\x04HTTPH\x00R\x06scheme\x12!\n" +
-	"\frelative_url\x18\x02 \x01(\tR\vrelativeUrl\x12\x12\n" +
+	"\frelative_url\x18\x02 \x01(\tR\vrelativeUrl\x126\n" +
+	"\x18redact_url_query_in_logs\x18\x19 \x01(\bR\x14redactUrlQueryInLogs\x12\x12\n" +
 	"\x04port\x18\x03 \x01(\x05R\x04port\x12#\n" +
 	"\rresolve_first\x18\x04 \x01(\bR\fresolveFirst\x12B\n" +
 	"\x1aexport_response_as_metrics\x18\x05 \x01(\b:\x05falseR\x17exportResponseAsMetrics\x12F\n" +

--- a/probes/http/proto/config.proto
+++ b/probes/http/proto/config.proto
@@ -45,6 +45,12 @@ message ProbeConf {
   // Note that the relative_url should start with a '/'.
   optional string relative_url = 2;
 
+  // If set, redact the URL query string (everything after '?') in log
+  // messages, replacing it with "?<redacted>". Use this when the relative_url
+  // carries secrets (e.g. passwords) in query parameters. Default is false,
+  // i.e. the full URL is logged.
+  optional bool redact_url_query_in_logs = 25;
+
   // Port for HTTP requests (Corresponding target field: port)
   // Default is to use the scheme specific port, but if this field is not
   // set and discovered target has a port (e.g., k8s services, ingresses),

--- a/probes/http/redact_test.go
+++ b/probes/http/redact_test.go
@@ -1,0 +1,115 @@
+// Copyright 2017-2025 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"fmt"
+	neturl "net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func mustParseURL(t *testing.T, s string) *neturl.URL {
+	t.Helper()
+	u, err := neturl.Parse(s)
+	if err != nil {
+		t.Fatalf("error parsing URL %q: %v", s, err)
+	}
+	return u
+}
+
+func TestRedactedURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		redact bool
+		url    string
+		want   string
+	}{
+		{
+			name:   "redaction off, no query",
+			redact: false,
+			url:    "http://example.com/path",
+			want:   "http://example.com/path",
+		},
+		{
+			name:   "redaction off, with query -- query kept",
+			redact: false,
+			url:    "http://example.com/login?password=secret",
+			want:   "http://example.com/login?password=secret",
+		},
+		{
+			name:   "redaction on, no query -- unchanged",
+			redact: true,
+			url:    "http://example.com/path",
+			want:   "http://example.com/path",
+		},
+		{
+			name:   "redaction on, with query -- query hidden",
+			redact: true,
+			url:    "http://example.com/login?password=secret",
+			want:   "http://example.com/login?<redacted>",
+		},
+		{
+			name:   "redaction on, multiple params -- all hidden",
+			redact: true,
+			url:    "https://example.com/a?user=admin&password=secret&x=1",
+			want:   "https://example.com/a?<redacted>",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := &Probe{redactURLQueryInLogs: test.redact}
+			got := p.redactedURL(mustParseURL(t, test.url))
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestRedactedErr(t *testing.T) {
+	rawURL := "http://example.com/login?password=secret"
+	u := mustParseURL(t, rawURL)
+
+	t.Run("nil error", func(t *testing.T) {
+		p := &Probe{redactURLQueryInLogs: true}
+		assert.Equal(t, "", p.redactedErr(u, nil))
+	})
+
+	t.Run("redaction off keeps secret", func(t *testing.T) {
+		p := &Probe{redactURLQueryInLogs: false}
+		// net/url.Error embeds the full URL in its message.
+		err := &neturl.Error{Op: "Get", URL: rawURL, Err: fmt.Errorf("dial tcp: connection refused")}
+		got := p.redactedErr(u, err)
+		assert.Contains(t, got, "password=secret")
+	})
+
+	t.Run("redaction on hides secret in error text", func(t *testing.T) {
+		p := &Probe{redactURLQueryInLogs: true}
+		err := &neturl.Error{Op: "Get", URL: rawURL, Err: fmt.Errorf("dial tcp: connection refused")}
+		got := p.redactedErr(u, err)
+		assert.NotContains(t, got, "password=secret")
+		assert.Contains(t, got, "<redacted>")
+		// The rest of the error text is preserved.
+		assert.Contains(t, got, "connection refused")
+	})
+
+	t.Run("redaction on, no query in URL is no-op", func(t *testing.T) {
+		p := &Probe{redactURLQueryInLogs: true}
+		noQueryURL := mustParseURL(t, "http://example.com/path")
+		err := fmt.Errorf("some error")
+		assert.Equal(t, "some error", p.redactedErr(noQueryURL, err))
+	})
+}

--- a/probes/http/redact_test.go
+++ b/probes/http/redact_test.go
@@ -15,6 +15,8 @@
 package http
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	neturl "net/url"
 	"testing"
@@ -34,15 +36,62 @@ func mustParseURL(t *testing.T, s string) *neturl.URL {
 	return u
 }
 
-func TestRawQuery(t *testing.T) {
-	for _, test := range []struct{ in, want string }{
-		{"", ""},
-		{"/path", ""},
-		{"/login?password=secret", "password=secret"},
-		{"/a?user=admin&password=secret", "user=admin&password=secret"},
-		{"/a?x=1?y=2", "x=1?y=2"},
-	} {
-		assert.Equal(t, test.want, rawQuery(test.in), "rawQuery(%q)", test.in)
+func TestRedactURL(t *testing.T) {
+	tests := []struct{ name, in, want string }{
+		{"no query", "/path", "/path"},
+		{"relative URL", "/login?password=secret", "/login?<redacted>"},
+		{"multiple params", "/a?user=admin&password=secret", "/a?<redacted>"},
+		{"bare trailing ?", "/a?", "/a?"},
+		// A space is legal in a query and survives url.URL.String() verbatim,
+		// so anything that stops at whitespace leaks the rest of the query.
+		{"space inside the query", "/a?msg=hello world&tok=secret", "/a?<redacted>"},
+		{"absolute URL", "http://h/a?tok=secret", "http://h/a?<redacted>"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := &Probe{redactURLQueryInLogs: true}
+			assert.Equal(t, test.want, p.redactURL(test.in))
+		})
+	}
+
+	t.Run("redaction off is a no-op", func(t *testing.T) {
+		p := &Probe{redactURLQueryInLogs: false}
+		assert.Equal(t, "/login?password=secret", p.redactURL("/login?password=secret"))
+	})
+}
+
+func TestRedactErrMsg(t *testing.T) {
+	p := &Probe{redactURLQueryInLogs: true}
+	tests := []struct{ name, in, want string }{
+		{
+			name: "quoted URL",
+			in:   `Get "http://h/a?tok=s": refused`,
+			want: `Get "http://h/a?<redacted>": refused`,
+		},
+		{
+			name: "query containing a space",
+			in:   `Get "http://h/a?msg=hello world&tok=secret": refused`,
+			want: `Get "http://h/a?<redacted>": refused`,
+		},
+		{
+			name: "two quoted URLs",
+			in:   `"http://a/x?s=1" and "http://b/y?s=2"`,
+			want: `"http://a/x?<redacted>" and "http://b/y?<redacted>"`,
+		},
+		// A '?' outside a quoted token is prose, not a query. Rewriting it
+		// would mangle the message for no security benefit.
+		{
+			name: "unquoted '?' is left alone",
+			in:   "error resolving target: foo?bar, no such host",
+			want: "error resolving target: foo?bar, no such host",
+		},
+		{"no query", `Get "http://h/a": refused`, `Get "http://h/a": refused`},
+		{"bare trailing ?", `Get "http://h/a?": refused`, `Get "http://h/a?": refused`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, p.redactErrMsg(test.in))
+		})
 	}
 }
 
@@ -102,86 +151,115 @@ func TestRedactedURL(t *testing.T) {
 
 func TestRedactedErr(t *testing.T) {
 	rawURL := "http://example.com/login?password=secret"
-	u := mustParseURL(t, rawURL)
+	// net/url.Error embeds the full URL, query included, in its message.
+	urlErr := &neturl.Error{Op: "Get", URL: rawURL, Err: fmt.Errorf("dial tcp: connection refused")}
 
-	t.Run("nil error", func(t *testing.T) {
+	t.Run("nil error stays nil", func(t *testing.T) {
 		p := &Probe{redactURLQueryInLogs: true}
-		assert.Equal(t, "", p.redactedErr(u.RawQuery, nil))
+		assert.NoError(t, p.redactedErr(nil))
 	})
 
-	t.Run("redaction off keeps secret", func(t *testing.T) {
+	// With redaction off we hand back the original error untouched, so that
+	// the default configuration keeps propagating the typed error.
+	t.Run("redaction off returns the original error", func(t *testing.T) {
 		p := &Probe{redactURLQueryInLogs: false}
-		// net/url.Error embeds the full URL in its message.
-		err := &neturl.Error{Op: "Get", URL: rawURL, Err: fmt.Errorf("dial tcp: connection refused")}
-		got := p.redactedErr(u.RawQuery, err)
-		assert.Contains(t, got, "password=secret")
+		got := p.redactedErr(urlErr)
+		assert.Same(t, urlErr, got)
+		assert.Contains(t, got.Error(), "password=secret")
 	})
 
 	t.Run("redaction on hides secret in error text", func(t *testing.T) {
 		p := &Probe{redactURLQueryInLogs: true}
-		err := &neturl.Error{Op: "Get", URL: rawURL, Err: fmt.Errorf("dial tcp: connection refused")}
-		got := p.redactedErr(u.RawQuery, err)
-		assert.NotContains(t, got, "password=secret")
-		assert.Contains(t, got, "<redacted>")
+		got := p.redactedErr(urlErr)
+		assert.NotContains(t, got.Error(), "password=secret")
+		assert.Contains(t, got.Error(), "<redacted>")
 		// The rest of the error text is preserved.
-		assert.Contains(t, got, "connection refused")
-	})
-
-	t.Run("redaction on, no query in URL is no-op", func(t *testing.T) {
-		p := &Probe{redactURLQueryInLogs: true}
-		noQueryURL := mustParseURL(t, "http://example.com/path")
-		err := fmt.Errorf("some error")
-		assert.Equal(t, "some error", p.redactedErr(noQueryURL.RawQuery, err))
+		assert.Contains(t, got.Error(), "connection refused")
+		assert.Contains(t, got.Error(), "http://example.com/login")
 	})
 
 	// net/http builds its error from the request it last made, so after a
-	// redirect the scheme, host and path are the redirect target's, while the
-	// query is carried over. Matching on the query alone still redacts it.
-	t.Run("redirected URL is still redacted", func(t *testing.T) {
+	// redirect the URL in the error is the redirect target's -- a different
+	// host, path and, crucially, a different query than the one we sent.
+	t.Run("redirect to a different query is redacted", func(t *testing.T) {
 		p := &Probe{redactURLQueryInLogs: true}
 		err := &neturl.Error{
 			Op:  "Get",
-			URL: "https://other.example.com/login?password=secret",
+			URL: "https://other.example.com/cb?code=supersecret",
 			Err: fmt.Errorf("dial tcp: connection refused"),
 		}
-		got := p.redactedErr(u.RawQuery, err)
-		assert.NotContains(t, got, "password=secret")
-		assert.Contains(t, got, "<redacted>")
+		got := p.redactedErr(err)
+		assert.NotContains(t, got.Error(), "code=supersecret")
+		assert.Contains(t, got.Error(), "<redacted>")
+	})
+
+	// The probe's own URL has no query at all, so there is nothing to match
+	// on; the redirect target's query must still be redacted.
+	t.Run("redirect adds a query where we had none", func(t *testing.T) {
+		p := &Probe{redactURLQueryInLogs: true}
+		err := &neturl.Error{
+			Op:  "Get",
+			URL: "https://other.example.com/cb?code=supersecret",
+			Err: fmt.Errorf("connection refused"),
+		}
+		got := p.redactedErr(err)
+		assert.NotContains(t, got.Error(), "supersecret")
+	})
+
+	// A redirect that carries our query over and appends to it must not leak
+	// the appended part.
+	t.Run("redirect extends our query", func(t *testing.T) {
+		p := &Probe{redactURLQueryInLogs: true}
+		err := &neturl.Error{
+			Op:  "Get",
+			URL: "https://other.example.com/cb?user=admin&token=secret",
+			Err: fmt.Errorf("connection refused"),
+		}
+		got := p.redactedErr(err)
+		assert.NotContains(t, got.Error(), "token=secret")
+		assert.NotContains(t, got.Error(), "user=admin")
+	})
+
+	// A space is legal in a query and survives url.URL.String() verbatim.
+	// Redacting the URL field rather than scanning the message means the
+	// whole query goes, not just the part before the space.
+	t.Run("query containing a space is fully redacted", func(t *testing.T) {
+		p := &Probe{redactURLQueryInLogs: true}
+		err := &neturl.Error{
+			Op:  "Get",
+			URL: "http://h/a?msg=hello world&tok=secret",
+			Err: fmt.Errorf("connection refused"),
+		}
+		got := p.redactedErr(err)
+		assert.NotContains(t, got.Error(), "tok=secret")
+		assert.NotContains(t, got.Error(), "hello world")
+		assert.Contains(t, got.Error(), "<redacted>")
+	})
+
+	// errors.Is/As must not depend on whether redaction is enabled, so the
+	// *url.Error is rebuilt rather than flattened into a bare error.
+	t.Run("error type and unwrap chain are preserved", func(t *testing.T) {
+		p := &Probe{redactURLQueryInLogs: true}
+		inner := context.DeadlineExceeded
+		err := &neturl.Error{Op: "Get", URL: "http://h/a?tok=secret", Err: inner}
+		got := p.redactedErr(err)
+
+		var ue *neturl.Error
+		assert.True(t, errors.As(got, &ue), "redacted error should still be a *url.Error")
+		assert.True(t, errors.Is(got, context.DeadlineExceeded), "unwrap chain should survive")
+		assert.Equal(t, "http://h/a?<redacted>", ue.URL)
+		assert.True(t, ue.Timeout(), "Timeout() should still report true")
 	})
 
 	// url.Error renders the URL with %q, so a quote in the query arrives
-	// escaped and doesn't match the query's plain form.
-	t.Run("quote in query is still redacted", func(t *testing.T) {
+	// escaped; the match must not stop at it and leave the tail exposed.
+	t.Run("quote in query is fully redacted", func(t *testing.T) {
 		p := &Probe{redactURLQueryInLogs: true}
 		qu := mustParseURL(t, `http://example.com/a?sig=x"y`)
 		err := &neturl.Error{Op: "Get", URL: qu.String(), Err: fmt.Errorf("connection refused")}
-		got := p.redactedErr(qu.RawQuery, err)
-		assert.NotContains(t, got, "sig=x")
-		assert.Contains(t, got, "<redacted>")
-	})
-}
-
-func TestRedactErr(t *testing.T) {
-	rawURL := "http://example.com/login?password=secret"
-	u := mustParseURL(t, rawURL)
-	urlErr := &neturl.Error{Op: "Get", URL: rawURL, Err: fmt.Errorf("connection refused")}
-
-	t.Run("nil error stays nil", func(t *testing.T) {
-		p := &Probe{redactURLQueryInLogs: true}
-		assert.NoError(t, p.redactErr(u.RawQuery, nil))
-	})
-
-	// With redaction off we must hand back the original error, unwrapped, so
-	// that the default configuration is bit-for-bit unchanged.
-	t.Run("redaction off returns the original error", func(t *testing.T) {
-		p := &Probe{redactURLQueryInLogs: false}
-		assert.Same(t, urlErr, p.redactErr(u.RawQuery, urlErr))
-	})
-
-	t.Run("redaction on hides secret", func(t *testing.T) {
-		p := &Probe{redactURLQueryInLogs: true}
-		got := p.redactErr(u.RawQuery, urlErr)
-		assert.NotContains(t, got.Error(), "password=secret")
+		got := p.redactedErr(err)
+		assert.NotContains(t, got.Error(), "sig=x")
+		assert.NotContains(t, got.Error(), `y"`)
 		assert.Contains(t, got.Error(), "<redacted>")
 	})
 }

--- a/probes/http/redact_test.go
+++ b/probes/http/redact_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2025 The Cloudprober Authors.
+// Copyright 2026 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,10 @@ import (
 	neturl "net/url"
 	"testing"
 
+	configpb "github.com/cloudprober/cloudprober/probes/http/proto"
+	"github.com/cloudprober/cloudprober/probes/options"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
 )
 
 func mustParseURL(t *testing.T, s string) *neturl.URL {
@@ -29,6 +32,18 @@ func mustParseURL(t *testing.T, s string) *neturl.URL {
 		t.Fatalf("error parsing URL %q: %v", s, err)
 	}
 	return u
+}
+
+func TestRawQuery(t *testing.T) {
+	for _, test := range []struct{ in, want string }{
+		{"", ""},
+		{"/path", ""},
+		{"/login?password=secret", "password=secret"},
+		{"/a?user=admin&password=secret", "user=admin&password=secret"},
+		{"/a?x=1?y=2", "x=1?y=2"},
+	} {
+		assert.Equal(t, test.want, rawQuery(test.in), "rawQuery(%q)", test.in)
+	}
 }
 
 func TestRedactedURL(t *testing.T) {
@@ -68,6 +83,12 @@ func TestRedactedURL(t *testing.T) {
 			url:    "https://example.com/a?user=admin&password=secret&x=1",
 			want:   "https://example.com/a?<redacted>",
 		},
+		{
+			name:   "redaction on, fragment kept",
+			redact: true,
+			url:    "https://example.com/a?token=secret#frag",
+			want:   "https://example.com/a?<redacted>#frag",
+		},
 	}
 
 	for _, test := range tests {
@@ -85,21 +106,21 @@ func TestRedactedErr(t *testing.T) {
 
 	t.Run("nil error", func(t *testing.T) {
 		p := &Probe{redactURLQueryInLogs: true}
-		assert.Equal(t, "", p.redactedErr(u, nil))
+		assert.Equal(t, "", p.redactedErr(u.RawQuery, nil))
 	})
 
 	t.Run("redaction off keeps secret", func(t *testing.T) {
 		p := &Probe{redactURLQueryInLogs: false}
 		// net/url.Error embeds the full URL in its message.
 		err := &neturl.Error{Op: "Get", URL: rawURL, Err: fmt.Errorf("dial tcp: connection refused")}
-		got := p.redactedErr(u, err)
+		got := p.redactedErr(u.RawQuery, err)
 		assert.Contains(t, got, "password=secret")
 	})
 
 	t.Run("redaction on hides secret in error text", func(t *testing.T) {
 		p := &Probe{redactURLQueryInLogs: true}
 		err := &neturl.Error{Op: "Get", URL: rawURL, Err: fmt.Errorf("dial tcp: connection refused")}
-		got := p.redactedErr(u, err)
+		got := p.redactedErr(u.RawQuery, err)
 		assert.NotContains(t, got, "password=secret")
 		assert.Contains(t, got, "<redacted>")
 		// The rest of the error text is preserved.
@@ -110,6 +131,77 @@ func TestRedactedErr(t *testing.T) {
 		p := &Probe{redactURLQueryInLogs: true}
 		noQueryURL := mustParseURL(t, "http://example.com/path")
 		err := fmt.Errorf("some error")
-		assert.Equal(t, "some error", p.redactedErr(noQueryURL, err))
+		assert.Equal(t, "some error", p.redactedErr(noQueryURL.RawQuery, err))
 	})
+
+	// net/http builds its error from the request it last made, so after a
+	// redirect the scheme, host and path are the redirect target's, while the
+	// query is carried over. Matching on the query alone still redacts it.
+	t.Run("redirected URL is still redacted", func(t *testing.T) {
+		p := &Probe{redactURLQueryInLogs: true}
+		err := &neturl.Error{
+			Op:  "Get",
+			URL: "https://other.example.com/login?password=secret",
+			Err: fmt.Errorf("dial tcp: connection refused"),
+		}
+		got := p.redactedErr(u.RawQuery, err)
+		assert.NotContains(t, got, "password=secret")
+		assert.Contains(t, got, "<redacted>")
+	})
+
+	// url.Error renders the URL with %q, so a quote in the query arrives
+	// escaped and doesn't match the query's plain form.
+	t.Run("quote in query is still redacted", func(t *testing.T) {
+		p := &Probe{redactURLQueryInLogs: true}
+		qu := mustParseURL(t, `http://example.com/a?sig=x"y`)
+		err := &neturl.Error{Op: "Get", URL: qu.String(), Err: fmt.Errorf("connection refused")}
+		got := p.redactedErr(qu.RawQuery, err)
+		assert.NotContains(t, got, "sig=x")
+		assert.Contains(t, got, "<redacted>")
+	})
+}
+
+func TestRedactErr(t *testing.T) {
+	rawURL := "http://example.com/login?password=secret"
+	u := mustParseURL(t, rawURL)
+	urlErr := &neturl.Error{Op: "Get", URL: rawURL, Err: fmt.Errorf("connection refused")}
+
+	t.Run("nil error stays nil", func(t *testing.T) {
+		p := &Probe{redactURLQueryInLogs: true}
+		assert.NoError(t, p.redactErr(u.RawQuery, nil))
+	})
+
+	// With redaction off we must hand back the original error, unwrapped, so
+	// that the default configuration is bit-for-bit unchanged.
+	t.Run("redaction off returns the original error", func(t *testing.T) {
+		p := &Probe{redactURLQueryInLogs: false}
+		assert.Same(t, urlErr, p.redactErr(u.RawQuery, urlErr))
+	})
+
+	t.Run("redaction on hides secret", func(t *testing.T) {
+		p := &Probe{redactURLQueryInLogs: true}
+		got := p.redactErr(u.RawQuery, urlErr)
+		assert.NotContains(t, got.Error(), "password=secret")
+		assert.Contains(t, got.Error(), "<redacted>")
+	})
+}
+
+// A malformed relative_url is rejected at Init, and that error carries the
+// relative URL -- including its query -- back to the caller.
+func TestInitInvalidRelativeURLIsRedacted(t *testing.T) {
+	for _, test := range []struct{ name, want string }{
+		{"redaction off", "invalid relative URL: login?password=secret, must begin with '/'"},
+		{"redaction on", "invalid relative URL: login?<redacted>, must begin with '/'"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			p := &Probe{}
+			err := p.Init("test-probe", &options.Options{
+				ProbeConf: &configpb.ProbeConf{
+					RelativeUrl:          proto.String("login?password=secret"),
+					RedactUrlQueryInLogs: proto.Bool(test.name == "redaction on"),
+				},
+			})
+			assert.EqualError(t, err, test.want)
+		})
+	}
 }

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/cloudprober/cloudprober/common/iputils"
@@ -94,6 +95,35 @@ func pathForTarget(target endpoint.Endpoint, probeURL string) string {
 	}
 
 	return ""
+}
+
+// redactedURL returns the URL string for logging. When redaction is enabled
+// (redact_url_query_in_logs) and the URL has a query string, the query is
+// replaced with "<redacted>" so secrets carried in query parameters (e.g.
+// passwords) don't end up in logs. The rest of the URL is left intact.
+func (p *Probe) redactedURL(u *url.URL) string {
+	if !p.redactURLQueryInLogs || u.RawQuery == "" {
+		return u.String()
+	}
+	redacted := *u
+	redacted.RawQuery = "<redacted>"
+	return redacted.String()
+}
+
+// redactedErr returns err's message with any occurrence of the full request
+// URL replaced by its redacted form. This is needed because net/http errors (a
+// *url.Error) embed the full URL, including the query string, in their
+// text, so redacting only the logged "url" attribute would still leak the
+// query via the error message.
+func (p *Probe) redactedErr(u *url.URL, err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	if !p.redactURLQueryInLogs || u.RawQuery == "" {
+		return msg
+	}
+	return strings.ReplaceAll(msg, u.String(), p.redactedURL(u))
 }
 
 func (p *Probe) resolveFirst(target endpoint.Endpoint) bool {

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -16,11 +16,13 @@ package http
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/cloudprober/cloudprober/common/iputils"
@@ -33,6 +35,9 @@ import (
 )
 
 const relURLLabel = "relative_url"
+
+// redactedQuery is what a redacted query string is replaced with in logs.
+const redactedQuery = "<redacted>"
 
 func hostWithPort(host string, port int) string {
 	if port == 0 {
@@ -97,33 +102,63 @@ func pathForTarget(target endpoint.Endpoint, probeURL string) string {
 	return ""
 }
 
-// redactedURL returns the URL string for logging. When redaction is enabled
-// (redact_url_query_in_logs) and the URL has a query string, the query is
-// replaced with "<redacted>" so secrets carried in query parameters (e.g.
-// passwords) don't end up in logs. The rest of the URL is left intact.
-func (p *Probe) redactedURL(u *url.URL) string {
-	if !p.redactURLQueryInLogs || u.RawQuery == "" {
-		return u.String()
-	}
-	redacted := *u
-	redacted.RawQuery = "<redacted>"
-	return redacted.String()
+// rawQuery returns everything after the first '?' in s, i.e. the query string
+// of a URL or of a relative URL. It returns "" if there is no '?'.
+func rawQuery(s string) string {
+	_, q, _ := strings.Cut(s, "?")
+	return q
 }
 
-// redactedErr returns err's message with any occurrence of the full request
-// URL replaced by its redacted form. This is needed because net/http errors (a
-// *url.Error) embed the full URL, including the query string, in their
-// text, so redacting only the logged "url" attribute would still leak the
-// query via the error message.
-func (p *Probe) redactedErr(u *url.URL, err error) string {
+// redactQuery replaces every occurrence of "?"+q in s with "?<redacted>", so
+// that secrets carried in query parameters (e.g. passwords) don't end up in
+// logs. It's a no-op if redaction is disabled or there is no query.
+//
+// We match on the query alone rather than on the full URL because the URL a
+// message carries is often not the one we started with: net/http builds its
+// errors from the last request it made, so after a redirect the host and path
+// have changed while the query is carried over.
+func (p *Probe) redactQuery(q, s string) string {
+	if !p.redactURLQueryInLogs || q == "" {
+		return s
+	}
+	s = strings.ReplaceAll(s, "?"+q, "?"+redactedQuery)
+
+	// *url.Error renders the URL with %q, so a query containing a quote or a
+	// backslash reaches us escaped and won't match the plain form above.
+	if quoted := strconv.Quote(q); quoted[1:len(quoted)-1] != q {
+		s = strings.ReplaceAll(s, "?"+quoted[1:len(quoted)-1], "?"+redactedQuery)
+	}
+
+	return s
+}
+
+// redactedURL returns the URL string for logging, with its query redacted if
+// redaction is enabled. The rest of the URL is left intact.
+func (p *Probe) redactedURL(u *url.URL) string {
+	return p.redactQuery(u.RawQuery, u.String())
+}
+
+// redactedErr returns err's message with the query redacted. This is needed
+// because net/http errors (a *url.Error) embed the full URL, including the
+// query string, in their text, so redacting only the logged "url" attribute
+// would still leak the query via the error message. q is the query to redact;
+// callers that have a parsed URL pass u.RawQuery, the rest pass
+// rawQuery(<relative url>).
+func (p *Probe) redactedErr(q string, err error) string {
 	if err == nil {
 		return ""
 	}
-	msg := err.Error()
-	if !p.redactURLQueryInLogs || u.RawQuery == "" {
-		return msg
+	return p.redactQuery(q, err.Error())
+}
+
+// redactErr is redactedErr, but it returns an error. It returns err itself
+// when redaction is disabled, so that the default configuration keeps
+// propagating the original, typed error.
+func (p *Probe) redactErr(q string, err error) error {
+	if err == nil || !p.redactURLQueryInLogs {
+		return err
 	}
-	return strings.ReplaceAll(msg, u.String(), p.redactedURL(u))
+	return errors.New(p.redactedErr(q, err))
 }
 
 func (p *Probe) resolveFirst(target endpoint.Endpoint) bool {

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -22,7 +22,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strconv"
+	"regexp"
 	"strings"
 
 	"github.com/cloudprober/cloudprober/common/iputils"
@@ -102,63 +102,82 @@ func pathForTarget(target endpoint.Endpoint, probeURL string) string {
 	return ""
 }
 
-// rawQuery returns everything after the first '?' in s, i.e. the query string
-// of a URL or of a relative URL. It returns "" if there is no '?'.
-func rawQuery(s string) string {
-	_, q, _ := strings.Cut(s, "?")
-	return q
-}
-
-// redactQuery replaces every occurrence of "?"+q in s with "?<redacted>", so
-// that secrets carried in query parameters (e.g. passwords) don't end up in
-// logs. It's a no-op if redaction is disabled or there is no query.
-//
-// We match on the query alone rather than on the full URL because the URL a
-// message carries is often not the one we started with: net/http builds its
-// errors from the last request it made, so after a redirect the host and path
-// have changed while the query is carried over.
-func (p *Probe) redactQuery(q, s string) string {
-	if !p.redactURLQueryInLogs || q == "" {
+// redactURL replaces the query of a raw URL string with "<redacted>". Because
+// we hold the URL itself rather than a message that contains one, we can cut
+// at the first '?' and take everything after it. That matters: a query may
+// legally contain characters -- a space among them -- that would otherwise
+// look like the end of the URL and leave the tail of the query exposed.
+func (p *Probe) redactURL(s string) string {
+	if !p.redactURLQueryInLogs {
 		return s
 	}
-	s = strings.ReplaceAll(s, "?"+q, "?"+redactedQuery)
-
-	// *url.Error renders the URL with %q, so a query containing a quote or a
-	// backslash reaches us escaped and won't match the plain form above.
-	if quoted := strconv.Quote(q); quoted[1:len(quoted)-1] != q {
-		s = strings.ReplaceAll(s, "?"+quoted[1:len(quoted)-1], "?"+redactedQuery)
+	base, query, found := strings.Cut(s, "?")
+	if !found || query == "" {
+		return s
 	}
-
-	return s
+	return base + "?" + redactedQuery
 }
 
-// redactedURL returns the URL string for logging, with its query redacted if
-// redaction is enabled. The rest of the URL is left intact.
+// quotedRE matches a %q-rendered token: a double-quoted string that may
+// contain backslash escapes. Matching the quoted token, rather than the URL
+// inside it, is what bounds the rewrite -- the closing quote ends the query no
+// matter what the query holds, and text outside the quotes is left alone:
+//
+//	in:  Get "http://h/a?msg=hello world" failed: is it up?
+//	out: Get "http://h/a?<redacted>" failed: is it up?
+//	                                                 ^ prose '?', not a query
+var quotedRE = regexp.MustCompile(`"(?:\\.|[^"\\])*"`)
+
+// redactErrMsg redacts the query of any quoted URL in an error message. It is
+// the fallback for errors that don't carry the URL as a field: we rewrite only
+// inside %q-quoted tokens, which is where an error puts a URL, so a '?' in the
+// surrounding prose is left alone and the message stays readable.
+func (p *Probe) redactErrMsg(s string) string {
+	return quotedRE.ReplaceAllStringFunc(s, func(tok string) string {
+		i := strings.Index(tok, "?")
+		// No query, or a bare '?' right before the closing quote.
+		if i < 0 || i == len(tok)-2 {
+			return tok
+		}
+		return tok[:i] + "?" + redactedQuery + `"`
+	})
+}
+
+// redactedURL returns the URL string for logging, with its query replaced by
+// "<redacted>" if redaction is enabled. Here we have the parsed URL, so we can
+// redact exactly rather than by shape, leaving the fragment and everything
+// else untouched.
 func (p *Probe) redactedURL(u *url.URL) string {
-	return p.redactQuery(u.RawQuery, u.String())
-}
-
-// redactedErr returns err's message with the query redacted. This is needed
-// because net/http errors (a *url.Error) embed the full URL, including the
-// query string, in their text, so redacting only the logged "url" attribute
-// would still leak the query via the error message. q is the query to redact;
-// callers that have a parsed URL pass u.RawQuery, the rest pass
-// rawQuery(<relative url>).
-func (p *Probe) redactedErr(q string, err error) string {
-	if err == nil {
-		return ""
+	if !p.redactURLQueryInLogs || u.RawQuery == "" {
+		return u.String()
 	}
-	return p.redactQuery(q, err.Error())
+	redacted := *u
+	redacted.RawQuery = redactedQuery
+	return redacted.String()
 }
 
-// redactErr is redactedErr, but it returns an error. It returns err itself
-// when redaction is disabled, so that the default configuration keeps
-// propagating the original, typed error.
-func (p *Probe) redactErr(q string, err error) error {
+// redactedErr returns err with the query redacted in its message. This is
+// needed because net/http errors embed the full URL, including the query, in
+// their text, so redacting only the logged "url" attribute would still leak
+// the query via the error message.
+//
+// A *url.Error holds the URL as a field, so we rebuild it with that field
+// redacted: the error keeps its type and its Unwrap chain, and errors.Is/As
+// behave the same whether or not redaction is on. Anything else falls back to
+// rewriting the message.
+//
+// It returns err unchanged when redaction is disabled, so that the default
+// configuration keeps propagating the original error untouched.
+func (p *Probe) redactedErr(err error) error {
 	if err == nil || !p.redactURLQueryInLogs {
 		return err
 	}
-	return errors.New(p.redactedErr(q, err))
+	if ue, ok := err.(*url.Error); ok {
+		redacted := *ue
+		redacted.URL = p.redactURL(ue.URL)
+		return &redacted
+	}
+	return errors.New(p.redactErrMsg(err.Error()))
 }
 
 func (p *Probe) resolveFirst(target endpoint.Endpoint) bool {
@@ -319,9 +338,9 @@ func (p *Probe) httpRequestForTarget(target endpoint.Endpoint) (*http.Request, e
 		return nil, err
 	}
 
-	url := fmt.Sprintf("%s://%s%s", p.schemeForTarget(target), hostWithPort(urlHost, port), pathForTarget(target, p.url))
+	urlStr := fmt.Sprintf("%s://%s%s", p.schemeForTarget(target), hostWithPort(urlHost, port), pathForTarget(target, p.url))
 
-	req, err := httpreq.NewRequest(p.method, url, p.requestBody)
+	req, err := httpreq.NewRequest(p.method, urlStr, p.requestBody)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hello,

I've added an opt-in redact_url_query_in_logs field to the HTTP probe config (default false, so existing behavior is unchanged); when enabled, URL query parameters are replaced with "\<redacted>" in probe logs.

Some of our legacy endpoints carry sensitive data in query parameters, and when a probe request fails cloudprober logs the full request URL including the query string, so those secrets end up in the logs with no way to opt out short of disabling logging entirely.

Also, in my opinion, probe validation failures shouldn't produce error logs: the system (cloudprober) is working properly - the probe is failing, which isn't a fault of the system itself, so surfacing it at Error feels misleading. But that's really a separate discussion. :)