### PR TITLE
[surfacers/probestatus] Emit status page start time in RFC3339

### DIFF
--- a/internal/surfacers/probestatus/probestatus.go
+++ b/internal/surfacers/probestatus/probestatus.go
@@ -500,7 +500,7 @@ func (ps *Surfacer) writeData(hw *httpWriter) {
 		DebugData   map[string]template.HTML
 		Header      template.HTML
 		LinkPrefix  string
-		StartTime   fmt.Stringer
+		StartTime   string // RFC3339, for Javascript's Date().
 	}{
 		BaseURL:     linkPrefix + strings.TrimLeft(ps.c.GetUrl(), "/"),
 		Durations:   ps.dashDurationsText,
@@ -511,7 +511,7 @@ func (ps *Surfacer) writeData(hw *httpWriter) {
 		DebugData:   debugData,
 		Header:      resources.Header(linkPrefix),
 		LinkPrefix:  linkPrefix,
-		StartTime:   ps.startTime,
+		StartTime:   ps.startTime.Format(time.RFC3339),
 	})
 	if err != nil {
 		ps.l.Errorf("Error executing probe status template: %v", err)

--- a/internal/surfacers/probestatus/probestatus_test.go
+++ b/internal/surfacers/probestatus/probestatus_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -334,6 +336,43 @@ func TestSurfacerWriteData(t *testing.T) {
 			for _, keyword := range tt.wantNotContains {
 				assert.NotContains(t, got, keyword)
 			}
+		})
+	}
+}
+
+func TestStatusPageStartTime(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		startTime time.Time
+	}{
+		{"utc", time.Date(2026, 8, 13, 21, 3, 32, 0, time.UTC)},
+		{"east_of_utc", time.Date(2026, 8, 13, 23, 3, 32, 0, time.FixedZone("CEST", 2*60*60))},
+		{"west_of_utc", time.Date(2026, 8, 13, 17, 3, 32, 0, time.FixedZone("EDT", -4*60*60))},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ps := &Surfacer{
+				pageCache:  newPageCache(1),
+				probeNames: []string{"p1"},
+				startTime:  tt.startTime,
+			}
+			hw := &httpWriter{
+				w: httptest.NewRecorder(),
+				r: httptest.NewRequest("", "/", nil),
+			}
+			ps.writeData(hw)
+
+			got := hw.w.(*httptest.ResponseRecorder).Body.String()
+			m := regexp.MustCompile(`var startTime = '([^']*)'`).FindStringSubmatch(got)
+			if m == nil {
+				t.Fatal("startTime is not set on the status page")
+			}
+			// html/template escapes "+" as \u002b in a script context.
+			ts := strings.ReplaceAll(m[1], `\u002b`, "+")
+			parsed, err := time.Parse(time.RFC3339, ts)
+			if err != nil {
+				t.Fatalf("startTime %q is not in RFC3339 format: %v", m[1], err)
+			}
+			assert.True(t, parsed.Equal(tt.startTime), "got %v, want %v", parsed, tt.startTime)
 		})
 	}
 }

--- a/internal/surfacers/probestatus/static/probestatus.js
+++ b/internal/surfacers/probestatus/static/probestatus.js
@@ -87,7 +87,11 @@ function populateD() {
   }
 }
 
+// Returns null if dt is an Invalid Date, e.g. from an unparseable input.
 function dateToValStr(dt) {
+  if (isNaN(dt.getTime())) {
+    return null;
+  }
   dt.setMinutes(dt.getMinutes() - dt.getTimezoneOffset());
   return dt.toISOString().slice(0, 16);
 }
@@ -109,12 +113,15 @@ function setupGraphEndpoint() {
 
   let params = new URLSearchParams(location.search);
   if (typeof startTime != 'undefined') {
-    $('#graph-endtime').attr('min', dateToValStr(new Date(startTime)));
+    let min = dateToValStr(new Date(startTime));
+    if (min) {
+      $('#graph-endtime').attr('min', min);
+    }
   }
   if (params.get('graph_endtime')) {
-    let dt = new Date(params.get('graph_endtime') * 1000);
-    if (dt) {
-      $('#graph-endtime').val(dateToValStr(dt));
+    let v = dateToValStr(new Date(params.get('graph_endtime') * 1000));
+    if (v) {
+      $('#graph-endtime').val(v);
     }
   }
 }


### PR DESCRIPTION
## Description

The status page embeds the prober start time in a Javascript variable:

```html
<script>
  var startTime = '{{.StartTime}}';
```

It was rendered with Go's default `time.Time` format, so the page emits e.g.

```js
var startTime = '2026-08-13 23:03:32.686 \u002b0200 CEST';
```

`new Date()` cannot parse that, so `setupGraphEndpoint()` produces an Invalid
Date and `dateToValStr()` throws `RangeError: Invalid time value` on
`toISOString()`. The throw propagates out of `$(document).ready(...)`, so the
three init calls after `setupGraphEndpoint()` never run:

```js
$(document).ready(function () {
  setupGraphEndpoint();      // throws
  setupGraphDuration();      // never runs
  showDebugInfo();           // never runs
  generateProbeSelectors();  // never runs
});
```

Visible effects on every load of `/status`:

- the probe selector is never rendered (`#probe-selector` stays empty, which is
  why it shows as an empty blue strip under "Success Ratio")
- the graph duration input has no change handler, so picking a duration does
  nothing
- `?debug=1` has no effect

This is not timezone-specific; `0001-01-01 00:00:00 +0000 UTC` is not parseable
by `Date()` either.

Measured on a running cloudprober before the change, on `/status`:

```
document.querySelectorAll('.probe-checkbox').length   // 0
document.getElementById('graph-endtime').getAttribute('min')   // null
window.allProbes   // ['public_web_endpoints', 'a_very_long_probe_name...']
```

The probe names are present in the page; only the code that renders them is
skipped. Calling `generateProbeSelectors()` by hand in the console then yields
3 checkboxes.

## Fix

Render the value as RFC3339 so `Date()` can parse it.

Also make `dateToValStr()` return `null` for an Invalid Date instead of
throwing, so no single unparseable timestamp can abort the rest of the page
setup. This matters because `setupGraphEndpoint()` has a second call site that
reached the same throw:

```js
let dt = new Date(params.get('graph_endtime') * 1000);
if (dt) {                        // an Invalid Date is truthy, so this is not a guard
  $('#graph-endtime').val(dateToValStr(dt));
}
```

`/status?graph_endtime=abc` reproduced the identical breakage (0 probe
checkboxes, same `RangeError`) even with the RFC3339 change applied. With this
patch the bad parameter is ignored and the page initialises normally.

## Tests

`TestStatusPageStartTime` renders the page and asserts the embedded value
parses as RFC3339 and refers to the same instant, for a UTC, an east-of-UTC and
a west-of-UTC start time. It fails on all three subtests if the `Format` call
is reverted, and also fails if the timestamp is correctly formatted but wrong.

Note the east-of-UTC case covers `html/template` escaping `+` to `\u002b` in a
script context, which is valid inside the JS string literal and parses fine in
the browser.

## Verification

Built and run against live probes; `/status` now renders the probe selector,
`?graph_duration=6h` and `?debug=1` both take effect, the `min` attribute is
set on the endtime picker, and the console is clean.
