### PR TITLE
[docs] Getting Started: document config path, all web endpoints, sys-metrics opt-out

### DIFF
--- a/docs/content/docs/overview/getting-started.md
+++ b/docs/content/docs/overview/getting-started.md
@@ -62,6 +62,10 @@ Disk and network stats are aggregated across all devices by default. To get a
 separate series per mount point (`mount_point` label) or per interface (`iface`
 label), configure a `SYSTEM` probe yourself with `export_individual_stats: true`.
 
+Pass `--disable_sys_metrics` if you'd rather not have this probe added, or
+configure a `SYSTEM` probe of your own -- cloudprober skips the automatic one
+if your config already has a `SYSTEM` probe.
+
 On non-Linux platforms, system metrics aren't auto-added, but all configured
 probes still work.
 
@@ -100,7 +104,11 @@ Run with your config:
 cloudprober --config_file cloudprober.cfg
 ```
 
-Or if using Docker:
+If you don't pass `--config_file`, cloudprober reads `/etc/cloudprober.cfg`,
+and starts with an empty config if that file doesn't exist either -- which is
+what happened in [Your First Run](#your-first-run) above.
+
+Or, with Docker. Note that the config is mounted at that same default path:
 
 ```bash
 docker run -p 9313:9313 -v $PWD/cloudprober.cfg:/etc/cloudprober.cfg \
@@ -127,12 +135,19 @@ latency{ptype="http",probe="cloudprober_website",dst="cloudprober.org"} 639773.4
 
 **Built-in web endpoints:**
 
-| Endpoint   | Description                      |
-| ---------- | -------------------------------- |
-| `/status`  | Probe status dashboard           |
-| `/config`  | Current configuration            |
-| `/metrics` | Prometheus-format metrics        |
-| `/alerts`  | Active alerts                    |
+| Endpoint          | Description                                       |
+| ----------------- | ------------------------------------------------- |
+| `/status`         | Probe status dashboard                            |
+| `/metrics`        | Prometheus-format metrics                         |
+| `/alerts`         | Active alerts                                     |
+| `/config`         | Config exactly as you provided it                 |
+| `/config-parsed`  | Config after templates and env vars are expanded  |
+| `/config-running` | Running probes, surfacers, and servers            |
+| `/logs`           | Recent log entries                                |
+| `/links`          | Index of all of the above                         |
+
+`/artifacts` also shows up when a probe produces artifacts, such as the
+screenshots from a browser probe.
 
 You can change the default port (`9313`) with the `CLOUDPROBER_PORT` environment
 variable and the listening address with `CLOUDPROBER_HOST`.


### PR DESCRIPTION
Stacked on #1433 (same file, so basing this on `main` would conflict). GitHub will retarget it to `main` once that merges.

Three things the page depended on but never told you.

### The default config path

`/etc/cloudprober.cfg` is what cloudprober reads when you don't pass `--config_file` (`config/configsource.go:28`), falling back to an empty config if that file is missing too. That fact was doing a lot of invisible work on this page: it's *why* the bare `cloudprober` in "Your First Run" produces nothing but system metrics, and it's *why* the Docker command mounts the config at that particular path. Now stated once, where both of those land.

### Half the web endpoints were missing

The table listed 4 of the 8 endpoints actually served. Added `/config-parsed`, `/config-running`, `/logs`, and `/links`, and drew the distinction between `/config` (exactly what you provided) and `/config-parsed` (after templates and env vars are expanded) — which is the one you want when debugging a templated config. Also noted that `/artifacts` appears when a probe produces artifacts, e.g. browser probe screenshots; it's registered conditionally, so it 404s otherwise.

Verified by hitting each endpoint on a running instance:

```
/status          200      /config-running  200
/config          200      /metrics         200
/config-parsed   200      /alerts          200
/links           200      /logs            200
/artifacts       404   (no browser probe configured)
```

### No way to turn off the system probe

The auto-added `sys_metrics` probe is the first output the page shows, and `--disable_sys_metrics` appeared nowhere. Also documented that configuring your own `SYSTEM` probe suppresses the automatic one (`cloudprober.go:218-226`).