### PR TITLE
[docs] FAQ: add BROWSER probe custom CA (ERR_CERT_AUTHORITY_INVALID) entry

### DIFF
--- a/docs/content/docs/faq/troubleshooting.md
+++ b/docs/content/docs/faq/troubleshooting.md
@@ -160,10 +160,11 @@ In containerized deployments, two things commonly make this fail silently:
    Chromium actually runs as. Build it as root but let the container drop to a
    non-root uid at runtime (e.g. k8s `runAsUser`), and Chromium won't find it.
 2. **Read-only root filesystem.** `cert9.db` is a SQLite file, and SQLite must
-   write journal/WAL files into its directory even for a read-only open. A
-   database baked into the image at `$HOME/.pki/nssdb` therefore can't be
-   opened when the root filesystem is read-only (common in k8s), even though
-   `certutil` succeeded at build time.
+   create journal files in the directory containing the database in order to
+   write to it. Chromium's NSS library opens the database in read-write mode,
+   so that directory has to be writable. A database baked into the image at
+   `$HOME/.pki/nssdb` therefore can't be used when the root filesystem is
+   read-only (common in k8s), even though `certutil` succeeded at build time.
 
 The fix for the read-only case is to copy the pre-built database to a writable
 location at startup and point `$HOME` there. Overriding the container `command`

--- a/docs/content/docs/faq/troubleshooting.md
+++ b/docs/content/docs/faq/troubleshooting.md
@@ -170,7 +170,8 @@ In containerized deployments, two things commonly make this fail silently:
 The fix for the read-only case is to copy the pre-built database to a writable
 location at startup and point `$HOME` there. (Build it during the Docker build
 with `certutil` — the runtime image doesn't ship `certutil`.) For example, if
-your image has the database at `/nssdb`:
+your image has the database at `/nssdb`, readable by the uid the container runs
+as (k8s `runAsUser`):
 
 ```yaml
 command:

--- a/docs/content/docs/faq/troubleshooting.md
+++ b/docs/content/docs/faq/troubleshooting.md
@@ -167,5 +167,22 @@ There are two pitfalls that produce this exact symptom:
    filesystem (common in k8s), an NSS DB baked into the image at
    `$HOME/.pki/nssdb` will fail to open at runtime even though `certutil`
    succeeded at build time. The fix is to copy the pre-built DB to a writable
-   location (e.g. `/tmp/.pki/nssdb`) at container startup — before Cloudprober's
-   Playwright subprocess launches — and point `$HOME` there.
+   location (e.g. `/tmp/node-home/.pki/nssdb`) at container startup — before
+   Cloudprober's Playwright subprocess launches — and point `$HOME` there.
+
+One way to do this is to override the container `command` so the copy happens
+at startup, right before Cloudprober launches:
+
+```yaml
+command:
+  - /bin/sh
+  - -c
+  - mkdir -p /tmp/node-home/.pki/nssdb &&
+    cp -f $HOME/.pki/nssdb/* /tmp/node-home/.pki/nssdb/ &&
+    HOME=/tmp/node-home exec /cloudprober "$@"
+  - --
+```
+
+This assumes the NSS DB was built into the image at `$HOME/.pki/nssdb` (via
+`certutil`) and that `/tmp` is writable. The `exec` replaces the shell so
+Cloudprober stays PID 1 and receives signals correctly.

--- a/docs/content/docs/faq/troubleshooting.md
+++ b/docs/content/docs/faq/troubleshooting.md
@@ -170,8 +170,9 @@ In containerized deployments, two things commonly make this fail silently:
 The fix for the read-only case is to copy the pre-built database to a writable
 location at startup and point `$HOME` there. (Build it during the Docker build
 with `certutil` — the runtime image doesn't ship `certutil`.) For example, if
-your image has the database at `/nssdb`, readable by the uid the container runs
-as (k8s `runAsUser`):
+your image has the certs database at `/nssdb`, readable by the uid the container
+runs as (k8s `runAsUser`), you can configure your container command as the
+following to make chrome use your certs:
 
 ```yaml
 command:
@@ -183,3 +184,45 @@ command:
   - --
 ```
 
+If you don't build your own Cloudprober image, you can do all of this in an
+init container instead. Run an image that has `certutil` (Alpine's `nss-tools`,
+Debian's `libnss3-tools`), build the database into a shared `emptyDir`, and
+point `$HOME` at it. The volume is writable, so the read-only root filesystem
+problem goes away and there's no need to override the container `command`:
+
+```yaml
+volumes:
+  - name: nss-home
+    emptyDir: {}
+  - name: ca
+    configMap:
+      name: custom-ca # contains ca.crt
+
+initContainers:
+  - name: build-nssdb
+    image: <image-with-certutil>
+    command:
+      - /bin/sh
+      - -c
+      - mkdir -p /nss-home/.pki/nssdb &&
+        certutil -d sql:/nss-home/.pki/nssdb -A -t "CT,C,C"
+        -n custom-ca -i /ca/ca.crt
+    volumeMounts:
+      - name: nss-home
+        mountPath: /nss-home
+      - name: ca
+        mountPath: /ca
+
+containers:
+  - name: cloudprober
+    image: cloudprober/cloudprober:latest-pw
+    env:
+      - name: HOME
+        value: /nss-home
+    volumeMounts:
+      - name: nss-home
+        mountPath: /nss-home
+```
+
+Cloudprober passes its own environment on to the Playwright subprocess, so
+setting `HOME` on the pod is enough for Chromium to find the database.

--- a/docs/content/docs/faq/troubleshooting.md
+++ b/docs/content/docs/faq/troubleshooting.md
@@ -142,36 +142,32 @@ to monitor both, create separate probes for each IP version.
 
 ## BROWSER probes fail with "ERR_CERT_AUTHORITY_INVALID" against a custom CA
 
-If a BROWSER probe's `page.goto` fails with `ERR_CERT_AUTHORITY_INVALID` when
-the target is secured by a certificate from a custom (private) CA, adding the
-certificate to the system trust store
-(`/usr/local/share/ca-certificates/` + `update-ca-certificates`) or setting
-`NODE_EXTRA_CA_CERTS` won't help — Chromium doesn't consult either. On Linux,
-Chromium uses the NSS certificate database at `$HOME/.pki/nssdb` (`cert9.db`).
+If a BROWSER probe fails with `ERR_CERT_AUTHORITY_INVALID` on a target secured
+by a custom (private) CA, the usual fixes don't apply. Chromium on Linux
+ignores both the system trust store (`/usr/local/share/ca-certificates/` +
+`update-ca-certificates`) and `NODE_EXTRA_CA_CERTS`; it reads certificates from
+the NSS database at `$HOME/.pki/nssdb` (`cert9.db`) instead.
 
-Build that database with `certutil`:
+Import your CA into that database with `certutil`:
 
 ```shell
 certutil -d sql:$HOME/.pki/nssdb -A -t "CT,C,C" -n "<CERT_NAME>" -i <CERT_PATH>
 ```
 
-There are two pitfalls that produce this exact symptom:
+In containerized deployments, two things commonly make this fail silently:
 
-1. **`$HOME` mismatch.** The NSS DB has to live under the `$HOME` of the user
-   the container actually runs as when Chromium launches. If you build the DB
-   as root but the container (or a k8s `runAsUser`) switches to a non-root uid
-   at runtime, Chrome won't find it.
-2. **Read-only root filesystem.** `cert9.db` is a SQLite database, and SQLite
-   needs write access to its directory even just to open it for reads
-   (journal/WAL files). If your deployment runs with a read-only root
-   filesystem (common in k8s), an NSS DB baked into the image at
-   `$HOME/.pki/nssdb` will fail to open at runtime even though `certutil`
-   succeeded at build time. The fix is to copy the pre-built DB to a writable
-   location (e.g. `/tmp/node-home/.pki/nssdb`) at container startup — before
-   Cloudprober's Playwright subprocess launches — and point `$HOME` there.
+1. **`$HOME` mismatch.** The database must live under the `$HOME` of the user
+   Chromium actually runs as. Build it as root but let the container drop to a
+   non-root uid at runtime (e.g. k8s `runAsUser`), and Chromium won't find it.
+2. **Read-only root filesystem.** `cert9.db` is a SQLite file, and SQLite must
+   write journal/WAL files into its directory even for a read-only open. A
+   database baked into the image at `$HOME/.pki/nssdb` therefore can't be
+   opened when the root filesystem is read-only (common in k8s), even though
+   `certutil` succeeded at build time.
 
-One way to do this is to override the container `command` so the copy happens
-at startup, right before Cloudprober launches:
+The fix for the read-only case is to copy the pre-built database to a writable
+location at startup and point `$HOME` there. Overriding the container `command`
+is one way to do it:
 
 ```yaml
 command:
@@ -183,6 +179,7 @@ command:
   - --
 ```
 
-This assumes the NSS DB was built into the image at `$HOME/.pki/nssdb` (via
-`certutil`) and that `/tmp` is writable. The `exec` replaces the shell so
-Cloudprober stays PID 1 and receives signals correctly.
+At startup this copies the database (built into the image at
+`$HOME/.pki/nssdb` during the Docker build) into `/tmp`, which is writable, and
+relaunches Cloudprober with `HOME=/tmp/node-home`. The `exec` replaces the
+shell so Cloudprober stays PID 1 and handles signals correctly.

--- a/docs/content/docs/faq/troubleshooting.md
+++ b/docs/content/docs/faq/troubleshooting.md
@@ -151,7 +151,8 @@ the NSS database at `$HOME/.pki/nssdb` (`cert9.db`) instead.
 Import your CA into that database with `certutil`:
 
 ```shell
-certutil -d sql:$HOME/.pki/nssdb -A -t "CT,C,C" -n "<CERT_NAME>" -i <CERT_PATH>
+mkdir -p $HOME/.pki/nssdb && \
+  certutil -d sql:$HOME/.pki/nssdb -A -t "CT,C,C" -n "<CERT_NAME>" -i <CERT_PATH>
 ```
 
 In containerized deployments, two things commonly make this fail silently:
@@ -167,20 +168,17 @@ In containerized deployments, two things commonly make this fail silently:
    read-only (common in k8s), even though `certutil` succeeded at build time.
 
 The fix for the read-only case is to copy the pre-built database to a writable
-location at startup and point `$HOME` there. Overriding the container `command`
-is one way to do it:
+location at startup and point `$HOME` there. For example if your container
+image already contains required certs at `/nssdb`, you can set them up correctly
+by overriding the container `command` with something like:
 
 ```yaml
 command:
   - /bin/sh
   - -c
   - mkdir -p /tmp/node-home/.pki/nssdb &&
-    cp -f $HOME/.pki/nssdb/* /tmp/node-home/.pki/nssdb/ &&
+    cp -f /certs/* /tmp/node-home/.pki/nssdb/ &&
     HOME=/tmp/node-home exec /cloudprober "$@"
   - --
 ```
 
-At startup this copies the database (built into the image at
-`$HOME/.pki/nssdb` during the Docker build) into `/tmp`, which is writable, and
-relaunches Cloudprober with `HOME=/tmp/node-home`. The `exec` replaces the
-shell so Cloudprober stays PID 1 and handles signals correctly.

--- a/docs/content/docs/faq/troubleshooting.md
+++ b/docs/content/docs/faq/troubleshooting.md
@@ -168,16 +168,16 @@ In containerized deployments, two things commonly make this fail silently:
    read-only (common in k8s), even though `certutil` succeeded at build time.
 
 The fix for the read-only case is to copy the pre-built database to a writable
-location at startup and point `$HOME` there. For example if your container
-image already contains required certs at `/nssdb`, you can set them up correctly
-by overriding the container `command` with something like:
+location at startup and point `$HOME` there. (Build it during the Docker build
+with `certutil` — the runtime image doesn't ship `certutil`.) For example, if
+your image has the database at `/nssdb`:
 
 ```yaml
 command:
   - /bin/sh
   - -c
   - mkdir -p /tmp/node-home/.pki/nssdb &&
-    cp -f /certs/* /tmp/node-home/.pki/nssdb/ &&
+    cp -f /nssdb/* /tmp/node-home/.pki/nssdb/ &&
     HOME=/tmp/node-home exec /cloudprober "$@"
   - --
 ```

--- a/docs/content/docs/faq/troubleshooting.md
+++ b/docs/content/docs/faq/troubleshooting.md
@@ -139,3 +139,33 @@ to monitor both, create separate probes for each IP version.
   1s, which might be too short for some probes.
 - Check network connectivity to the target from the host running Cloudprober.
 - For HTTP probes, verify that the target URL is correct and accessible.
+
+## BROWSER probes fail with "ERR_CERT_AUTHORITY_INVALID" against a custom CA
+
+If a BROWSER probe's `page.goto` fails with `ERR_CERT_AUTHORITY_INVALID` when
+the target is secured by a certificate from a custom (private) CA, adding the
+certificate to the system trust store
+(`/usr/local/share/ca-certificates/` + `update-ca-certificates`) or setting
+`NODE_EXTRA_CA_CERTS` won't help — Chromium doesn't consult either. On Linux,
+Chromium uses the NSS certificate database at `$HOME/.pki/nssdb` (`cert9.db`).
+
+Build that database with `certutil`:
+
+```shell
+certutil -d sql:$HOME/.pki/nssdb -A -t "CT,C,C" -n "<CERT_NAME>" -i <CERT_PATH>
+```
+
+There are two pitfalls that produce this exact symptom:
+
+1. **`$HOME` mismatch.** The NSS DB has to live under the `$HOME` of the user
+   the container actually runs as when Chromium launches. If you build the DB
+   as root but the container (or a k8s `runAsUser`) switches to a non-root uid
+   at runtime, Chrome won't find it.
+2. **Read-only root filesystem.** `cert9.db` is a SQLite database, and SQLite
+   needs write access to its directory even just to open it for reads
+   (journal/WAL files). If your deployment runs with a read-only root
+   filesystem (common in k8s), an NSS DB baked into the image at
+   `$HOME/.pki/nssdb` will fail to open at runtime even though `certutil`
+   succeeded at build time. The fix is to copy the pre-built DB to a writable
+   location (e.g. `/tmp/.pki/nssdb`) at container startup — before Cloudprober's
+   Playwright subprocess launches — and point `$HOME` there.

--- a/docs/content/docs/faq/troubleshooting.md
+++ b/docs/content/docs/faq/troubleshooting.md
@@ -224,5 +224,6 @@ containers:
         mountPath: /nss-home
 ```
 
-Cloudprober passes its own environment on to the Playwright subprocess, so
-setting `HOME` on the pod is enough for Chromium to find the database.
+If the main container runs as a non-root user, run the init container as that
+same uid (e.g. set `runAsUser` at the pod level) so the database it creates is
+readable and writable by the main container.


### PR DESCRIPTION
Adds a Troubleshooting FAQ entry for BROWSER probes that fail with `ERR_CERT_AUTHORITY_INVALID` against a custom (private) CA.

Covers:
- Why the system trust store and `NODE_EXTRA_CA_CERTS` don't apply (Chromium on Linux uses the NSS database at `$HOME/.pki/nssdb`).
- Importing the CA with `certutil`.
- Two pitfalls: a $HOME/uid mismatch, and a read-only root filesystem (NSS opens the DB read-write, so its directory must be writable).
- Two fixes: override the container `command` to copy the pre-built DB to a writable location, or use an initContainer to build the DB into a shared `emptyDir`.

Resolves the discussion in #1360.