### PR TITLE
[rds.kubernetes] Add HTTPRoute (Gateway API) target discovery

### DIFF
--- a/docs/content/docs/how-to/k8s_targets.md
+++ b/docs/content/docs/how-to/k8s_targets.md
@@ -51,7 +51,9 @@ unlike `Ingress`). The probe resolves it via DNS, and the hostname is also
 exposed as the `fqdn` label so HTTP probes set the correct Host header / SNI.
 Routes without hostnames (which inherit them from the Gateway listener) and
 wildcard hostnames (e.g. `*.example.com`) are skipped, as there is no
-specific host to probe. HTTPRoute discovery requires the
+specific host to probe, and so are `RegularExpression` path matches. If the
+route has its own `relative_url` label, paths are not expanded and you get one
+target per hostname. HTTPRoute discovery requires the
 [Gateway API](https://gateway-api.sigs.k8s.io/) CRDs to be installed in the
 cluster.
 
@@ -116,8 +118,8 @@ You can filter k8s resources using the following options:
 Discovered targets carry the Kubernetes resource's labels, plus a `namespace`
 label set to the resource's namespace. Endpoints targets also get a `node`
 label, and a `pod` label if the address belongs to a pod. Ingress and HTTPRoute
-targets get `fqdn` and `relative_url` labels. If the resource already has a label with one
-of these names, its value is kept.
+targets get `fqdn` and `relative_url` labels. If the resource already has a
+label with one of these names, its value is kept.
 
 You can use these labels in
 [additional labels]({{< ref "additional-labels.md" >}}), e.g. to add the

--- a/docs/content/docs/how-to/k8s_targets.md
+++ b/docs/content/docs/how-to/k8s_targets.md
@@ -43,6 +43,12 @@ Cloudprober supports discovery for the following k8s resources:
 - **Endpoints**
 - **Pods**
 - **Ingresses**
+- **HTTPRoutes** (Gateway API)
+
+Note: For `HTTPRoute` resources, the discovered target IP is the route's
+hostname (an `HTTPRoute` does not carry a load balancer IP in its status,
+unlike `Ingress`). The probe resolves it via DNS, and the hostname is also
+exposed as the `fqdn` label so HTTP probes set the correct Host header / SNI.
 
 #### Filters
 
@@ -167,6 +173,11 @@ rules:
   resources:
   - ingresses
   - ingresses/status
+  verbs: ["get", "list"]
+- apiGroups:
+  - "gateway.networking.k8s.io"
+  resources:
+  - httproutes
   verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/docs/content/docs/how-to/k8s_targets.md
+++ b/docs/content/docs/how-to/k8s_targets.md
@@ -51,7 +51,9 @@ unlike `Ingress`). The probe resolves it via DNS, and the hostname is also
 exposed as the `fqdn` label so HTTP probes set the correct Host header / SNI.
 Routes without hostnames (which inherit them from the Gateway listener) and
 wildcard hostnames (e.g. `*.example.com`) are skipped, as there is no
-specific host to probe.
+specific host to probe. HTTPRoute discovery requires the
+[Gateway API](https://gateway-api.sigs.k8s.io/) CRDs to be installed in the
+cluster.
 
 #### Filters
 

--- a/docs/content/docs/how-to/k8s_targets.md
+++ b/docs/content/docs/how-to/k8s_targets.md
@@ -113,8 +113,8 @@ You can filter k8s resources using the following options:
 
 Discovered targets carry the Kubernetes resource's labels, plus a `namespace`
 label set to the resource's namespace. Endpoints targets also get a `node`
-label, and a `pod` label if the address belongs to a pod. Ingress targets get
-`fqdn` and `relative_url` labels. If the resource already has a label with one
+label, and a `pod` label if the address belongs to a pod. Ingress and HTTPRoute
+targets get `fqdn` and `relative_url` labels. If the resource already has a label with one
 of these names, its value is kept.
 
 You can use these labels in

--- a/docs/content/docs/how-to/k8s_targets.md
+++ b/docs/content/docs/how-to/k8s_targets.md
@@ -49,6 +49,9 @@ Note: For `HTTPRoute` resources, the discovered target IP is the route's
 hostname (an `HTTPRoute` does not carry a load balancer IP in its status,
 unlike `Ingress`). The probe resolves it via DNS, and the hostname is also
 exposed as the `fqdn` label so HTTP probes set the correct Host header / SNI.
+Routes without hostnames (which inherit them from the Gateway listener) and
+wildcard hostnames (e.g. `*.example.com`) are skipped, as there is no
+specific host to probe.
 
 #### Filters
 

--- a/internal/rds/kubernetes/httproutes.go
+++ b/internal/rds/kubernetes/httproutes.go
@@ -34,8 +34,7 @@ type httpRouteMatch struct {
 }
 
 type httpRouteRule struct {
-	Hostnames []string
-	Matches   []httpRouteMatch
+	Matches []httpRouteMatch
 }
 
 type httpRouteInfo struct {
@@ -71,22 +70,15 @@ func (i *httpRouteInfo) metadata() kMetadata {
 func (i *httpRouteInfo) resources(f *listFilters, l *logger.Logger) (resources []*pb.Resource) {
 	resName := i.Metadata.Name
 	baseLabels := i.Metadata.Labels
-	routeHosts := i.Spec.Hostnames
 
 	for _, rule := range i.Spec.Rules {
-		// Rule-level hostnames override the route-level ones.
-		hosts := rule.Hostnames
-		if len(hosts) == 0 {
-			hosts = routeHosts
-		}
-
 		// A rule with no matches matches all paths; treat it as "/".
 		matches := rule.Matches
 		if len(matches) == 0 {
 			matches = []httpRouteMatch{{}}
 		}
 
-		for _, host := range hosts {
+		for _, host := range i.Spec.Hostnames {
 			if strings.HasPrefix(host, "*") {
 				continue
 			}

--- a/internal/rds/kubernetes/httproutes.go
+++ b/internal/rds/kubernetes/httproutes.go
@@ -61,23 +61,23 @@ func (i *httpRouteInfo) metadata() kMetadata {
 // target IP; the probe resolves it via DNS. The hostname is also exposed as
 // the "fqdn" label so HTTP probes can set the correct Host header / SNI.
 //
+// Since the hostname is the only thing we can probe, routes without
+// hostnames (which inherit them from the Gateway listener) and wildcard
+// hostnames (e.g. "*.example.com") produce no resources.
+//
 // As with ingresses, the name and labels filters apply to the expanded
 // resources rather than to the route object, because each resource carries a
 // derived name and its own fqdn and relative_url labels.
-func (i *httpRouteInfo) resources(f *listFilters, l *logger.Logger) []*pb.Resource {
+func (i *httpRouteInfo) resources(f *listFilters, l *logger.Logger) (resources []*pb.Resource) {
 	resName := i.Metadata.Name
 	baseLabels := i.Metadata.Labels
 	routeHosts := i.Spec.Hostnames
 
-	var expanded []*pb.Resource
 	for _, rule := range i.Spec.Rules {
 		// Rule-level hostnames override the route-level ones.
 		hosts := rule.Hostnames
 		if len(hosts) == 0 {
 			hosts = routeHosts
-		}
-		if len(hosts) == 0 {
-			continue
 		}
 
 		// A rule with no matches matches all paths; treat it as "/".
@@ -87,6 +87,10 @@ func (i *httpRouteInfo) resources(f *listFilters, l *logger.Logger) []*pb.Resour
 		}
 
 		for _, host := range hosts {
+			if strings.HasPrefix(host, "*") {
+				continue
+			}
+
 			for _, m := range matches {
 				path := m.Path.Value
 				if path == "" {
@@ -110,33 +114,17 @@ func (i *httpRouteInfo) resources(f *listFilters, l *logger.Logger) []*pb.Resour
 					labels["relative_url"] = path
 				}
 
-				expanded = append(expanded, &pb.Resource{
-					Name:   proto.String(nameWithPath),
-					Labels: labels,
-					Ip:     proto.String(host),
-				})
+				if f.matches(nameWithPath, labels, l) {
+					resources = append(resources, &pb.Resource{
+						Name:   proto.String(nameWithPath),
+						Labels: labels,
+						Ip:     proto.String(host),
+					})
+				}
 			}
 		}
 	}
-
-	// If no resources were generated (e.g. the route has no hostnames), emit a
-	// single resource named after the route. This is decided before filtering,
-	// so that a route whose resources are all filtered out doesn't fall back to
-	// its bare name.
-	if len(expanded) == 0 {
-		expanded = append(expanded, &pb.Resource{
-			Name:   proto.String(resName),
-			Labels: baseLabels,
-		})
-	}
-
-	var resources []*pb.Resource
-	for _, res := range expanded {
-		if f.matches(res.GetName(), res.GetLabels(), l) {
-			resources = append(resources, res)
-		}
-	}
-	return resources
+	return
 }
 
 func newHTTPRoutesLister(namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) *httpRoutesLister {

--- a/internal/rds/kubernetes/httproutes.go
+++ b/internal/rds/kubernetes/httproutes.go
@@ -1,0 +1,152 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
+	"github.com/cloudprober/cloudprober/logger"
+	"google.golang.org/protobuf/proto"
+)
+
+type httpRoutesLister = resourceLister[*httpRouteInfo]
+
+type httpRouteMatch struct {
+	Path struct {
+		Type  string
+		Value string
+	}
+}
+
+type httpRouteRule struct {
+	Hostnames []string
+	Matches   []httpRouteMatch
+}
+
+type httpRouteInfo struct {
+	Metadata kMetadata
+	Spec     struct {
+		Hostnames []string
+		Rules     []httpRouteRule
+	}
+}
+
+func (i *httpRouteInfo) metadata() kMetadata {
+	return i.Metadata
+}
+
+// resources returns RDS resources corresponding to an HTTPRoute resource.
+// Each route can have multiple hostnames and rules, and each rule can in turn
+// have multiple path matches. We emit one RDS resource per (hostname, path)
+// pair, mirroring how ingresses are expanded.
+//
+// Note that, unlike ingresses, an HTTPRoute does not carry a load balancer IP
+// in its status. The address to connect to is the parent Gateway's address,
+// which is not resolved here. We therefore use the route hostname as the
+// target IP; the probe resolves it via DNS. The hostname is also exposed as
+// the "fqdn" label so HTTP probes can set the correct Host header / SNI.
+//
+// As with ingresses, the name and labels filters apply to the expanded
+// resources rather than to the route object, because each resource carries a
+// derived name and its own fqdn and relative_url labels.
+func (i *httpRouteInfo) resources(f *listFilters, l *logger.Logger) []*pb.Resource {
+	resName := i.Metadata.Name
+	baseLabels := i.Metadata.Labels
+	routeHosts := i.Spec.Hostnames
+
+	var expanded []*pb.Resource
+	for _, rule := range i.Spec.Rules {
+		// Rule-level hostnames override the route-level ones.
+		hosts := rule.Hostnames
+		if len(hosts) == 0 {
+			hosts = routeHosts
+		}
+		if len(hosts) == 0 {
+			continue
+		}
+
+		// A rule with no matches matches all paths; treat it as "/".
+		matches := rule.Matches
+		if len(matches) == 0 {
+			matches = []httpRouteMatch{{}}
+		}
+
+		for _, host := range hosts {
+			for _, m := range matches {
+				path := m.Path.Value
+				if path == "" {
+					path = "/"
+				}
+
+				nameWithPath := fmt.Sprintf("%s_%s", resName, host)
+				if path != "/" {
+					nameWithPath = fmt.Sprintf("%s_%s", nameWithPath, strings.Replace(path, "/", "_", -1))
+				}
+
+				// Add fqdn and url labels to the resources.
+				labels := make(map[string]string, len(baseLabels)+2)
+				for k, v := range baseLabels {
+					labels[k] = v
+				}
+				if _, ok := labels["fqdn"]; !ok {
+					labels["fqdn"] = host
+				}
+				if _, ok := labels["relative_url"]; !ok {
+					labels["relative_url"] = path
+				}
+
+				expanded = append(expanded, &pb.Resource{
+					Name:   proto.String(nameWithPath),
+					Labels: labels,
+					Ip:     proto.String(host),
+				})
+			}
+		}
+	}
+
+	// If no resources were generated (e.g. the route has no hostnames), emit a
+	// single resource named after the route. This is decided before filtering,
+	// so that a route whose resources are all filtered out doesn't fall back to
+	// its bare name.
+	if len(expanded) == 0 {
+		expanded = append(expanded, &pb.Resource{
+			Name:   proto.String(resName),
+			Labels: baseLabels,
+		})
+	}
+
+	var resources []*pb.Resource
+	for _, res := range expanded {
+		if f.matches(res.GetName(), res.GetLabels(), l) {
+			resources = append(resources, res)
+		}
+	}
+	return resources
+}
+
+func newHTTPRoutesLister(namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) *httpRoutesLister {
+	lister := &httpRoutesLister{
+		kind:      "httproutes",
+		apiPrefix: "apis/gateway.networking.k8s.io/v1",
+		namespace: namespace,
+		kClient:   kc,
+		l:         l,
+	}
+	lister.start(reEvalInterval)
+	return lister
+}

--- a/internal/rds/kubernetes/httproutes.go
+++ b/internal/rds/kubernetes/httproutes.go
@@ -62,7 +62,12 @@ func (i *httpRouteInfo) metadata() kMetadata {
 //
 // Since the hostname is the only thing we can probe, routes without
 // hostnames (which inherit them from the Gateway listener) and wildcard
-// hostnames (e.g. "*.example.com") produce no resources.
+// hostnames (e.g. "*.example.com") produce no resources. Similarly,
+// RegularExpression path matches are skipped, as they don't name a specific
+// URL.
+//
+// If the route has its own relative_url label, all resources would probe
+// that URL, so we don't expand paths and emit one resource per hostname.
 //
 // Rules that differ only in header or method matches expand to the same
 // (hostname, path) pair; we emit such a resource only once.
@@ -73,13 +78,14 @@ func (i *httpRouteInfo) metadata() kMetadata {
 func (i *httpRouteInfo) resources(f *listFilters, l *logger.Logger) (resources []*pb.Resource) {
 	resName := i.Metadata.Name
 	baseLabels := i.Metadata.resourceLabels()
+	_, urlOverride := baseLabels["relative_url"]
 	seen := make(map[string]bool)
 
 	for _, rule := range i.Spec.Rules {
 		// A rule with no matches matches all paths; treat it as "/".
 		matches := rule.Matches
-		if len(matches) == 0 {
-			matches = []httpRouteMatch{{}}
+		if len(matches) == 0 || urlOverride {
+			matches = []httpRouteMatch{{}} // one zero-value match, not zero matches
 		}
 
 		for _, host := range i.Spec.Hostnames {
@@ -88,6 +94,10 @@ func (i *httpRouteInfo) resources(f *listFilters, l *logger.Logger) (resources [
 			}
 
 			for _, m := range matches {
+				if m.Path.Type == "RegularExpression" {
+					continue
+				}
+
 				path := m.Path.Value
 				if path == "" {
 					path = "/"

--- a/internal/rds/kubernetes/httproutes.go
+++ b/internal/rds/kubernetes/httproutes.go
@@ -69,7 +69,7 @@ func (i *httpRouteInfo) metadata() kMetadata {
 // derived name and its own fqdn and relative_url labels.
 func (i *httpRouteInfo) resources(f *listFilters, l *logger.Logger) (resources []*pb.Resource) {
 	resName := i.Metadata.Name
-	baseLabels := i.Metadata.Labels
+	baseLabels := i.Metadata.resourceLabels()
 
 	for _, rule := range i.Spec.Rules {
 		// A rule with no matches matches all paths; treat it as "/".

--- a/internal/rds/kubernetes/httproutes.go
+++ b/internal/rds/kubernetes/httproutes.go
@@ -64,12 +64,16 @@ func (i *httpRouteInfo) metadata() kMetadata {
 // hostnames (which inherit them from the Gateway listener) and wildcard
 // hostnames (e.g. "*.example.com") produce no resources.
 //
+// Rules that differ only in header or method matches expand to the same
+// (hostname, path) pair; we emit such a resource only once.
+//
 // As with ingresses, the name and labels filters apply to the expanded
 // resources rather than to the route object, because each resource carries a
 // derived name and its own fqdn and relative_url labels.
 func (i *httpRouteInfo) resources(f *listFilters, l *logger.Logger) (resources []*pb.Resource) {
 	resName := i.Metadata.Name
 	baseLabels := i.Metadata.resourceLabels()
+	seen := make(map[string]bool)
 
 	for _, rule := range i.Spec.Rules {
 		// A rule with no matches matches all paths; treat it as "/".
@@ -93,6 +97,10 @@ func (i *httpRouteInfo) resources(f *listFilters, l *logger.Logger) (resources [
 				if path != "/" {
 					nameWithPath = fmt.Sprintf("%s_%s", nameWithPath, strings.Replace(path, "/", "_", -1))
 				}
+				if seen[nameWithPath] {
+					continue
+				}
+				seen[nameWithPath] = true
 
 				// Add fqdn and url labels to the resources.
 				labels := make(map[string]string, len(baseLabels)+2)

--- a/internal/rds/kubernetes/httproutes_test.go
+++ b/internal/rds/kubernetes/httproutes_test.go
@@ -50,9 +50,9 @@ func TestParseHTTPRoutesJSON(t *testing.T) {
 	}
 
 	key1 := resourceKey{"default", "rds-route"}
-	key2 := resourceKey{"default", "rule-host-route"}
+	key2 := resourceKey{"default", "api-route"}
 	if lister.cache[key1] == nil || lister.cache[key2] == nil {
-		t.Errorf("Expected routes rds-route and rule-host-route, got: %+v", lister.cache)
+		t.Errorf("Expected routes rds-route and api-route, got: %+v", lister.cache)
 	}
 }
 
@@ -69,7 +69,7 @@ func TestListHTTPRouteResources(t *testing.T) {
 	}{
 		{
 			desc:      "no filter",
-			wantNames: []string{"rds-route_foo.bar.com__health", "rds-route_foo.bar.com__rds", "rule-host-route_bar.baz.com__api"},
+			wantNames: []string{"rds-route_foo.bar.com__health", "rds-route_foo.bar.com__rds", "api-route_bar.baz.com__api"},
 			wantFQDNs: []string{"foo.bar.com", "foo.bar.com", "bar.baz.com"},
 			wantURLs:  []string{"/health", "/rds", "/api"},
 			wantIPs:   []string{"foo.bar.com", "foo.bar.com", "bar.baz.com"},
@@ -93,7 +93,7 @@ func TestListHTTPRouteResources(t *testing.T) {
 		{
 			desc:      "fqdn filter",
 			filters:   map[string]string{"labels.fqdn": "bar.baz.com"},
-			wantNames: []string{"rule-host-route_bar.baz.com__api"},
+			wantNames: []string{"api-route_bar.baz.com__api"},
 			wantFQDNs: []string{"bar.baz.com"},
 			wantURLs:  []string{"/api"},
 			wantIPs:   []string{"bar.baz.com"},
@@ -145,10 +145,10 @@ func TestListHTTPRouteResources(t *testing.T) {
 // TestHTTPRouteUnprobeableHostnames checks that routes without hostnames and
 // wildcard hostnames produce no resources, since there is nothing to probe.
 func TestHTTPRouteUnprobeableHostnames(t *testing.T) {
-	route := func(name string, routeHosts, ruleHosts []string) *httpRouteInfo {
+	route := func(name string, hosts []string) *httpRouteInfo {
 		r := &httpRouteInfo{Metadata: kMetadata{Name: name, Namespace: "default"}}
-		r.Spec.Hostnames = routeHosts
-		r.Spec.Rules = []httpRouteRule{{Hostnames: ruleHosts}}
+		r.Spec.Hostnames = hosts
+		r.Spec.Rules = []httpRouteRule{{}}
 		return r
 	}
 
@@ -159,15 +159,15 @@ func TestHTTPRouteUnprobeableHostnames(t *testing.T) {
 	}{
 		{
 			desc:  "no hostnames",
-			route: route("no-host", nil, nil),
+			route: route("no-host", nil),
 		},
 		{
-			desc:  "wildcard route hostname",
-			route: route("wildcard", []string{"*.example.com"}, nil),
+			desc:  "wildcard hostname",
+			route: route("wildcard", []string{"*.example.com"}),
 		},
 		{
 			desc:      "wildcard mixed with concrete hostname",
-			route:     route("mixed", nil, []string{"*.example.com", "foo.example.com"}),
+			route:     route("mixed", []string{"*.example.com", "foo.example.com"}),
 			wantNames: []string{"mixed_foo.example.com"},
 		},
 	}

--- a/internal/rds/kubernetes/httproutes_test.go
+++ b/internal/rds/kubernetes/httproutes_test.go
@@ -142,22 +142,55 @@ func TestListHTTPRouteResources(t *testing.T) {
 	}
 }
 
-// TestHTTPRouteNoHostnames checks that a route with no hostnames (neither
-// route-level nor rule-level) produces a single resource named after the route.
-func TestHTTPRouteNoHostnames(t *testing.T) {
-	key := resourceKey{name: "no-host-route", namespace: "default"}
-	lister := &httpRoutesLister{
-		keys: []resourceKey{key},
-		cache: map[resourceKey]*httpRouteInfo{
-			key: {Metadata: kMetadata{Name: key.name, Namespace: key.namespace}},
+// TestHTTPRouteUnprobeableHostnames checks that routes without hostnames and
+// wildcard hostnames produce no resources, since there is nothing to probe.
+func TestHTTPRouteUnprobeableHostnames(t *testing.T) {
+	route := func(name string, routeHosts, ruleHosts []string) *httpRouteInfo {
+		r := &httpRouteInfo{Metadata: kMetadata{Name: name, Namespace: "default"}}
+		r.Spec.Hostnames = routeHosts
+		r.Spec.Rules = []httpRouteRule{{Hostnames: ruleHosts}}
+		return r
+	}
+
+	tests := []struct {
+		desc      string
+		route     *httpRouteInfo
+		wantNames []string
+	}{
+		{
+			desc:  "no hostnames",
+			route: route("no-host", nil, nil),
+		},
+		{
+			desc:  "wildcard route hostname",
+			route: route("wildcard", []string{"*.example.com"}, nil),
+		},
+		{
+			desc:      "wildcard mixed with concrete hostname",
+			route:     route("mixed", nil, []string{"*.example.com", "foo.example.com"}),
+			wantNames: []string{"mixed_foo.example.com"},
 		},
 	}
 
-	resources, err := lister.listResources(&pb.ListResourcesRequest{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(resources) != 1 || resources[0].GetName() != "no-host-route" {
-		t.Errorf("expected a single resource named no-host-route, got: %+v", resources)
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			key := resourceKey{name: test.route.Metadata.Name, namespace: "default"}
+			lister := &httpRoutesLister{
+				keys:  []resourceKey{key},
+				cache: map[resourceKey]*httpRouteInfo{key: test.route},
+			}
+
+			resources, err := lister.listResources(&pb.ListResourcesRequest{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var gotNames []string
+			for _, res := range resources {
+				gotNames = append(gotNames, res.GetName())
+			}
+			if !reflect.DeepEqual(gotNames, test.wantNames) {
+				t.Errorf("gotNames: %v, wantNames: %v", gotNames, test.wantNames)
+			}
+		})
 	}
 }

--- a/internal/rds/kubernetes/httproutes_test.go
+++ b/internal/rds/kubernetes/httproutes_test.go
@@ -225,3 +225,66 @@ func TestHTTPRouteDuplicatePaths(t *testing.T) {
 		t.Errorf("expected a single resource named dup-route_foo.example.com, got: %+v", resources)
 	}
 }
+
+// TestHTTPRoutePathMatches checks the handling of RegularExpression path
+// matches, and that a relative_url label on the route disables path expansion.
+func TestHTTPRoutePathMatches(t *testing.T) {
+	match := func(typ, value string) httpRouteMatch {
+		var m httpRouteMatch
+		m.Path.Type, m.Path.Value = typ, value
+		return m
+	}
+	rules := []httpRouteRule{
+		{Matches: []httpRouteMatch{match("RegularExpression", "/api/v[0-9]+/.*"), match("PathPrefix", "/health")}},
+		{Matches: []httpRouteMatch{match("Exact", "/status")}},
+	}
+
+	tests := []struct {
+		desc      string
+		labels    map[string]string
+		wantNames []string
+		wantURLs  []string
+	}{
+		{
+			desc:      "regex match skipped",
+			wantNames: []string{"route_foo.example.com__health", "route_foo.example.com__status"},
+			wantURLs:  []string{"/health", "/status"},
+		},
+		{
+			desc:      "relative_url label, one resource per hostname",
+			labels:    map[string]string{"relative_url": "/probe"},
+			wantNames: []string{"route_foo.example.com"},
+			wantURLs:  []string{"/probe"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			key := resourceKey{name: "route", namespace: "default"}
+			route := &httpRouteInfo{Metadata: kMetadata{Name: key.name, Namespace: key.namespace, Labels: test.labels}}
+			route.Spec.Hostnames = []string{"foo.example.com"}
+			route.Spec.Rules = rules
+
+			lister := &httpRoutesLister{
+				keys:  []resourceKey{key},
+				cache: map[resourceKey]*httpRouteInfo{key: route},
+			}
+
+			resources, err := lister.listResources(&pb.ListResourcesRequest{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var gotNames, gotURLs []string
+			for _, res := range resources {
+				gotNames = append(gotNames, res.GetName())
+				gotURLs = append(gotURLs, res.GetLabels()["relative_url"])
+			}
+			if !reflect.DeepEqual(gotNames, test.wantNames) {
+				t.Errorf("gotNames: %v, wantNames: %v", gotNames, test.wantNames)
+			}
+			if !reflect.DeepEqual(gotURLs, test.wantURLs) {
+				t.Errorf("gotURLs: %v, wantURLs: %v", gotURLs, test.wantURLs)
+			}
+		})
+	}
+}

--- a/internal/rds/kubernetes/httproutes_test.go
+++ b/internal/rds/kubernetes/httproutes_test.go
@@ -202,3 +202,26 @@ func TestHTTPRouteUnprobeableHostnames(t *testing.T) {
 		})
 	}
 }
+
+// TestHTTPRouteDuplicatePaths checks that rules expanding to the same
+// (hostname, path) pair, e.g. rules that differ only in header matches,
+// produce a single resource.
+func TestHTTPRouteDuplicatePaths(t *testing.T) {
+	key := resourceKey{name: "dup-route", namespace: "default"}
+	route := &httpRouteInfo{Metadata: kMetadata{Name: key.name, Namespace: key.namespace}}
+	route.Spec.Hostnames = []string{"foo.example.com"}
+	route.Spec.Rules = []httpRouteRule{{}, {}}
+
+	lister := &httpRoutesLister{
+		keys:  []resourceKey{key},
+		cache: map[resourceKey]*httpRouteInfo{key: route},
+	}
+
+	resources, err := lister.listResources(&pb.ListResourcesRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resources) != 1 || resources[0].GetName() != "dup-route_foo.example.com" {
+		t.Errorf("expected a single resource named dup-route_foo.example.com, got: %+v", resources)
+	}
+}

--- a/internal/rds/kubernetes/httproutes_test.go
+++ b/internal/rds/kubernetes/httproutes_test.go
@@ -75,6 +75,14 @@ func TestListHTTPRouteResources(t *testing.T) {
 			wantIPs:   []string{"foo.bar.com", "foo.bar.com", "bar.baz.com"},
 		},
 		{
+			desc:      "namespace label filter",
+			filters:   map[string]string{"labels.namespace": "default"},
+			wantNames: []string{"rds-route_foo.bar.com__health", "rds-route_foo.bar.com__rds", "api-route_bar.baz.com__api"},
+			wantFQDNs: []string{"foo.bar.com", "foo.bar.com", "bar.baz.com"},
+			wantURLs:  []string{"/health", "/rds", "/api"},
+			wantIPs:   []string{"foo.bar.com", "foo.bar.com", "bar.baz.com"},
+		},
+		{
 			desc:      "name filter for host regex",
 			filters:   map[string]string{"name": ".*foo.bar.com.*"},
 			wantNames: []string{"rds-route_foo.bar.com__health", "rds-route_foo.bar.com__rds"},

--- a/internal/rds/kubernetes/httproutes_test.go
+++ b/internal/rds/kubernetes/httproutes_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
+	"google.golang.org/protobuf/proto"
+)
+
+func httpRoutesListerFromDataFile(t *testing.T) *httpRoutesLister {
+	t.Helper()
+
+	httpRoutesListFile := "./testdata/httproutes.json"
+	data, err := os.ReadFile(httpRoutesListFile)
+	if err != nil {
+		t.Fatalf("error reading test data file: %s", httpRoutesListFile)
+	}
+	keys, routes, err := parseResourceList[*httpRouteInfo](data, nil)
+	if err != nil {
+		t.Fatalf("Error while parsing http routes JSON data: %v", err)
+	}
+
+	return &httpRoutesLister{
+		keys:  keys,
+		cache: routes,
+	}
+}
+
+func TestParseHTTPRoutesJSON(t *testing.T) {
+	lister := httpRoutesListerFromDataFile(t)
+
+	if len(lister.keys) != 2 {
+		t.Errorf("Expected exactly two http routes, got: %d (%+v)", len(lister.keys), lister.cache)
+	}
+
+	key1 := resourceKey{"default", "rds-route"}
+	key2 := resourceKey{"default", "rule-host-route"}
+	if lister.cache[key1] == nil || lister.cache[key2] == nil {
+		t.Errorf("Expected routes rds-route and rule-host-route, got: %+v", lister.cache)
+	}
+}
+
+func TestListHTTPRouteResources(t *testing.T) {
+	lister := httpRoutesListerFromDataFile(t)
+
+	tests := []struct {
+		desc      string
+		filters   map[string]string
+		wantNames []string
+		wantFQDNs []string
+		wantURLs  []string
+		wantIPs   []string
+	}{
+		{
+			desc:      "no filter",
+			wantNames: []string{"rds-route_foo.bar.com__health", "rds-route_foo.bar.com__rds", "rule-host-route_bar.baz.com__api"},
+			wantFQDNs: []string{"foo.bar.com", "foo.bar.com", "bar.baz.com"},
+			wantURLs:  []string{"/health", "/rds", "/api"},
+			wantIPs:   []string{"foo.bar.com", "foo.bar.com", "bar.baz.com"},
+		},
+		{
+			desc:      "name filter for host regex",
+			filters:   map[string]string{"name": ".*foo.bar.com.*"},
+			wantNames: []string{"rds-route_foo.bar.com__health", "rds-route_foo.bar.com__rds"},
+			wantFQDNs: []string{"foo.bar.com", "foo.bar.com"},
+			wantURLs:  []string{"/health", "/rds"},
+			wantIPs:   []string{"foo.bar.com", "foo.bar.com"},
+		},
+		{
+			desc:      "name and label filter",
+			filters:   map[string]string{"name": ".*foo.bar.com.*", "labels.relative_url": "/rds"},
+			wantNames: []string{"rds-route_foo.bar.com__rds"},
+			wantFQDNs: []string{"foo.bar.com"},
+			wantURLs:  []string{"/rds"},
+			wantIPs:   []string{"foo.bar.com"},
+		},
+		{
+			desc:      "fqdn filter",
+			filters:   map[string]string{"labels.fqdn": "bar.baz.com"},
+			wantNames: []string{"rule-host-route_bar.baz.com__api"},
+			wantFQDNs: []string{"bar.baz.com"},
+			wantURLs:  []string{"/api"},
+			wantIPs:   []string{"bar.baz.com"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			var filters []*pb.Filter
+
+			for k, v := range test.filters {
+				filters = append(filters, &pb.Filter{
+					Key:   proto.String(k),
+					Value: proto.String(v),
+				})
+			}
+
+			resources, err := lister.listResources(&pb.ListResourcesRequest{Filter: filters})
+			if err != nil {
+				t.Errorf("Error while listing resources: %v", err)
+			}
+			var gotNames, gotFQDNs, gotURLs, gotIPs []string
+			for _, res := range resources {
+				gotNames = append(gotNames, res.GetName())
+				gotFQDNs = append(gotFQDNs, res.GetLabels()["fqdn"])
+				gotURLs = append(gotURLs, res.GetLabels()["relative_url"])
+				gotIPs = append(gotIPs, res.GetIp())
+			}
+
+			if !reflect.DeepEqual(gotNames, test.wantNames) {
+				t.Errorf("gotNames: %v, wantNames: %v", gotNames, test.wantNames)
+			}
+
+			if !reflect.DeepEqual(gotFQDNs, test.wantFQDNs) {
+				t.Errorf("gotFQDNs: %v, wantFQDNs: %v", gotFQDNs, test.wantFQDNs)
+			}
+
+			if !reflect.DeepEqual(gotURLs, test.wantURLs) {
+				t.Errorf("gotURLs: %v, wantURLs: %v", gotURLs, test.wantURLs)
+			}
+
+			if !reflect.DeepEqual(gotIPs, test.wantIPs) {
+				t.Errorf("gotIPs: %v, wantIPs: %v", gotIPs, test.wantIPs)
+			}
+		})
+	}
+}
+
+// TestHTTPRouteNoHostnames checks that a route with no hostnames (neither
+// route-level nor rule-level) produces a single resource named after the route.
+func TestHTTPRouteNoHostnames(t *testing.T) {
+	key := resourceKey{name: "no-host-route", namespace: "default"}
+	lister := &httpRoutesLister{
+		keys: []resourceKey{key},
+		cache: map[resourceKey]*httpRouteInfo{
+			key: {Metadata: kMetadata{Name: key.name, Namespace: key.namespace}},
+		},
+	}
+
+	resources, err := lister.listResources(&pb.ListResourcesRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resources) != 1 || resources[0].GetName() != "no-host-route" {
+		t.Errorf("expected a single resource named no-host-route, got: %+v", resources)
+	}
+}

--- a/internal/rds/kubernetes/kubernetes.go
+++ b/internal/rds/kubernetes/kubernetes.go
@@ -47,12 +47,13 @@ const DefaultProviderID = "k8s"
 
 // ResourceTypes declares resource types supported by the Kubernetes provider.
 var ResourceTypes = struct {
-	Pods, Endpoints, Services, Ingresses string
+	Pods, Endpoints, Services, Ingresses, HTTPRoutes string
 }{
 	"pods",
 	"endpoints",
 	"services",
 	"ingresses",
+	"httproutes",
 }
 
 /*
@@ -185,6 +186,9 @@ func New(c *configpb.ProviderConfig, l *logger.Logger) (*Provider, error) {
 	}
 	if c.GetIngresses() != nil {
 		p.listers[ResourceTypes.Ingresses] = newIngressesLister(c.GetNamespace(), reEvalInterval, client, l)
+	}
+	if c.GetHttpRoutes() != nil {
+		p.listers[ResourceTypes.HTTPRoutes] = newHTTPRoutesLister(c.GetNamespace(), reEvalInterval, client, l)
 	}
 
 	return p, nil

--- a/internal/rds/kubernetes/lister_test.go
+++ b/internal/rds/kubernetes/lister_test.go
@@ -78,6 +78,12 @@ func TestListerAPIPaths(t *testing.T) {
 			wantAll: "/apis/networking.k8s.io/v1/ingresses",
 			wantNS:  "/apis/networking.k8s.io/v1/namespaces/test-ns/ingresses",
 		},
+		{
+			kind:    "httproutes",
+			start:   func(ns string, kc *client) { newHTTPRoutesLister(ns, time.Hour, kc, nil) },
+			wantAll: "/apis/gateway.networking.k8s.io/v1/httproutes",
+			wantNS:  "/apis/gateway.networking.k8s.io/v1/namespaces/test-ns/httproutes",
+		},
 	}
 
 	for _, lister := range listers {

--- a/internal/rds/kubernetes/proto/config.pb.go
+++ b/internal/rds/kubernetes/proto/config.pb.go
@@ -190,6 +190,42 @@ func (*Ingresses) Descriptor() ([]byte, []int) {
 	return file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_config_proto_rawDescGZIP(), []int{3}
 }
 
+type HTTPRoutes struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HTTPRoutes) Reset() {
+	*x = HTTPRoutes{}
+	mi := &file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_config_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HTTPRoutes) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HTTPRoutes) ProtoMessage() {}
+
+func (x *HTTPRoutes) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_config_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HTTPRoutes.ProtoReflect.Descriptor instead.
+func (*HTTPRoutes) Descriptor() ([]byte, []int) {
+	return file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_config_proto_rawDescGZIP(), []int{4}
+}
+
 // Kubernetes provider config.
 type ProviderConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -209,6 +245,11 @@ type ProviderConfig struct {
 	// ingresses discovery to be enabled.
 	// Note: Ingress support is experimental and may change in future.
 	Ingresses *Ingresses `protobuf:"bytes,5,opt,name=ingresses" json:"ingresses,omitempty"`
+	// HTTPRoutes discovery options. This field should be declared for the
+	// http_routes discovery to be enabled.
+	// Note: HTTPRoute (Gateway API) support is experimental and may change in
+	// future.
+	HttpRoutes *HTTPRoutes `protobuf:"bytes,6,opt,name=http_routes,json=httpRoutes" json:"http_routes,omitempty"`
 	// Label selectors to filter resources. This is useful for large clusters.
 	// label_selector: ["app=cloudprober", "env!=dev"]
 	LabelSelector []string `protobuf:"bytes,20,rep,name=label_selector,json=labelSelector" json:"label_selector,omitempty"`
@@ -230,7 +271,7 @@ const (
 
 func (x *ProviderConfig) Reset() {
 	*x = ProviderConfig{}
-	mi := &file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_config_proto_msgTypes[4]
+	mi := &file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_config_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -242,7 +283,7 @@ func (x *ProviderConfig) String() string {
 func (*ProviderConfig) ProtoMessage() {}
 
 func (x *ProviderConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_config_proto_msgTypes[4]
+	mi := &file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_config_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -255,7 +296,7 @@ func (x *ProviderConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProviderConfig.ProtoReflect.Descriptor instead.
 func (*ProviderConfig) Descriptor() ([]byte, []int) {
-	return file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_config_proto_rawDescGZIP(), []int{4}
+	return file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_config_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ProviderConfig) GetNamespace() string {
@@ -289,6 +330,13 @@ func (x *ProviderConfig) GetServices() *Services {
 func (x *ProviderConfig) GetIngresses() *Ingresses {
 	if x != nil {
 		return x.Ingresses
+	}
+	return nil
+}
+
+func (x *ProviderConfig) GetHttpRoutes() *HTTPRoutes {
+	if x != nil {
+		return x.HttpRoutes
 	}
 	return nil
 }
@@ -330,13 +378,17 @@ const file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_conf
 	"\tEndpoints\"\n" +
 	"\n" +
 	"\bServices\"\v\n" +
-	"\tIngresses\"\xea\x03\n" +
+	"\tIngresses\"\f\n" +
+	"\n" +
+	"HTTPRoutes\"\xb3\x04\n" +
 	"\x0eProviderConfig\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x124\n" +
 	"\x04pods\x18\x02 \x01(\v2 .cloudprober.rds.kubernetes.PodsR\x04pods\x12C\n" +
 	"\tendpoints\x18\x03 \x01(\v2%.cloudprober.rds.kubernetes.EndpointsR\tendpoints\x12@\n" +
 	"\bservices\x18\x04 \x01(\v2$.cloudprober.rds.kubernetes.ServicesR\bservices\x12C\n" +
-	"\tingresses\x18\x05 \x01(\v2%.cloudprober.rds.kubernetes.IngressesR\tingresses\x12%\n" +
+	"\tingresses\x18\x05 \x01(\v2%.cloudprober.rds.kubernetes.IngressesR\tingresses\x12G\n" +
+	"\vhttp_routes\x18\x06 \x01(\v2&.cloudprober.rds.kubernetes.HTTPRoutesR\n" +
+	"httpRoutes\x12%\n" +
 	"\x0elabel_selector\x18\x14 \x03(\tR\rlabelSelector\x12,\n" +
 	"\x12api_server_address\x18[ \x01(\tR\x10apiServerAddress\x12?\n" +
 	"\n" +
@@ -355,26 +407,28 @@ func file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_confi
 	return file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_config_proto_rawDescData
 }
 
-var file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_config_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_config_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_config_proto_goTypes = []any{
 	(*Pods)(nil),            // 0: cloudprober.rds.kubernetes.Pods
 	(*Endpoints)(nil),       // 1: cloudprober.rds.kubernetes.Endpoints
 	(*Services)(nil),        // 2: cloudprober.rds.kubernetes.Services
 	(*Ingresses)(nil),       // 3: cloudprober.rds.kubernetes.Ingresses
-	(*ProviderConfig)(nil),  // 4: cloudprober.rds.kubernetes.ProviderConfig
-	(*proto.TLSConfig)(nil), // 5: cloudprober.tlsconfig.TLSConfig
+	(*HTTPRoutes)(nil),      // 4: cloudprober.rds.kubernetes.HTTPRoutes
+	(*ProviderConfig)(nil),  // 5: cloudprober.rds.kubernetes.ProviderConfig
+	(*proto.TLSConfig)(nil), // 6: cloudprober.tlsconfig.TLSConfig
 }
 var file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_config_proto_depIdxs = []int32{
 	0, // 0: cloudprober.rds.kubernetes.ProviderConfig.pods:type_name -> cloudprober.rds.kubernetes.Pods
 	1, // 1: cloudprober.rds.kubernetes.ProviderConfig.endpoints:type_name -> cloudprober.rds.kubernetes.Endpoints
 	2, // 2: cloudprober.rds.kubernetes.ProviderConfig.services:type_name -> cloudprober.rds.kubernetes.Services
 	3, // 3: cloudprober.rds.kubernetes.ProviderConfig.ingresses:type_name -> cloudprober.rds.kubernetes.Ingresses
-	5, // 4: cloudprober.rds.kubernetes.ProviderConfig.tls_config:type_name -> cloudprober.tlsconfig.TLSConfig
-	5, // [5:5] is the sub-list for method output_type
-	5, // [5:5] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	4, // 4: cloudprober.rds.kubernetes.ProviderConfig.http_routes:type_name -> cloudprober.rds.kubernetes.HTTPRoutes
+	6, // 5: cloudprober.rds.kubernetes.ProviderConfig.tls_config:type_name -> cloudprober.tlsconfig.TLSConfig
+	6, // [6:6] is the sub-list for method output_type
+	6, // [6:6] is the sub-list for method input_type
+	6, // [6:6] is the sub-list for extension type_name
+	6, // [6:6] is the sub-list for extension extendee
+	0, // [0:6] is the sub-list for field type_name
 }
 
 func init() {
@@ -390,7 +444,7 @@ func file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_confi
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_config_proto_rawDesc), len(file_github_com_cloudprober_cloudprober_internal_rds_kubernetes_proto_config_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/rds/kubernetes/proto/config.proto
+++ b/internal/rds/kubernetes/proto/config.proto
@@ -37,6 +37,8 @@ message Services {}
 
 message Ingresses {}
 
+message HTTPRoutes {}
+
 // Kubernetes provider config.
 message ProviderConfig {
   // Namespace to list resources for. If not specified, we default to all
@@ -59,6 +61,12 @@ message ProviderConfig {
   // ingresses discovery to be enabled.
   // Note: Ingress support is experimental and may change in future.
   optional Ingresses ingresses = 5;
+
+  // HTTPRoutes discovery options. This field should be declared for the
+  // http_routes discovery to be enabled.
+  // Note: HTTPRoute (Gateway API) support is experimental and may change in
+  // future.
+  optional HTTPRoutes http_routes = 6;
 
   // Label selectors to filter resources. This is useful for large clusters.
   // label_selector: ["app=cloudprober", "env!=dev"]

--- a/internal/rds/kubernetes/testdata/httproutes.json
+++ b/internal/rds/kubernetes/testdata/httproutes.json
@@ -1,0 +1,97 @@
+{
+  "kind": "HTTPRouteList",
+  "apiVersion": "gateway.networking.k8s.io/v1",
+  "metadata": {
+    "resourceVersion": "123456"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "rds-route",
+        "namespace": "default",
+        "labels": {
+          "app": "cloudprober"
+        }
+      },
+      "spec": {
+        "hostnames": [
+          "foo.bar.com"
+        ],
+        "parentRefs": [
+          {
+            "name": "my-gateway",
+            "kind": "Gateway",
+            "group": "gateway.networking.k8s.io"
+          }
+        ],
+        "rules": [
+          {
+            "matches": [
+              {
+                "path": {
+                  "type": "PathPrefix",
+                  "value": "/health"
+                }
+              },
+              {
+                "path": {
+                  "type": "PathPrefix",
+                  "value": "/rds"
+                }
+              }
+            ],
+            "backendRefs": [
+              {
+                "name": "cloudprober-rds",
+                "port": 9313,
+                "kind": "Service",
+                "group": ""
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "rule-host-route",
+        "namespace": "default",
+        "labels": {
+          "app": "other"
+        }
+      },
+      "spec": {
+        "parentRefs": [
+          {
+            "name": "my-gateway",
+            "kind": "Gateway",
+            "group": "gateway.networking.k8s.io"
+          }
+        ],
+        "rules": [
+          {
+            "hostnames": [
+              "bar.baz.com"
+            ],
+            "matches": [
+              {
+                "path": {
+                  "type": "Exact",
+                  "value": "/api"
+                }
+              }
+            ],
+            "backendRefs": [
+              {
+                "name": "other-svc",
+                "port": 8080,
+                "kind": "Service",
+                "group": ""
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/internal/rds/kubernetes/testdata/httproutes.json
+++ b/internal/rds/kubernetes/testdata/httproutes.json
@@ -54,13 +54,16 @@
     },
     {
       "metadata": {
-        "name": "rule-host-route",
+        "name": "api-route",
         "namespace": "default",
         "labels": {
           "app": "other"
         }
       },
       "spec": {
+        "hostnames": [
+          "bar.baz.com"
+        ],
         "parentRefs": [
           {
             "name": "my-gateway",
@@ -70,9 +73,6 @@
         ],
         "rules": [
           {
-            "hostnames": [
-              "bar.baz.com"
-            ],
             "matches": [
               {
                 "path": {

--- a/targets/k8s.go
+++ b/targets/k8s.go
@@ -92,6 +92,9 @@ func parseConfig(pb *targetspb.K8STargets) (*k8sconfigpb.ProviderConfig, string,
 	case *targetspb.K8STargets_Pods:
 		pc.Pods = &k8sconfigpb.Pods{}
 		return pc, "pods", pb.GetPods()
+	case *targetspb.K8STargets_HttpRoutes:
+		pc.HttpRoutes = &k8sconfigpb.HTTPRoutes{}
+		return pc, "httproutes", pb.GetHttpRoutes()
 	}
 
 	return nil, "", ""

--- a/targets/k8s_test.go
+++ b/targets/k8s_test.go
@@ -61,6 +61,16 @@ func Test_parseConfig(t *testing.T) {
 			wantName: "pods",
 		},
 		{
+			cfg: `http_routes:".*"`,
+			wantPC: &k8sconfigpb.ProviderConfig{
+				Namespace:  proto.String(""),
+				HttpRoutes: &k8sconfigpb.HTTPRoutes{},
+				ReEvalSec:  proto.Int32(30),
+			},
+			wantName:  "httproutes",
+			wantValue: ".*",
+		},
+		{
 			cfg: `namespace:"dev"
 			      endpoints:".*-service"
 				  labelSelector:["k8s-app","role!=canary"]`,

--- a/targets/proto/targets.pb.go
+++ b/targets/proto/targets.pb.go
@@ -139,6 +139,7 @@ type K8STargets struct {
 	//	*K8STargets_Endpoints
 	//	*K8STargets_Ingresses
 	//	*K8STargets_Pods
+	//	*K8STargets_HttpRoutes
 	Resources isK8STargets_Resources `protobuf_oneof:"resources"`
 	// portFilter can be used to filter resources by port name. This is useful
 	// for resources like endpoints and services, where each resource may have
@@ -242,6 +243,15 @@ func (x *K8STargets) GetPods() string {
 	return ""
 }
 
+func (x *K8STargets) GetHttpRoutes() string {
+	if x != nil {
+		if x, ok := x.Resources.(*K8STargets_HttpRoutes); ok {
+			return x.HttpRoutes
+		}
+	}
+	return ""
+}
+
 func (x *K8STargets) GetPortFilter() string {
 	if x != nil && x.PortFilter != nil {
 		return *x.PortFilter
@@ -283,6 +293,10 @@ type K8STargets_Pods struct {
 	Pods string `protobuf:"bytes,6,opt,name=pods,oneof"`
 }
 
+type K8STargets_HttpRoutes struct {
+	HttpRoutes string `protobuf:"bytes,7,opt,name=http_routes,json=httpRoutes,oneof"`
+}
+
 func (*K8STargets_Services) isK8STargets_Resources() {}
 
 func (*K8STargets_Endpoints) isK8STargets_Resources() {}
@@ -290,6 +304,8 @@ func (*K8STargets_Endpoints) isK8STargets_Resources() {}
 func (*K8STargets_Ingresses) isK8STargets_Resources() {}
 
 func (*K8STargets_Pods) isK8STargets_Resources() {}
+
+func (*K8STargets_HttpRoutes) isK8STargets_Resources() {}
 
 type DNSOptions struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -809,7 +825,7 @@ const file_github_com_cloudprober_cloudprober_targets_proto_targets_proto_rawDes
 	"\x12rds_server_options\x18\x01 \x01(\v2).cloudprober.rds.ClientConf.ServerOptionsR\x10rdsServerOptions\x12#\n" +
 	"\rresource_path\x18\x02 \x01(\tR\fresourcePath\x12/\n" +
 	"\x06filter\x18\x03 \x03(\v2\x17.cloudprober.rds.FilterR\x06filter\x126\n" +
-	"\tip_config\x18\x04 \x01(\v2\x19.cloudprober.rds.IPConfigR\bipConfig\"\xea\x02\n" +
+	"\tip_config\x18\x04 \x01(\v2\x19.cloudprober.rds.IPConfigR\bipConfig\"\x8d\x03\n" +
 	"\n" +
 	"K8sTargets\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12$\n" +
@@ -817,7 +833,9 @@ const file_github_com_cloudprober_cloudprober_targets_proto_targets_proto_rawDes
 	"\bservices\x18\x03 \x01(\tH\x00R\bservices\x12\x1e\n" +
 	"\tendpoints\x18\x04 \x01(\tH\x00R\tendpoints\x12\x1e\n" +
 	"\tingresses\x18\x05 \x01(\tH\x00R\tingresses\x12\x14\n" +
-	"\x04pods\x18\x06 \x01(\tH\x00R\x04pods\x12\x1e\n" +
+	"\x04pods\x18\x06 \x01(\tH\x00R\x04pods\x12!\n" +
+	"\vhttp_routes\x18\a \x01(\tH\x00R\n" +
+	"httpRoutes\x12\x1e\n" +
 	"\n" +
 	"portFilter\x18\n" +
 	" \x01(\tR\n" +
@@ -919,6 +937,7 @@ func file_github_com_cloudprober_cloudprober_targets_proto_targets_proto_init() 
 		(*K8STargets_Endpoints)(nil),
 		(*K8STargets_Ingresses)(nil),
 		(*K8STargets_Pods)(nil),
+		(*K8STargets_HttpRoutes)(nil),
 	}
 	file_github_com_cloudprober_cloudprober_targets_proto_targets_proto_msgTypes[3].OneofWrappers = []any{
 		(*TargetsDef_HostNames)(nil),

--- a/targets/proto/targets.proto
+++ b/targets/proto/targets.proto
@@ -61,6 +61,7 @@ message K8sTargets {
     string endpoints = 4;
     string ingresses = 5;
     string pods = 6;
+    string http_routes = 7;
   }
 
   // portFilter can be used to filter resources by port name. This is useful


### PR DESCRIPTION
Adds Kubernetes target discovery for Gateway API `HTTPRoute` resources, analogous to the existing `Ingress` support. Closes #1409.

## What it does
- New `http_routes` resource type for the `k8s` targets provider.
- Each `HTTPRoute` is expanded into one RDS resource per (hostname x match path), mirroring how ingresses are expanded:
  - `name`: `<route>_<host>_<path>`
  - `fqdn` label: hostname
  - `relative_url` label: match path (`/` for rules without a path match)
  - `namespace` label, as for the other kinds (#1489)
- Hostnames come from `spec.hostnames` (Gateway API has no rule-level hostnames).
- Routes without hostnames (they inherit them from the Gateway listener) and wildcard hostnames (e.g. `*.example.com`) produce no resources, since there is no specific host to probe.
- `RegularExpression` path matches are skipped, as they don't name a specific URL.
- If the route has its own `relative_url` label, paths are not expanded: one resource per hostname, named `<route>_<host>`.
- Rules that expand to the same (hostname, path), e.g. rules differing only in header or method matches, produce a single resource.

## Note on the target IP
Unlike `Ingress`, an `HTTPRoute` does not carry a load balancer IP in its status (the address lives on the parent `Gateway`). This change uses the route hostname as the target IP; the probe resolves it via DNS, and the `fqdn` label drives the Host header / SNI. Resolving the parent `Gateway.status.addresses` for a real IP is a possible follow-up, as is using the route's status conditions as a readiness signal.

Requires the Gateway API CRDs to be installed in the cluster.

## Config
```
targets {
  k8s {
    http_routes: ".*"
  }
}
```

## Tests
- `httproutes_test.go` + `testdata/httproutes.json` cover parsing, listing, and name/label/namespace filtering, skipping of hostname-less and wildcard routes and regex paths, the `relative_url` label override, and deduplication of identical (hostname, path) pairs.
- `targets/k8s_test.go` covers the `http_routes` config.
