### PR TITLE
[docs] Add dual-stack (IPv4 + IPv6) probing example

### DIFF
--- a/docs/content/docs/config/probe-options.md
+++ b/docs/content/docs/config/probe-options.md
@@ -65,33 +65,10 @@ an IPv6 source IP with `ip_version: IPV4` will cause an error.
 
 ### Dual-stack targets
 
-IPv4 and IPv6 targets can't be mixed within a single probe. To monitor both,
-run one probe per family:
-
-```proto
-probe {
-  name: "net4"
-  type: PING
-  ip_version: IPV4
-  targets {
-    endpoint { name: "serverA" ip: "192.168.10.10" }
-  }
-}
-
-probe {
-  name: "net6"
-  type: PING
-  ip_version: IPV6
-  targets {
-    endpoint { name: "serverA" ip: "2001:db8::a" }
-  }
-}
-```
-
-Declaring targets with `endpoint` keeps the `dst` metric label stable across
-both probes (`dst="serverA"` in each), so the two families stay comparable for
-the same host. See
-[examples/dual_stack](https://github.com/cloudprober/cloudprober/tree/main/examples/dual_stack)
+IPv4 and IPv6 targets can't be mixed within a single probe -- to monitor both,
+run one probe per family. Declaring targets with `endpoint` keeps the `dst`
+metric label stable across the two, so a host stays comparable across families.
+See [examples/dual_stack](https://github.com/cloudprober/cloudprober/tree/main/examples/dual_stack)
 for a complete config.
 
 ## Latency Configuration

--- a/docs/content/docs/config/probe-options.md
+++ b/docs/content/docs/config/probe-options.md
@@ -63,6 +63,37 @@ When `ip_version` is not set, the behavior depends on the probe type:
 If you set both `ip_version` and `source_ip`, they must be consistent -- e.g.,
 an IPv6 source IP with `ip_version: IPV4` will cause an error.
 
+### Dual-stack targets
+
+IPv4 and IPv6 targets can't be mixed within a single probe. To monitor both,
+run one probe per family:
+
+```proto
+probe {
+  name: "net4"
+  type: PING
+  ip_version: IPV4
+  targets {
+    endpoint { name: "serverA" ip: "192.168.10.10" }
+  }
+}
+
+probe {
+  name: "net6"
+  type: PING
+  ip_version: IPV6
+  targets {
+    endpoint { name: "serverA" ip: "2001:db8::a" }
+  }
+}
+```
+
+Declaring targets with `endpoint` keeps the `dst` metric label stable across
+both probes (`dst="serverA"` in each), so the two families stay comparable for
+the same host. See
+[examples/dual_stack](https://github.com/cloudprober/cloudprober/tree/main/examples/dual_stack)
+for a complete config.
+
 ## Latency Configuration
 
 All probes export a cumulative `latency` metric. You can customize the unit,

--- a/docs/content/docs/faq/troubleshooting.md
+++ b/docs/content/docs/faq/troubleshooting.md
@@ -131,7 +131,8 @@ probe {
 ```
 
 Note that IPv4 and IPv6 targets cannot be mixed in a single probe. If you need
-to monitor both, create separate probes for each IP version.
+to monitor both, create separate probes for each IP version -- see
+[dual-stack targets](/docs/config/probe-options/#dual-stack-targets).
 
 ## Probes show high latency or timeouts
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,7 @@ This directory contains various examples demonstrating different features and us
 | Feature | Description | Subdirectory |
 |---------|-------------|--------------|
 | Additional Labels | Examples of adding custom labels to metrics | `additional_label/` |
+| Dual-stack | Probing the same hosts over both IPv4 and IPv6 | `dual_stack/` |
 | Extensions | How to extend Cloudprober with custom probes and targets | `extensions/` |
 | External Probes | Examples of external probes in different languages | `external/` |
 | File-based Targets | Configuring targets using files | `file_based_targets/` |

--- a/examples/dual_stack/README.md
+++ b/examples/dual_stack/README.md
@@ -1,0 +1,26 @@
+# Dual-stack (IPv4 + IPv6) probing
+
+IPv4 and IPv6 targets cannot be mixed within a single probe. Packet-level
+probes (PING, UDP) need to know the address family upfront to craft packets,
+and default to IPv4 when `ip_version` is not set. To monitor both families,
+run one probe per family with `ip_version` set explicitly on each.
+
+[`cloudprober.cfg`](cloudprober.cfg) pings two hosts over both families.
+
+## Keeping metrics comparable across families
+
+The example declares targets with `endpoint` (name + `ip`) rather than
+`host_names`. The `dst` metric label comes from the endpoint name, so the same
+host is directly comparable across the two probes:
+
+```
+total{ptype="ping",probe="net4",dst="serverA"} 20
+total{ptype="ping",probe="net6",dst="serverA"} 20
+```
+
+With `host_names`, `dst` would carry the raw address instead, and the v4 and v6
+series for a host would have nothing in common to join on.
+
+`endpoint` also accepts `port`, `url`, and `labels` -- see the
+[targets documentation](https://cloudprober.org/docs/how-to/targets/) for the
+full set.

--- a/examples/dual_stack/cloudprober.cfg
+++ b/examples/dual_stack/cloudprober.cfg
@@ -1,0 +1,56 @@
+# Dual-stack (IPv4 + IPv6) probing.
+#
+# IPv4 and IPv6 targets cannot be mixed within a single probe: packet-level
+# probes (PING, UDP) need to know the address family upfront to craft packets,
+# and default to IPv4 when "ip_version" is not set. To monitor both families,
+# run one probe per family and set "ip_version" explicitly on each.
+#
+# Targets are declared using "endpoint" rather than "host_names" so that each
+# host keeps a stable name in metrics regardless of address family. The "dst"
+# label comes from the endpoint name, so the same host is directly comparable
+# across the two probes:
+#
+#   total{ptype="ping",probe="net4",dst="serverA"} 20
+#   total{ptype="ping",probe="net4",dst="serverB"} 20
+#   total{ptype="ping",probe="net6",dst="serverA"} 20
+#   total{ptype="ping",probe="net6",dst="serverB"} 20
+#
+# Without endpoints -- e.g. host_names: "192.168.10.10,2001:db8::a" -- "dst"
+# would carry the raw address instead, and the v4 and v6 series for a host
+# would have nothing in common to join on.
+
+probe {
+  name: "net4"
+  type: PING
+  ip_version: IPV4
+  latency_unit: "ms"
+
+  targets {
+    endpoint {
+      name: "serverA"
+      ip: "192.168.10.10"
+    }
+    endpoint {
+      name: "serverB"
+      ip: "192.168.10.11"
+    }
+  }
+}
+
+probe {
+  name: "net6"
+  type: PING
+  ip_version: IPV6
+  latency_unit: "ms"
+
+  targets {
+    endpoint {
+      name: "serverA"
+      ip: "2001:db8::a"
+    }
+    endpoint {
+      name: "serverB"
+      ip: "2001:db8::b"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1264.

Adds `examples/dual_stack`: one PING probe per address family, with targets
declared as `endpoint` (name + `ip`) rather than `host_names`.

The endpoint form is the part worth showing. `dst` comes from the endpoint
name, so the same host is directly comparable across the two probes:

```
total{ptype="ping",probe="net4",dst="serverA"} 20
total{ptype="ping",probe="net6",dst="serverA"} 20
```

With `host_names`, `dst` carries the raw address and the v4/v6 series for a
host have nothing to join on -- which is the second half of what #1264 asked
for (`targets.endpoint` for named target metrics being hard to find).

Also links to the example from the IP Version section of probe options, and
from the IPv6 troubleshooting FAQ entry where it says to create separate
probes but doesn't show how.

Putting it under `examples/` means CI validates it via
`tools/test_example_configs.sh`, which matters here: the config in #1264
doesn't actually parse (`hostnames` is not a field; it's `host_names`).
Both the example and the inline snippet in probe-options were verified with
`-configtest`.