### PR TITLE
[test] Fix Go 1.26 Windows failure in probes/common/command by sorting env list

### DIFF
--- a/probes/common/command/command_test.go
+++ b/probes/common/command/command_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -42,6 +43,11 @@ func TestShellProcessSuccess(t *testing.T) {
 			exportEnvList = append(exportEnvList, env)
 		}
 	}
+	// Sort the env list to make the output independent of the order in which
+	// os.Environ() returns the variables. On Windows the environment block is
+	// sorted by the OS, while on Unix it preserves the insertion order.
+	slices.Sort(exportEnvList)
+
 	fmt.Fprintf(os.Stderr, "Running test command. Env: %s\n", strings.Join(exportEnvList, ","))
 
 	pauseTime := 50 * time.Millisecond
@@ -81,7 +87,7 @@ func testCommandExecute(t *testing.T, disableStreaming bool) {
 	wantOutput := []string{
 		"cmd \"/test/cmd\"",
 		"args \"--address=a.com,--arg2\"",
-		"env \"GO_CP_TEST_PROCESS=1,GO_CP_TEST_PIDS_FILE=pidsFile\"",
+		"env \"GO_CP_TEST_PIDS_FILE=pidsFile,GO_CP_TEST_PROCESS=1\"",
 	}
 
 	var output []string
@@ -108,7 +114,7 @@ func testCommandExecute(t *testing.T, disableStreaming bool) {
 	})
 
 	wantOutput = append(wantOutput, wantOutput...)
-	wantOutput[len(wantOutput)-1] = "env \"GO_CP_TEST_PROCESS_FAIL=1,GO_CP_TEST_PROCESS=1,GO_CP_TEST_PIDS_FILE=pidsFile\""
+	wantOutput[len(wantOutput)-1] = "env \"GO_CP_TEST_PIDS_FILE=pidsFile,GO_CP_TEST_PROCESS=1,GO_CP_TEST_PROCESS_FAIL=1\""
 	t.Run("second-run", func(t *testing.T) {
 		os.Setenv("GO_CP_TEST_PROCESS_FAIL", "1")
 		defer os.Unsetenv("GO_CP_TEST_PROCESS_FAIL")


### PR DESCRIPTION
On Windows with Go 1.26, `TestCommand` (all subtests) in `probes/common/command` fails, e.g. [this run](https://github.com/cloudprober/cloudprober/actions/runs/32909156802/job/97999663966):

```
expected: ... "env \"GO_CP_TEST_PROCESS=1,GO_CP_TEST_PIDS_FILE=pidsFile\"" ...
actual  : ... "env \"GO_CP_TEST_PIDS_FILE=pidsFile,GO_CP_TEST_PROCESS=1\"" ...
```

## Cause

Go 1.26 added `envSorted()` to `syscall.createEnvBlock` on Windows (`src/syscall/exec_windows.go`), which sorts the child process's environment block by name (case-insensitively) before handing it to `CreateProcess`, per the [Windows requirement](https://learn.microsoft.com/en-us/windows/win32/procthread/changing-environment-variables) that "All strings in the environment block must be sorted alphabetically by name."

`TestShellProcessSuccess` (the helper subprocess) prints the `GO_CP_TEST*` variables in whatever order `os.Environ()` returns them, and `TestCommand` asserts on that exact order -- the order in which `Command.EnvVars` sets them. Under Go 1.26 the child now sees them sorted instead, so the assertion fails. Unix is unaffected: `execve` takes the env array as-is.

This is why `windows-latest` is green on main (Go 1.25.12) but red on #1427 (Go 1.26.6), even though that PR does not touch this package.

## Fix

Sort the collected list in the subprocess and write the expectations in sorted order, so the assertion no longer depends on `os.Environ()` ordering on any platform.

Split out of #1427 so the Go bump is not mixed with a test fix; #1427 needs this to go green on Windows.
