### PR TITLE
[surfacers/probestatus] Fix deferred chart load on the status page

### DIFF
--- a/internal/surfacers/probestatus/html_tmpl.go
+++ b/internal/surfacers/probestatus/html_tmpl.go
@@ -108,11 +108,7 @@ populateD();
 
 <script>
 for (const probe in d) {
-  var chart = c3.generate(d[probe]);
-
-  setTimeout(function () {
-      chart.load();
-  }, 1000);
+  c3.generate(d[probe]);
 }
 </script>
 </html>

--- a/internal/surfacers/probestatus/probestatus_test.go
+++ b/internal/surfacers/probestatus/probestatus_test.go
@@ -297,9 +297,10 @@ func TestSurfacerWriteData(t *testing.T) {
 		{
 			name: "default",
 			wantContains: []string{
-				"startTime", "allProbes", "chart",
+				"startTime", "allProbes", "chart", "c3.generate(",
 			},
-			probeNames: []string{"Probe: p1", "Probe: p2"},
+			wantNotContains: []string{"chart.load()", "setTimeout"},
+			probeNames:      []string{"Probe: p1", "Probe: p2"},
 		},
 		{
 			name:  "probe_filter",


### PR DESCRIPTION
## Description

The status page ends with:

```js
for (const probe in d) {
  var chart = c3.generate(d[probe]);

  setTimeout(function () {
      chart.load();
  }, 1000);
}
```

Two problems:

1. `chart.load()` is called with no arguments. c3's `load()` dereferences its
   `args` parameter, so this throws on every page load:

   ```
   TypeError: Cannot read properties of undefined (reading 'xs')
       at n.load (c3.min.js:2:91066)
       at /status:174:13
   ```

2. `chart` is declared with `var`, which is function-scoped rather than
   block-scoped. Every deferred callback therefore closes over the same
   binding and sees the last generated chart, not its own. With N probes, the
   last chart is loaded N times and the others are never touched.

## Fix

`c3.generate()` already renders the columns it is passed (`populateProbeData()`
fills `d[probe].data.columns` before this script runs), so the deferred
`load()` was not contributing to rendering — the charts draw correctly today in
spite of it throwing. Dropping the call also removes the 1s timeout and the
`var` closure capture.

## Tests

Extended the existing `TestSurfacerWriteData` table: the rendered page must
contain `c3.generate(` and must not contain `chart.load()` or `setTimeout`. Both
negative assertions fail if the change is reverted.

There is no Javascript test harness in the repo, so this pins the emitted
template rather than the runtime behaviour.

## Verification

Built and run against live probes; charts render as before and the console is
clean.

Independent of #1412 — different file, no overlap.
