### PR TITLE
[ci] Generate 'latest' config docs on docs pushes, and fail loudly

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -50,7 +50,15 @@ jobs:
           git checkout -b gh-pages-github-action gh-pages
 
       - name: Generate config docs
-        run: tools/gen_config_docs.sh
+        # The bare call generates docs for the current branch (config/main/).
+        # The 'latest' call regenerates config/latest/ and the non-versioned
+        # config/ pages, which are otherwise absent from the content tree on a
+        # docs push, and so drop out of the sitemap, RSS and search index that
+        # Hugo rebuilds from content. Output is derived from the latest release
+        # tarball, so it is identical between runs.
+        run: |
+          tools/gen_config_docs.sh
+          tools/gen_config_docs.sh latest
 
       - name: Build pages
         run: |

--- a/tools/gen_config_docs.sh
+++ b/tools/gen_config_docs.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 
+# Fail on error, on unset variables, and on any failure within a pipeline.
+# Without this the script would sail past a missing protodoc or a failed
+# download and exit 0 having generated nothing.
+set -euo pipefail
+
 # To generate config docs for a specific version, copy this script to a
 # different location and checkout cloudprober repo at the desired version.
 # Then run the script with the version as an argument. For example:
 #   cp tools/gen_config_docs.sh /tmp
 #   git checkout v0.13.7
 #   /tmp/gen_config_docs.sh v0.13.7
-DOCS_VERSION=$1
-RELEASE=$1
+# Both are optional; `set -u` requires an explicit default.
+DOCS_VERSION=${1:-}
+RELEASE=${1:-}
 
 if [[ -z "${DOCS_VERSION}" ]]; then
     DOCS_VERSION=$(git describe --exact-match --exclude tip --tags HEAD 2>/dev/null || /bin/true)
@@ -22,7 +28,15 @@ DOCS_VERSION=${DOCS_VERSION//\//_}
 ORIGINAL_DIR=$(pwd)
 
 if [[ "${RELEASE}" == "latest" ]]; then
-  RELEASE=$(curl -s https://api.github.com/repos/cloudprober/cloudprober/releases/latest | grep 'tag_name' | cut -d '"' -f4)
+  RELEASE=$(curl -s https://api.github.com/repos/cloudprober/cloudprober/releases/latest | grep 'tag_name' | cut -d '"' -f4 || true)
+  # Without this, an API hiccup leaves RELEASE empty, the tarball download
+  # below is skipped, and we'd generate "latest" from the working tree --
+  # publishing unreleased protos as the released config reference.
+  if [[ -z "${RELEASE}" ]]; then
+    echo "Could not resolve the latest release tag; refusing to generate" >&2
+    echo "'latest' config docs from the working tree." >&2
+    exit 1
+  fi
 fi
 
 if [[ ! -z "${RELEASE}" ]]; then


### PR DESCRIPTION
Fixes the sitemap/RSS/search shrinkage seen in #1438.

### Root cause

`hugo.yml` called `tools/gen_config_docs.sh` with no argument. With no argument the script picks its own version:

```bash
DOCS_VERSION=$(git describe --exact-match --exclude tip --tags HEAD 2>/dev/null || /bin/true)
if [[ -z "${DOCS_VERSION}" ]]; then
    DOCS_VERSION=$(git rev-parse --abbrev-ref HEAD)   # -> "main"
fi
```

On a main push HEAD isn't a tag, so it falls through to the branch name and generates `config/main/` only. The block that also writes `config/latest/` and the non-versioned `config/` pages is gated on `DOCS_VERSION == "latest"`, so it never ran on a docs push.

I confirmed this live: running the bare script on this branch generated `docs/content/docs/config/ci-hugo-gen-latest-config-docs/`, named after the branch.

### Why the pages stayed up while disappearing from the sitemap

Hugo builds `sitemap.xml`, `index.xml` and the search index from **content**, never from the output directory. No content, no entry. The HTML survived because `hugo --gc --minify` has no `--cleanDestinationDir` and `docs/public` is a gh-pages worktree that accumulates across builds — so the pages kept serving while being unlisted. Release builds put them back and docs pushes took them away again, so the site oscillated.

Demonstrated with a throwaway page: built with content present → in sitemap; removed the content and rebuilt → HTML still on disk and serving, gone from sitemap.

### The fix

Call `gen_config_docs.sh latest` as well. Its output is generated from the latest release tarball rather than the working tree, so it's identical between runs and adds no churn to gh-pages — it just puts those pages back in front of Hugo.

Verified locally by running both calls and building:

| | config sitemap URLs | search entries | of those, under `/docs/config/` |
|---|---|---|---|
| before (as in #1438) | 15 | 47 | 16 (`main/` only) |
| after | **40** | **72** | **41** (`main/` + `latest/` + non-versioned) |

40 matches the pre-breakage count exactly.

Older versioned snapshots (`v0.13.7` … `v0.14.4`) stay delisted, per discussion — they've been out of the sitemap since the release following each one, and remain reachable by direct link and through the version switcher.

### `set -euo pipefail`

This path now runs on every docs push instead of only on releases, and it had two silent failure modes worth closing first:

- a missing `protodoc` would generate nothing and still exit 0
- a failed release-tag lookup left `RELEASE` empty, skipped the tarball download, and generated `latest` **from the working tree** — publishing unreleased protos as the released config reference

The tag lookup now fails with a message instead of falling through. `$1` is optional so it's defaulted for `set -u`, and the `curl | grep | cut` pipeline gets `|| true` so the explicit guard reports the failure rather than `pipefail` killing the script with no explanation.

Tested all three paths: bare call exits 0, `latest` exits 0, and pointing the API at a bad URL exits 1 with the intended message.