### PR TITLE
[docs] Bump js-yaml override to 4.3.1

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -4750,9 +4750,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/docs/package.json
+++ b/docs/package.json
@@ -68,7 +68,7 @@
     "semver": "^7.6.0",
     "yauzl": "^3.2.1",
     "lodash": "^4.18.0",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.1",
     "markdown-it": "^14.2.0",
     "decompress": "npm:@xhmikosr/decompress@^11.1.3"
   },


### PR DESCRIPTION
Addresses Dependabot alert #110 (GHSA-5p4m-2wfm-xmqj): quadratic CPU consumption in js-yaml !!omap resolution, affecting 4.0.0-4.3.0.

js-yaml is a transitive dev dependency (eslint, stylelint, markdownlint-cli2) pinned by the overrides block in docs/package.json, which was at ^4.2.0 and resolved to 4.3.0. Bumped the override to ^4.3.1, which fixes the issue with an O(1) key lookup in resolveYamlOmap.

Verified: npm ci + npm run build (hugo) passes.