### PR TITLE
[docs] Getting Started: fix broken config snippet and wrong sample output

### DIFF
--- a/docs/content/docs/overview/getting-started.md
+++ b/docs/content/docs/overview/getting-started.md
@@ -50,13 +50,17 @@ On **Linux**, cloudprober automatically adds a `sys_metrics` system probe that
 exports memory, CPU load, uptime, disk, and network metrics -- no config needed.
 Open `http://localhost:9313/metrics` to see output like:
 
+```text
+system_load_1m{probe="sys_metrics",ptype="system"} 0.170 1756440000000
+system_uptime_sec{probe="sys_metrics",ptype="system"} 258162.780 1756440000000
+system_mem_available{probe="sys_metrics",ptype="system"} 56676487168.000 1756440000000
+system_net_aggregated_rx_bytes{probe="sys_metrics",ptype="system"} 1899739498.000
+system_disk_io_aggregated_read_bytes{probe="sys_metrics",ptype="system"} 49954401280.000
 ```
-system_load_1m 0.52
-system_mem_free 4.12e+09
-system_uptime_sec 123456
-system_disk_usage_free{disk="/dev/sda1"} 5.24e+10
-system_net_rx_bytes{intf="eth0"} 1.02e+08
-```
+
+Disk and network stats are aggregated across all devices by default. To get a
+separate series per mount point (`mount_point` label) or per interface (`iface`
+label), configure a `SYSTEM` probe yourself with `export_individual_stats: true`.
 
 On non-Linux platforms, system metrics aren't auto-added, but all configured
 probes still work.
@@ -70,8 +74,8 @@ Create a config file that probes cloudprober.org every 5 seconds:
 
 **Textproto** (`cloudprober.cfg`):
 
-```
-echo > /tmp/cloudprober.cfg <<EOF
+```bash
+cat > cloudprober.cfg <<EOF
 probe {
   name: "cloudprober_website"
   type: HTTP
@@ -86,20 +90,20 @@ probe {
 }
 EOF
 ```
+
 (Note: you can write the same config in YAML format too.
  See [config guide](/docs/config/guide/) to learn more.)
-
 
 Run with your config:
 
 ```bash
-cloudprober --config_file /tmp/cloudprober.cfg
+cloudprober --config_file cloudprober.cfg
 ```
 
 Or if using Docker:
 
 ```bash
-docker run -v $PWD/cloudprober.cfg:/etc/cloudprober.cfg \
+docker run -p 9313:9313 -v $PWD/cloudprober.cfg:/etc/cloudprober.cfg \
     ghcr.io/cloudprober/cloudprober
 ```
 
@@ -112,11 +116,13 @@ Cloudprober exports metrics in two ways by default:
 
 Prometheus-format output looks like:
 
-```
-# HELP total Total probes
-total{probe="cloudprober_website",dst="cloudprober.org"} 120
-success{probe="cloudprober_website",dst="cloudprober.org"} 120
-latency{probe="cloudprober_website",dst="cloudprober.org"} 2489734
+```text
+# TYPE total counter
+total{ptype="http",probe="cloudprober_website",dst="cloudprober.org"} 120
+# TYPE success counter
+success{ptype="http",probe="cloudprober_website",dst="cloudprober.org"} 120
+# TYPE latency counter
+latency{ptype="http",probe="cloudprober_website",dst="cloudprober.org"} 639773.455
 ```
 
 **Built-in web endpoints:**
@@ -137,7 +143,7 @@ Cloudprober supports several probe types. Here are a few common patterns:
 
 **DNS probe** -- verify a DNS resolver:
 
-```
+```protobuf
 probe {
   name: "dns_google"
   type: DNS
@@ -243,11 +249,15 @@ Other supported export backends: **OpenTelemetry**, **CloudWatch**,
 **Stackdriver**, **PostgreSQL**, **Pub/Sub**, **Datadog**, **BigQuery**.
 
 All probes export at least three counters -- `total`, `success`, and `latency`.
-Useful PromQL formulas:
+Useful PromQL queries:
 
-```
-success_ratio = rate(success[5m]) / rate(total[5m])
-avg_latency   = rate(latency[5m]) / rate(success[5m])
+```promql
+# Success ratio, over a 5m window.
+rate(success[5m]) / rate(total[5m])
+
+# Average latency. Note that latency is in microseconds unless you change
+# the probe's latency_unit.
+rate(latency[5m]) / rate(success[5m])
 ```
 
 See [Surfacers](/docs/surfacers/overview) for setup details on each backend.
@@ -271,4 +281,4 @@ See [Surfacers](/docs/surfacers/overview) for setup details on each backend.
 **Explore:**
 
 - [Example Configs on GitHub](https://github.com/cloudprober/cloudprober/tree/main/examples#cloudprober-examples)
-- [Community Slack](https://cloudprober.slack.com)
+- [Community Slack](/goto/slack-invite/)


### PR DESCRIPTION
Verified each of these against the code and against an actual `cloudprober` run.

### The config snippet wrote an empty file

```bash
echo > /tmp/cloudprober.cfg <<EOF
```

`echo` ignores stdin, so this produces a 1-byte file containing a newline. Copy-pasting the tutorial left the reader with an empty config and no error — cloudprober just started with no probe. Now uses `cat`.

The same ten lines also referred to the file three different ways (`cloudprober.cfg` in the label, `/tmp/cloudprober.cfg` in the write and run commands, `$PWD/cloudprober.cfg` in the Docker command — which therefore pointed at a file that didn't exist). Settled on `cloudprober.cfg` throughout.

### The Docker command couldn't be followed

`docker run -v ... ghcr.io/cloudprober/cloudprober` had no port mapping, while the instructions immediately before and after it say to open `localhost:9313`. Added `-p 9313:9313`.

### Both sample outputs were wrong

**System metrics.** The block claimed:

```
system_disk_usage_free{disk="/dev/sda1"} 5.24e+10
system_net_rx_bytes{intf="eth0"} 1.02e+08
```

Three problems, all confirmed in `probes/system/system_linux.go`: the labels are `mount_point` and `iface`, not `disk` and `intf`; `export_individual_stats` defaults to `false` (`probes/system/proto/config.proto:15`) so a no-config run emits `system_*_aggregated_*` with no per-device label at all; and every line carries `probe="sys_metrics",ptype="system"`, which the sample omitted. Replaced with lines copied from a real run and added a note about how to get the per-device breakdown.

**Prometheus.** The block showed `# HELP total Total probes`. The surfacer emits `# TYPE` and never `# HELP` — zero occurrences in `internal/surfacers/prometheus/prometheus.go`. The `ptype` label was missing too. Replaced with real output.

### Smaller fixes

- The PromQL wasn't PromQL: `success_ratio = rate(success[5m]) / rate(total[5m])` doesn't parse. Also noted that `latency` is in microseconds unless `latency_unit` is changed (`probes/proto/config.proto:89`).
- "Community Slack" pointed at `https://cloudprober.slack.com`, which only resolves for people who are already members — a login wall as the last link on the getting-started page. Now uses the `/goto/slack-invite/` shortlink like the rest of the site.
- Added the missing code-fence languages.

### Verification

Ran the corrected snippet verbatim; it produces a valid config and the metrics output matches what the page now shows. `hugo --gc --minify` builds clean, and markdownlint on this file goes from 13 errors to 6 (the 6 remaining are pre-existing: the `h5` heading and the install-methods table).

This is the first of a few PRs tidying up the homepage and getting-started pages.