### PR TITLE
[web] Point "Get started" at the guide, and make Overview a docs landing page

### DIFF
--- a/docs/content/docs/overview/cloudprober/index.md
+++ b/docs/content/docs/overview/cloudprober/index.md
@@ -7,50 +7,55 @@ menu:
       hide: true
 ---
 
-[![Docker Pulls](https://img.shields.io/docker/pulls/cloudprober/cloudprober.svg)](https://hub.docker.com/v2/repositories/cloudprober/cloudprober/)
-[![Go Build and Test](https://github.com/cloudprober/cloudprober/actions/workflows/go.yml/badge.svg)](https://github.com/cloudprober/cloudprober/actions/workflows/go.yml)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=cloudprober_cloudprober&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=cloudprober_cloudprober)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=cloudprober_cloudprober&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=cloudprober_cloudprober)
-
 Cloudprober supercharges your monitoring with active probes (a.k.a. synthetic
 monitoring) to ensure your systems—homelabs, microservices, APIs, websites, or
-cloud-to-on-prem connections—run as expected. See
-[this post](https://medium.com/@manugarg/why-you-need-probers-f38400f5830e) for
-why probers provide one of the most reliable monitoring signals.
+cloud-to-on-prem connections—run as expected.
 
-<img width="460" src="https://cloudprober.org/homepage.png"/>
+<img width="560" src="/homepage.png"
+     alt="Cloudprober probes websites, internal services and partner
+          connectivity, and feeds dashboards, SLOs and alerts"/>
 
-## Why Cloudprober?
+Probes run continuously from wherever you choose to run them, measuring what
+your users actually experience rather than what your servers report about
+themselves. See [why you need probers](https://medium.com/cloudprober/why-you-need-probers-f38400f5830e)
+for why that turns out to be one of the most reliable monitoring signals you
+can have.
 
-* **Versatile Probes**: Built-in HTTP, PING, TCP, DNS, gRPC, and UDP probes, plus custom checks via external probes.
+## Ready to try it?
 
-* **Auto-Discover Targets**: Effortlessly monitor Kubernetes, GCP, or file-based resources without constant redeployment.
+[Getting Started](/docs/overview/getting-started/) has you probing a real
+endpoint in a couple of minutes: install, one small config file, done.
 
-* **Integrate with Existing Systems**: Out-of-the-box integration with Prometheus, Grafana, DataDog, AWS CloudWatch, PostgreSQL, and Google Cloud Monitoring.
+## What's in the box
 
-* **Easy Alerts**: Stay informed via email, Slack, PagerDuty, OpsGenie, or any other HTTP based system.
+| | What you get |
+| --- | --- |
+| [Probes](/docs/overview/probe/) | HTTP, gRPC, Browser, Starlark script, DNS, PING, TCP, and UDP, plus [external](/docs/how-to/external-probe/) commands and Go [extensions](/docs/how-to/extensions/) when you need something else. |
+| [Targets](/docs/how-to/targets/) | Discovered automatically from Kubernetes, GCP, or files, so you're not redeploying every time your fleet changes. |
+| [Surfacers](/docs/surfacers/overview/) | Metrics out to Prometheus, Grafana, Datadog, CloudWatch, PostgreSQL, Google Cloud Monitoring, and more. |
+| [Alerts](/docs/how-to/alerting/) | Email, Slack, PagerDuty, Opsgenie, or any HTTP endpoint. |
+| [Config](/docs/config/guide/) | Textproto or YAML, with Go templates for when one probe block has to cover hundreds of endpoints. |
 
-* **Lightweight & Scalable**: Written in Go, compiles to a single binary, and runs efficiently as a standalone app or Docker container.
+Written in Go, it compiles to a single binary and runs as happily on a
+Raspberry Pi as it does across a global fleet.
 
-* **Custom Metrics**: Flexible latency histograms and configurable labels for precise insights.
+## Learn more
 
-* **Extensible**: Easily add new probe types, targets, or monitoring systems.
+* Coming from Prometheus Blackbox Exporter? See how the two compare:
+  [Prometheus Blackbox Exporter vs Cloudprober](https://medium.com/cloudprober/prometheus-blackbox-exporter-vs-cloudprober-08a1d3beeda2).
 
-## Learn More
-
-* If you're familiar with Prometheus Blackbox Exporter, see how Cloudprober stacks against it: [Prometheus Blackbox Exporter vs Cloudprober](https://medium.com/cloudprober/prometheus-blackbox-exporter-vs-cloudprober-08a1d3beeda2).
-  
-* If you're not very familiar with the blackbox/synthetic monitoring paradigm, take a look at [why you need probers](https://medium.com/cloudprober/why-you-need-probers-f38400f5830e).
+* New to the blackbox/synthetic monitoring paradigm?
+  [Why you need probers](https://medium.com/cloudprober/why-you-need-probers-f38400f5830e).
 
 * Cloudprober's [origin story](https://medium.com/cloudprober/story-of-cloudprober-5ac1dbc0066c).
-  
-* How [DoorDash](https://careersatdoordash.com/blog/infra-prober-active-infrastructure-monitor/) & [Hostinger](https://www.hostinger.com/blog/cloudprober-explained-the-way-we-use-it-at-hostinger) use Cloudprober.
 
-## Get Started
+* How [DoorDash](https://careersatdoordash.com/blog/infra-prober-active-infrastructure-monitor/)
+  and [Hostinger](https://www.hostinger.com/blog/cloudprober-explained-the-way-we-use-it-at-hostinger)
+  use Cloudprober.
 
-Jump in with our [Getting Started](https://cloudprober.org/docs/overview/getting-started/) guide and start monitoring your systems in minutes.
+## Join the community
 
-## Join the Community
-
-Join our [Slack](https://join.slack.com/t/cloudprober/shared_invite/enQtNjA1OTkyOTk3ODc3LWQzZDM2ZWUyNTI0M2E4NmM4NTIyMjM5M2E0MDdjMmU1NGQ3NWNiMjU4NTViMWMyMjg0M2QwMDhkZGZjZmFlNGE), or discuss on [Github](https://github.com/cloudprober/cloudprober/discussions). Help shape Cloudprober's future by commenting
-[here](https://github.com/cloudprober/cloudprober/discussions/121).
+Join our [Slack](/goto/slack-invite/), or discuss on
+[GitHub](https://github.com/cloudprober/cloudprober/discussions). And if you're
+already running it, tell us about it in
+[How do you use Cloudprober?](https://github.com/cloudprober/cloudprober/discussions/121)

--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -494,6 +494,20 @@
   [data-dark-mode] .cp-logo-grid .darker  { filter: grayscale(100%) invert(85%) brightness(150%); }
   [data-dark-mode] .cp-logo-grid .lighter { filter: grayscale(100%) invert(75%); }
   [data-dark-mode] .cp-logo-grid .apple-fix { filter: grayscale(100%) invert(95%) !important; }
+  .cp-trusted-note {
+    margin: 1.5rem 0 0;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+  }
+  body.home .cp-trusted-note a {
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 1px;
+  }
+  body.home .cp-trusted-note a:hover {
+    color: var(--text);
+    border-bottom-color: var(--text-muted);
+  }
   .cp-logo-list {
     display: none;
     max-width: 720px;
@@ -960,7 +974,7 @@
     Runs anywhere — from a Raspberry Pi to global fleets.
   </p>
   <div class="cp-hero-ctas">
-    <a class="cp-btn-hero-primary" href="/docs/overview/cloudprober/">
+    <a class="cp-btn-hero-primary" href="/docs/overview/getting-started/">
       Get started
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px;">
         <path d="M5 12h14M13 5l7 7-7 7"/>
@@ -1003,6 +1017,10 @@
     <strong>Google, Tesla, Snowflake, Apple, DoorDash, Uber, Cloudflare, Walmart,
     Robinhood, Okta, Goldman Sachs, JPMorgan Chase, Hostinger, DigitalOcean,
     Disney+, Yahoo Japan</strong>, and more.
+  </p>
+
+  <p class="cp-trusted-note">
+    <a href="https://hub.docker.com/r/cloudprober/cloudprober" target="_blank" rel="noopener">20M+ container pulls</a>
   </p>
 </section>
 
@@ -1316,7 +1334,7 @@
 <section class="cp-closing-cta" aria-label="Get started">
   <p>
     Start detecting failures before your users do.
-    <a class="cp-closing-cta-link" href="/docs/overview/cloudprober/">Get started</a>
+    <a class="cp-closing-cta-link" href="/docs/overview/getting-started/">Get started</a>
   </p>
 </section>
 


### PR DESCRIPTION
### "Get started" didn't go to Getting Started

Both CTAs — the hero button and the closing one — pointed at `/docs/overview/cloudprober/`. That page opens with four CI badges, then restates the homepage (its "Why Cloudprober?" bullets cover the same ground as the capability cards; its DoorDash and Hostinger links the same ground as the testimonials), and only near the bottom says "Jump in with our Getting Started guide" — a second click. Two clicks and a redundant page between wanting to start and starting.

Both now go straight to `/docs/overview/getting-started/`.

### Overview becomes the docs landing page

It can't be deleted — it's the section landing page for "Get Started" in both the main nav and the docs sidebar (`config/_default/menus/menus.toml`). But it no longer has to be a second homepage:

- **Dropped the four CI badges.** Docker pulls, build status, SonarCloud security and maintainability ratings are README furniture on a docs page.
- **Replaced the marketing bullets with a table where every row is a door into the docs** — probes, targets, surfacers, alerts, config. Arriving from the sidebar now puts you one click from the thing you came for.
- **Kept what this page uniquely offered**: the Blackbox Exporter comparison, the origin story, the "why you need probers" piece, and the DoorDash and Hostinger write-ups.

### Docker pulls move to the homepage

One of those four badges was worth keeping, just not as a badge. Build status and code-quality ratings say nothing to a reader; **21.7M pulls is adoption evidence**. It now sits as a quiet line under the logo strip, where it reinforces the claim that band already makes — the logos say *who* runs this, the pull count says *how much*.

Two decisions worth recording:

- **Written as a floor ("20M+"), not the exact figure.** Docker Hub reports 21,707,442 today, and the `ghcr.io` images Getting Started actually points people at publish no public pull count, so the true number is higher by an unknown amount. A rounded floor stays true for years.
- **Hardcoded, not fetched.** Docker Hub's API returns 200 but sends no `access-control-allow-origin` header, so the `fetch()` pattern the star counter uses would be blocked from the browser. A shields.io `<img>` would work but reintroduces the badge look and a third-party image on the homepage. The number's precision doesn't matter, so a static floor is the right trade.

Fair warning on the counter-argument: Docker Hub pull counts are soft — CI runs, layer checks and k8s node re-pulls all count — so it's deliberately styled as a muted footnote rather than a headline stat, to avoid a soft number sitting loudly next to a hard one (Google, Tesla, Snowflake *in production*). Easy to drop if you'd rather the logos stand alone.

### Smaller fixes on the Overview page

- The diagram was hardcoded to `https://cloudprober.org/homepage.png`, so it broke in local builds and previews. Now `/homepage.png`, resolved against `baseURL`. Also gave it alt text, which it had none of.
- Slack link now uses the `/goto/slack-invite/` shortlink.
- "Help shape Cloudprober's future by commenting [here]" now names the discussion it links to ("How do you use Cloudprober?"), which is more useful and fixes the non-descriptive link text.

markdownlint on the Overview page: **14 errors → 1** (the remaining one is `MD033` for the `<img>` tag, which is there for the `width` attribute and was present before).

### Verification

Screenshotted the new line in light and dark, desktop and mobile — on mobile the logo grid is hidden and it correctly falls below the text fallback list. Checked at 375 / 430 / 768 / 1400px: rendered and visible at every width, no horizontal overflow. Confirmed the Docker Hub link returns 200 and that the "20M+" claim is currently true.
