### PR TITLE
[tools] Actually test nested example configs, and fix the one that was broken

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ This directory contains various examples demonstrating different features and us
 | Additional Labels | Examples of adding custom labels to metrics | `additional_label/` |
 | Extensions | How to extend Cloudprober with custom probes and targets | `extensions/` |
 | External Probes | Examples of external probes in different languages | `external/` |
-| File-based Targets | Configuring targets using files | `file_based_targets/` |
+| File-based Targets | Configuring targets using files | `targets/file/` |
 | gRPC | Examples of gRPC probes and servers | `grpc/` |
 | Include Files | Splitting configuration into multiple files | `include/` |
 | OAuth | Authentication examples using OAuth | `oauth/` |

--- a/examples/targets/file/cloudprober.cfg
+++ b/examples/targets/file/cloudprober.cfg
@@ -17,10 +17,10 @@
 
 
 # file_path have any of the following prefixes:
-//  - /tmp/resources.textpb , for local files
-//  - gs://my-bucket/resources.json , for GCS Storage Bucket
-//  - s3://my-bucket/resources.json , for an S3 (compatible) Bucket
-//  - https://my-public-bucket.s3.amazonaws.com/resources.json , for a HTTP(s) endpoint
+#  - /tmp/resources.textpb , for local files
+#  - gs://my-bucket/resources.json , for GCS Storage Bucket
+#  - s3://my-bucket/resources.json , for an S3 (compatible) Bucket
+#  - https://my-public-bucket.s3.amazonaws.com/resources.json , for a HTTP(s) endpoint
 
 probe {
     name: "all-endpoints"

--- a/tools/test_example_configs.sh
+++ b/tools/test_example_configs.sh
@@ -20,6 +20,8 @@ for example in examples/**/*.cfg; do
             echo "Skipping ${example} (needs a custom build)"
             continue
             ;;
+        *)
+            ;;
     esac
     echo "Testing ${example}"
     go run ./cmd/cloudprober/. -configtest -config_file "${example}"

--- a/tools/test_example_configs.sh
+++ b/tools/test_example_configs.sh
@@ -8,7 +8,19 @@ set -euo pipefail
 # It is used by the CI system to ensure that the examples are
 # valid and up-to-date.
 
+# ** only recurses with globstar; without it these globs stop one level deep
+# and configs in nested directories go untested.
+shopt -s globstar
+
 for example in examples/**/*.cfg; do
+    # examples/extensions/ configs reference probe types that only exist in a
+    # custom-built prober, so the stock binary can't validate them.
+    case "${example}" in
+        examples/extensions/*)
+            echo "Skipping ${example} (needs a custom build)"
+            continue
+            ;;
+    esac
     echo "Testing ${example}"
     go run ./cmd/cloudprober/. -configtest -config_file "${example}"
 done


### PR DESCRIPTION
Noticed while looking at #1264.

`tools/test_example_configs.sh` globs `examples/**/*.cfg` but never enables
`globstar`, so bash treats `**` as `*` and the glob stops one level deep:

```
globstar off -> 20 files
globstar on  -> 27 files
```

The seven configs in nested directories have never been validated by CI.

One of them is broken. `examples/targets/file/cloudprober.cfg` uses `//` for
four comment lines, which textproto rejects:

```
Err: proto: syntax error (line 20:1): invalid field name: //
```

Switched those to `#`.

`examples/extensions/myprober/myprober.cfg` legitimately can't be validated by
the stock binary -- it references `[myprober.redis_probe]`, which only exists
in a custom build -- so the script now skips `examples/extensions/`
explicitly rather than leaving it accidentally uncovered. The other five
nested configs pass as-is.

With this, the script tests 26 configs and skips 1, all green.

Unrelated one-liner while in the file: the examples README table pointed at a
`file_based_targets/` directory that doesn't exist; the configs are in
`targets/file/`.