### PR TITLE
[internal/http]: http:// should not be stripped down (#1431)

### DIFF
--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -20,8 +20,6 @@ package file
 import (
 	"context"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -67,50 +65,6 @@ func parseObjectURL(objectPath string) (bucket, object string, err error) {
 	return parts[0], parts[1], nil
 }
 
-func httpLastModified(res *http.Response) (time.Time, error) {
-	t, err := time.Parse(time.RFC1123, res.Header.Get("Last-Modified"))
-	if err != nil {
-		return zeroTime, fmt.Errorf("error parsing Last-Modified header: %v", err)
-	}
-	return t, nil
-}
-
-func readFileFromHTTP(ctx context.Context, fileURL string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", fileURL, nil)
-	if err != nil {
-		return nil, err
-	}
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("got error while retrieving HTTP object, http status: %s, status code: %d", res.Status, res.StatusCode)
-	}
-
-	defer res.Body.Close()
-	return io.ReadAll(res.Body)
-}
-
-func httpModTime(ctx context.Context, fileURL string) (time.Time, error) {
-	req, err := http.NewRequestWithContext(ctx, "HEAD", fileURL, nil)
-	if err != nil {
-		return zeroTime, err
-	}
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return zeroTime, err
-	}
-
-	if res.StatusCode != http.StatusOK {
-		return zeroTime, fmt.Errorf("got error while retrieving HTTP object, http status: %s, status code: %d", res.Status, res.StatusCode)
-	}
-
-	defer res.Body.Close()
-	return httpLastModified(res)
-}
-
 func substituteEnvVariables(content []byte) []byte {
 	return []byte(os.ExpandEnv(string(content)))
 }
@@ -149,7 +103,7 @@ func ReadFile(ctx context.Context, fname string, readOptions ...ReadOption) ([]b
 
 	for prefix, f := range prefixToReadfunc {
 		if strings.HasPrefix(fname, prefix) {
-			return processContent(f(ctx, fname[len(prefix):]))
+			return processContent(f(ctx, fname))
 		}
 	}
 	return processContent(os.ReadFile(fname))
@@ -178,7 +132,7 @@ func ReadWithCache(ctx context.Context, fname string, refreshInterval time.Durat
 func ModTime(ctx context.Context, fname string) (time.Time, error) {
 	for prefix, f := range prefixToModTimeFunc {
 		if strings.HasPrefix(fname, prefix) {
-			return f(ctx, fname[len(prefix):])
+			return f(ctx, fname)
 		}
 	}
 

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -16,6 +16,8 @@ package file
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -39,8 +41,8 @@ func createTempFile(t *testing.T, b []byte) string {
 	return tmpfile.Name()
 }
 
-func testReadFile(ctx context.Context, path string) ([]byte, error) {
-	return []byte("content-for-" + path), nil
+func testReadFile(ctx context.Context, fname string) ([]byte, error) {
+	return []byte("content-for-" + strings.TrimPrefix(fname, "test://")), nil
 }
 
 func TestReadFile(t *testing.T) {
@@ -73,6 +75,22 @@ func TestReadFile(t *testing.T) {
 				t.Errorf("ReadFile(%s) = %s, expected=%s", path, string(b), expectedContent)
 			}
 		})
+	}
+}
+
+func TestReadFileHTTP(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("http-content"))
+	}))
+	defer ts.Close()
+
+	b, err := ReadFile(context.Background(), ts.URL)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) returned error: %v", ts.URL, err)
+	}
+
+	if string(b) != "http-content" {
+		t.Errorf("ReadFile(%s) = %s, expected=http-content", ts.URL, string(b))
 	}
 }
 

--- a/internal/file/gcs.go
+++ b/internal/file/gcs.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 	"time"
 
 	"golang.org/x/oauth2/google"
@@ -59,8 +60,8 @@ func gcsRequest(ctx context.Context, method, objectPath string) (*http.Response,
 	return res, nil
 }
 
-func readFileFromGCS(ctx context.Context, objectPath string) ([]byte, error) {
-	res, err := gcsRequest(ctx, "GET", objectPath)
+func readFileFromGCS(ctx context.Context, fname string) ([]byte, error) {
+	res, err := gcsRequest(ctx, "GET", strings.TrimPrefix(fname, "gs://"))
 	if err != nil {
 		return nil, err
 	}
@@ -69,8 +70,8 @@ func readFileFromGCS(ctx context.Context, objectPath string) ([]byte, error) {
 	return io.ReadAll(res.Body)
 }
 
-func gcsModTime(ctx context.Context, objectPath string) (time.Time, error) {
-	res, err := gcsRequest(ctx, "HEAD", objectPath)
+func gcsModTime(ctx context.Context, fname string) (time.Time, error) {
+	res, err := gcsRequest(ctx, "HEAD", strings.TrimPrefix(fname, "gs://"))
 	if err != nil {
 		return zeroTime, err
 	}

--- a/internal/file/http.go
+++ b/internal/file/http.go
@@ -1,0 +1,53 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+func httpLastModified(res *http.Response) (time.Time, error) {
+	t, err := time.Parse(time.RFC1123, res.Header.Get("Last-Modified"))
+	if err != nil {
+		return zeroTime, fmt.Errorf("error parsing Last-Modified header: %v", err)
+	}
+	return t, nil
+}
+
+func readFileFromHTTP(ctx context.Context, fileURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", fileURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("got error while retrieving HTTP object, http status: %s, status code: %d", res.Status, res.StatusCode)
+	}
+
+	defer res.Body.Close()
+	return io.ReadAll(res.Body)
+}
+
+func httpModTime(ctx context.Context, fileURL string) (time.Time, error) {
+	req, err := http.NewRequestWithContext(ctx, "HEAD", fileURL, nil)
+	if err != nil {
+		return zeroTime, err
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return zeroTime, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return zeroTime, fmt.Errorf("got error while retrieving HTTP object, http status: %s, status code: %d", res.Status, res.StatusCode)
+	}
+
+	defer res.Body.Close()
+	return httpLastModified(res)
+}

--- a/internal/file/s3.go
+++ b/internal/file/s3.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -30,8 +31,8 @@ import (
 
 // readFileFromS3 reads a file using an S3 Bucket URL
 // s3://bucket-name/path/to/file.txt
-func readFileFromS3(ctx context.Context, objectPath string) ([]byte, error) {
-	bucket, object, err := parseObjectURL(objectPath)
+func readFileFromS3(ctx context.Context, fname string) ([]byte, error) {
+	bucket, object, err := parseObjectURL(strings.TrimPrefix(fname, "s3://"))
 	if err != nil {
 		return nil, err
 	}
@@ -48,15 +49,15 @@ func readFileFromS3(ctx context.Context, objectPath string) ([]byte, error) {
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve file (%s): %v", objectPath, err)
+		return nil, fmt.Errorf("failed to retrieve file (%s): %v", fname, err)
 	}
 	defer result.Body.Close()
 
 	return io.ReadAll(result.Body)
 }
 
-func s3ModTime(ctx context.Context, objectPath string) (time.Time, error) {
-	bucket, object, err := parseObjectURL(objectPath)
+func s3ModTime(ctx context.Context, fname string) (time.Time, error) {
+	bucket, object, err := parseObjectURL(strings.TrimPrefix(fname, "s3://"))
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -72,7 +73,7 @@ func s3ModTime(ctx context.Context, objectPath string) (time.Time, error) {
 		Key:    aws.String(object),
 	})
 	if err != nil {
-		return time.Time{}, fmt.Errorf("failed to retrieve file (%s): %v", objectPath, err)
+		return time.Time{}, fmt.Errorf("failed to retrieve file (%s): %v", fname, err)
 	}
 
 	return *result.LastModified, nil


### PR DESCRIPTION
Addresses #1431. 

Stripping http:// and https:// with http.NewRequestWithContext generate error and makes file_target with http not working.

I have deported the stripping into each s3 and gcs functions.

I have also moved http functions to a specific file.

Build / Docker tested + live tested