### PR TITLE
[surfacers.prometheus] Expire stale non-timestamped metrics after 4h

### DIFF
--- a/internal/surfacers/prometheus/prometheus.go
+++ b/internal/surfacers/prometheus/prometheus.go
@@ -220,13 +220,24 @@ func New(ctx context.Context, config *configpb.SurfacerConf, opts *options.Optio
 	// is deliberately much larger than metricExpirationTime: expiring a series
 	// that a slow probe is still updating is worse -- it shows up as a gap and
 	// a counter reset -- than letting a dead one linger for a few hours.
+	if ps.c.GetStaleMetricsExpirationSec() < 0 {
+		return nil, fmt.Errorf("prometheus surfacer: stale_metrics_expiration_sec (%d) cannot be negative; use 0 to never expire", ps.c.GetStaleMetricsExpirationSec())
+	}
 	ps.staleMetricsExpiration = time.Duration(ps.c.GetStaleMetricsExpirationSec()) * time.Second
 
 	// Start a goroutine to process the incoming EventMetrics as well as
 	// the incoming web queries. To avoid data access race conditions, we do
 	// one thing at a time.
+	// Sweep at least as often as the shortest deadline we have to honor,
+	// otherwise a stale_metrics_expiration_sec below metricExpirationTime would
+	// be silently rounded up to it.
+	sweepInterval := metricExpirationTime
+	if ps.staleMetricsExpiration > 0 && ps.staleMetricsExpiration < sweepInterval {
+		sweepInterval = ps.staleMetricsExpiration
+	}
+
 	go func() {
-		staleMetricDeleteTimer := time.NewTicker(metricExpirationTime)
+		staleMetricDeleteTimer := time.NewTicker(sweepInterval)
 		defer staleMetricDeleteTimer.Stop()
 
 		for {
@@ -287,16 +298,12 @@ func (ps *PromSurfacer) isTimestamped(typ string) bool {
 // expirationAge returns how long a metric of the given prometheus type is kept
 // after its last update. A zero duration means it's never expired.
 func (ps *PromSurfacer) expirationAge(typ string) time.Duration {
-	// An explicit disable_metrics_expiration overrides everything: true turns
-	// off expiration altogether, false expires all metrics at the timestamp
-	// deadline, whether they carry a timestamp or not.
-	if ps.c != nil && ps.c.DisableMetricsExpiration != nil {
-		if ps.c.GetDisableMetricsExpiration() {
-			return 0
-		}
-		return metricExpirationTime
+	if ps.c.GetDisableMetricsExpiration() {
+		return 0
 	}
 
+	// Metrics we export with a timestamp have to go once Prometheus would warn
+	// about them; the rest are kept until they're simply stale.
 	if ps.isTimestamped(typ) {
 		return metricExpirationTime
 	}
@@ -507,6 +514,7 @@ func (ps *PromSurfacer) writeData(w io.Writer) {
 // keys while serving the metrics, and deleting them based on the timer.
 func (ps *PromSurfacer) deleteExpiredMetrics() {
 	now := promTime(time.Now())
+	deleted := 0
 
 	for _, name := range ps.metricNames {
 		pm := ps.metrics[name]
@@ -517,32 +525,36 @@ func (ps *PromSurfacer) deleteExpiredMetrics() {
 		}
 		staleTimeThreshold := now - expirationAge.Milliseconds()
 
-		var expiredMetricsKeys []string
+		expiredMetricsKeys := make(map[string]bool)
 		for metricKey, v := range pm.data {
 			if v.timestamp < staleTimeThreshold {
-				expiredMetricsKeys = append(expiredMetricsKeys, metricKey)
+				expiredMetricsKeys[metricKey] = true
 			}
 		}
-
-		for _, expiredMetricKey := range expiredMetricsKeys {
-			delete(pm.data, expiredMetricKey)
-			pm.dataKeys = deleteFromSlice(pm.dataKeys, expiredMetricKey)
+		if len(expiredMetricsKeys) == 0 {
+			continue
 		}
-	}
-}
 
-// deleteFromSlice delete target on slice
-func deleteFromSlice(stringSlice []string, targetData string) []string {
-	targetIndex := -1
-	for i, data := range stringSlice {
-		if data == targetData {
-			targetIndex = i
-			break
+		for metricKey := range expiredMetricsKeys {
+			delete(pm.data, metricKey)
 		}
+
+		// Filter dataKeys in one pass. Deleting keys from the slice one at a
+		// time would rescan it for each key, which gets expensive when a probe
+		// or a target with many data keys goes away and they all expire in the
+		// same sweep.
+		dataKeys := pm.dataKeys[:0]
+		for _, k := range pm.dataKeys {
+			if !expiredMetricsKeys[k] {
+				dataKeys = append(dataKeys, k)
+			}
+		}
+		pm.dataKeys = dataKeys
+
+		deleted += len(expiredMetricsKeys)
 	}
 
-	if targetIndex != -1 {
-		stringSlice = append(stringSlice[:targetIndex], stringSlice[targetIndex+1:]...)
+	if deleted > 0 {
+		ps.l.Infof("prometheus surfacer: deleted %d stale metric series.", deleted)
 	}
-	return stringSlice
 }

--- a/internal/surfacers/prometheus/prometheus.go
+++ b/internal/surfacers/prometheus/prometheus.go
@@ -70,8 +70,8 @@ const histogram = "histogram"
 // blocking on previous queries to finish.
 const queriesQueueSize = 10
 
-// Prometheus does not take metrics that have passed 10 minutes. We delete
-// metrics that are older than this time.
+// Prometheus generates warnings while scraping samples whose timestamp is more
+// than 10 minutes old. We delete timestamped metrics once they get that stale.
 const metricExpirationTime = 10 * time.Minute
 
 var (
@@ -149,16 +149,16 @@ func shouldIncludeTimestamp(c *configpb.SurfacerConf) defaultBoolEnum {
 //
 // Data key represents a unique combination of metric name and labels.
 type PromSurfacer struct {
-	c                        *configpb.SurfacerConf // Configuration
-	opts                     *options.Options
-	includeTimestamp         defaultBoolEnum
-	disableMetricsExpiration defaultBoolEnum
-	prefix                   string                     // Metrics prefix, e.g. "cloudprober_"
-	emChan                   chan *metrics.EventMetrics // Buffered channel to store incoming EventMetrics
-	metrics                  map[string]*promMetric     // Metric name to promMetric mapping
-	metricNames              []string                   // Metric names, to keep names ordered.
-	queryChan                chan *httpWriter           // Query channel
-	l                        *logger.Logger
+	c                      *configpb.SurfacerConf // Configuration
+	opts                   *options.Options
+	includeTimestamp       defaultBoolEnum
+	staleMetricsExpiration time.Duration              // For metrics without a timestamp; 0 disables.
+	prefix                 string                     // Metrics prefix, e.g. "cloudprober_"
+	emChan                 chan *metrics.EventMetrics // Buffered channel to store incoming EventMetrics
+	metrics                map[string]*promMetric     // Metric name to promMetric mapping
+	metricNames            []string                   // Metric names, to keep names ordered.
+	queryChan              chan *httpWriter           // Query channel
+	l                      *logger.Logger
 
 	// A handler that takes a promMetric and a dataKey and writes the
 	// corresponding metric string to the provided io.Writer.
@@ -213,7 +213,14 @@ func New(ctx context.Context, config *configpb.SurfacerConf, opts *options.Optio
 		}
 	}
 
-	ps.disableMetricsExpiration = ps.shouldDisableMetricsExpiration()
+	// Metrics that we export without a timestamp are not subject to the 10m
+	// limit above, but we still drop them once they've been stale for this
+	// long, so that series belonging to probes and targets that have gone away
+	// don't stay in the /metrics output forever. The default (see the proto)
+	// is deliberately much larger than metricExpirationTime: expiring a series
+	// that a slow probe is still updating is worse -- it shows up as a gap and
+	// a counter reset -- than letting a dead one linger for a few hours.
+	ps.staleMetricsExpiration = time.Duration(ps.c.GetStaleMetricsExpirationSec()) * time.Second
 
 	// Start a goroutine to process the incoming EventMetrics as well as
 	// the incoming web queries. To avoid data access race conditions, we do
@@ -264,18 +271,36 @@ func (ps *PromSurfacer) Write(_ context.Context, em *metrics.EventMetrics) {
 	}
 }
 
-func (ps *PromSurfacer) shouldDisableMetricsExpiration() defaultBoolEnum {
+// isTimestamped returns whether we export metrics of the given prometheus type
+// with a timestamp. It mirrors the dataWriter selection in New().
+func (ps *PromSurfacer) isTimestamped(typ string) bool {
+	switch ps.includeTimestamp {
+	case explicitTrue:
+		return true
+	case explicitFalse:
+		return false
+	default:
+		return typ == "gauge"
+	}
+}
+
+// expirationAge returns how long a metric of the given prometheus type is kept
+// after its last update. A zero duration means it's never expired.
+func (ps *PromSurfacer) expirationAge(typ string) time.Duration {
+	// An explicit disable_metrics_expiration overrides everything: true turns
+	// off expiration altogether, false expires all metrics at the timestamp
+	// deadline, whether they carry a timestamp or not.
 	if ps.c != nil && ps.c.DisableMetricsExpiration != nil {
-		return defaultBoolMap[*ps.c.DisableMetricsExpiration]
+		if ps.c.GetDisableMetricsExpiration() {
+			return 0
+		}
+		return metricExpirationTime
 	}
 
-	// If we are never including timestamp, we disable metrics expiration
-	// and vice versa.
-	return map[defaultBoolEnum]defaultBoolEnum{
-		explicitFalse:   explicitTrue,
-		explicitTrue:    explicitFalse,
-		defaultBehavior: defaultBehavior,
-	}[ps.includeTimestamp]
+	if ps.isTimestamped(typ) {
+		return metricExpirationTime
+	}
+	return ps.staleMetricsExpiration
 }
 
 func promType(em *metrics.EventMetrics) string {
@@ -481,19 +506,16 @@ func (ps *PromSurfacer) writeData(w io.Writer) {
 // Note from manugarg: We can possibly optimize this by recording expired
 // keys while serving the metrics, and deleting them based on the timer.
 func (ps *PromSurfacer) deleteExpiredMetrics() {
-	if ps.disableMetricsExpiration == explicitTrue {
-		return
-	}
-
-	staleTimeThreshold := promTime(time.Now()) - metricExpirationTime.Milliseconds()
+	now := promTime(time.Now())
 
 	for _, name := range ps.metricNames {
 		pm := ps.metrics[name]
 
-		// For default behavior, we don't expire counter metrics.
-		if ps.disableMetricsExpiration == defaultBehavior && pm.typ == "counter" {
+		expirationAge := ps.expirationAge(pm.typ)
+		if expirationAge <= 0 {
 			continue
 		}
+		staleTimeThreshold := now - expirationAge.Milliseconds()
 
 		var expiredMetricsKeys []string
 		for metricKey, v := range pm.data {

--- a/internal/surfacers/prometheus/prometheus_test.go
+++ b/internal/surfacers/prometheus/prometheus_test.go
@@ -389,6 +389,7 @@ func TestExpirationAge(t *testing.T) {
 		desc                     string
 		includeTimestamp         defaultBoolEnum
 		disableMetricsExpiration *bool
+		staleOverride            *int32
 		wantGauge                time.Duration
 		wantCounter              time.Duration
 	}{
@@ -418,22 +419,33 @@ func TestExpirationAge(t *testing.T) {
 			wantCounter:              0,
 		},
 		{
-			desc:                     "expiration explicitly enabled: everything on the timestamp deadline",
+			desc:                     "expiration explicitly enabled: same as leaving it unset",
 			includeTimestamp:         defaultBehavior,
 			disableMetricsExpiration: proto.Bool(false),
 			wantGauge:                metricExpirationTime,
-			wantCounter:              metricExpirationTime,
+			wantCounter:              stale,
+		},
+		{
+			desc:             "staleness expiration disabled, gauges still bounded by the timestamp deadline",
+			includeTimestamp: defaultBehavior,
+			staleOverride:    proto.Int32(0),
+			wantGauge:        metricExpirationTime,
+			wantCounter:      0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+			staleExpiration := stale
+			if tt.staleOverride != nil {
+				staleExpiration = time.Duration(*tt.staleOverride)
+			}
 			ps := &PromSurfacer{
 				c: &configpb.SurfacerConf{
 					DisableMetricsExpiration: tt.disableMetricsExpiration,
 				},
 				includeTimestamp:       tt.includeTimestamp,
-				staleMetricsExpiration: stale,
+				staleMetricsExpiration: staleExpiration,
 			}
 			assert.Equal(t, tt.wantGauge, ps.expirationAge("gauge"), "gauge")
 			assert.Equal(t, tt.wantCounter, ps.expirationAge("counter"), "counter")
@@ -447,30 +459,85 @@ func TestStaleMetricsExpiration(t *testing.T) {
 		ps.writeData(&b)
 		return b.String()
 	}
+	staleEM := func() *metrics.EventMetrics {
+		return metrics.NewEventMetrics(time.Now().Add(-30*time.Minute)).
+			AddMetric("total", metrics.NewInt(20)).
+			AddLabel("probe", "stale-probe")
+	}
 
 	// Counters are not timestamped by default, so they are expired only after
 	// the staleness deadline, not the 10m timestamp deadline.
-	ps := testPromSurfacerNoErr(t, &configpb.SurfacerConf{})
-	assert.Equal(t, 4*time.Hour, ps.staleMetricsExpiration, "default from the config proto")
+	t.Run("under the default deadline", func(t *testing.T) {
+		ps := testPromSurfacerNoErr(t, &configpb.SurfacerConf{})
+		assert.Equal(t, 4*time.Hour, ps.staleMetricsExpiration, "default from the config proto")
 
-	staleEM := metrics.NewEventMetrics(time.Now().Add(-30*time.Minute)).
-		AddMetric("total", metrics.NewInt(20)).
-		AddLabel("probe", "stale-probe")
-	ps.record(staleEM)
+		ps.record(staleEM())
+		ps.deleteExpiredMetrics()
+		assert.Contains(t, scrape(ps), "stale-probe", "counter stale for 30m, but under the 4h deadline")
+	})
+
+	t.Run("past the deadline", func(t *testing.T) {
+		ps := testPromSurfacerNoErr(t, &configpb.SurfacerConf{
+			StaleMetricsExpirationSec: proto.Int32(600),
+		})
+		ps.record(staleEM())
+		ps.deleteExpiredMetrics()
+		assert.NotContains(t, scrape(ps), "stale-probe", "counter stale beyond the deadline")
+	})
+
+	t.Run("zero disables staleness expiration", func(t *testing.T) {
+		ps := testPromSurfacerNoErr(t, &configpb.SurfacerConf{
+			StaleMetricsExpirationSec: proto.Int32(0),
+		})
+		ps.record(staleEM())
+		ps.deleteExpiredMetrics()
+		assert.Contains(t, scrape(ps), "stale-probe", "staleness expiration disabled")
+	})
+}
+
+func TestDeleteExpiredMetricsKeepsKeyOrder(t *testing.T) {
+	ps := testPromSurfacerNoErr(t, &configpb.SurfacerConf{
+		StaleMetricsExpirationSec: proto.Int32(3600),
+	})
+
+	// Three series on the same metric; only the middle one is stale enough to
+	// be expired, so the surviving dataKeys must stay in insertion order.
+	for _, tc := range []struct {
+		probe string
+		age   time.Duration
+	}{
+		{"probe-a", 0},
+		{"probe-b", 2 * time.Hour},
+		{"probe-c", 0},
+	} {
+		ps.record(metrics.NewEventMetrics(time.Now().Add(-tc.age)).
+			AddMetric("total", metrics.NewInt(1)).
+			AddLabel("probe", tc.probe))
+	}
+
+	pm := ps.metrics["total"]
+	assert.Len(t, pm.dataKeys, 3, "before expiration")
 
 	ps.deleteExpiredMetrics()
-	assert.Contains(t, scrape(ps), "stale-probe", "counter stale for 30m, but under the 4h deadline")
 
-	// Now push it past the staleness deadline.
-	ps.staleMetricsExpiration = 10 * time.Minute
-	ps.deleteExpiredMetrics()
-	assert.NotContains(t, scrape(ps), "stale-probe", "counter stale beyond the deadline")
+	assert.Equal(t, []string{
+		"total{probe=\"probe-a\"}",
+		"total{probe=\"probe-c\"}",
+	}, pm.dataKeys)
+	assert.Len(t, pm.data, 2, "data map and dataKeys must stay in sync")
+}
 
-	// Zero disables staleness based expiration altogether.
-	ps.staleMetricsExpiration = 0
-	ps.record(staleEM)
-	ps.deleteExpiredMetrics()
-	assert.Contains(t, scrape(ps), "stale-probe", "staleness expiration disabled")
+func TestNegativeStaleMetricsExpiration(t *testing.T) {
+	_, err := testPromSurfacer(&configpb.SurfacerConf{
+		StaleMetricsExpirationSec: proto.Int32(-1),
+	})
+	assert.Error(t, err, "negative stale_metrics_expiration_sec should be rejected")
+
+	ps, err := testPromSurfacer(&configpb.SurfacerConf{
+		StaleMetricsExpirationSec: proto.Int32(0),
+	})
+	assert.NoError(t, err, "zero means never expire, and is valid")
+	assert.Equal(t, time.Duration(0), ps.staleMetricsExpiration)
 }
 
 func TestIncludeTimestamp(t *testing.T) {

--- a/internal/surfacers/prometheus/prometheus_test.go
+++ b/internal/surfacers/prometheus/prometheus_test.go
@@ -382,43 +382,95 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
-func TestDisableMetricsExpiration(t *testing.T) {
+func TestExpirationAge(t *testing.T) {
+	const stale = 42 * time.Minute
+
 	tests := []struct {
-		includeTimestamp         []defaultBoolEnum
+		desc                     string
+		includeTimestamp         defaultBoolEnum
 		disableMetricsExpiration *bool
-		want                     []defaultBoolEnum
+		wantGauge                time.Duration
+		wantCounter              time.Duration
 	}{
-		// Not explicitly set
 		{
-			includeTimestamp: []defaultBoolEnum{defaultBehavior, explicitTrue, explicitFalse},
-			want:             []defaultBoolEnum{defaultBehavior, explicitFalse, explicitTrue},
+			desc:             "default: gauges on the timestamp deadline, counters on staleness",
+			includeTimestamp: defaultBehavior,
+			wantGauge:        metricExpirationTime,
+			wantCounter:      stale,
 		},
 		{
-			includeTimestamp:         []defaultBoolEnum{defaultBehavior, explicitTrue, explicitFalse},
+			desc:             "all metrics timestamped: everything on the timestamp deadline",
+			includeTimestamp: explicitTrue,
+			wantGauge:        metricExpirationTime,
+			wantCounter:      metricExpirationTime,
+		},
+		{
+			desc:             "no metrics timestamped: everything on staleness",
+			includeTimestamp: explicitFalse,
+			wantGauge:        stale,
+			wantCounter:      stale,
+		},
+		{
+			desc:                     "expiration explicitly disabled",
+			includeTimestamp:         defaultBehavior,
 			disableMetricsExpiration: proto.Bool(true),
-			want:                     []defaultBoolEnum{explicitTrue, explicitTrue, explicitTrue},
+			wantGauge:                0,
+			wantCounter:              0,
 		},
 		{
-			includeTimestamp:         []defaultBoolEnum{defaultBehavior, explicitTrue, explicitFalse},
+			desc:                     "expiration explicitly enabled: everything on the timestamp deadline",
+			includeTimestamp:         defaultBehavior,
 			disableMetricsExpiration: proto.Bool(false),
-			want:                     []defaultBoolEnum{explicitFalse, explicitFalse, explicitFalse},
+			wantGauge:                metricExpirationTime,
+			wantCounter:              metricExpirationTime,
 		},
 	}
 
 	for _, tt := range tests {
-		for i, includeTimestamp := range tt.includeTimestamp {
-			t.Run(fmt.Sprintf("includeTimestamp=%v, disableMetricsExpiration=%v", includeTimestamp, tt.disableMetricsExpiration), func(t *testing.T) {
-				conf := &configpb.SurfacerConf{
+		t.Run(tt.desc, func(t *testing.T) {
+			ps := &PromSurfacer{
+				c: &configpb.SurfacerConf{
 					DisableMetricsExpiration: tt.disableMetricsExpiration,
-				}
-				ps := &PromSurfacer{
-					c:                conf,
-					includeTimestamp: includeTimestamp,
-				}
-				assert.Equal(t, tt.want[i], ps.shouldDisableMetricsExpiration())
-			})
-		}
+				},
+				includeTimestamp:       tt.includeTimestamp,
+				staleMetricsExpiration: stale,
+			}
+			assert.Equal(t, tt.wantGauge, ps.expirationAge("gauge"), "gauge")
+			assert.Equal(t, tt.wantCounter, ps.expirationAge("counter"), "counter")
+		})
 	}
+}
+
+func TestStaleMetricsExpiration(t *testing.T) {
+	scrape := func(ps *PromSurfacer) string {
+		var b bytes.Buffer
+		ps.writeData(&b)
+		return b.String()
+	}
+
+	// Counters are not timestamped by default, so they are expired only after
+	// the staleness deadline, not the 10m timestamp deadline.
+	ps := testPromSurfacerNoErr(t, &configpb.SurfacerConf{})
+	assert.Equal(t, 4*time.Hour, ps.staleMetricsExpiration, "default from the config proto")
+
+	staleEM := metrics.NewEventMetrics(time.Now().Add(-30*time.Minute)).
+		AddMetric("total", metrics.NewInt(20)).
+		AddLabel("probe", "stale-probe")
+	ps.record(staleEM)
+
+	ps.deleteExpiredMetrics()
+	assert.Contains(t, scrape(ps), "stale-probe", "counter stale for 30m, but under the 4h deadline")
+
+	// Now push it past the staleness deadline.
+	ps.staleMetricsExpiration = 10 * time.Minute
+	ps.deleteExpiredMetrics()
+	assert.NotContains(t, scrape(ps), "stale-probe", "counter stale beyond the deadline")
+
+	// Zero disables staleness based expiration altogether.
+	ps.staleMetricsExpiration = 0
+	ps.record(staleEM)
+	ps.deleteExpiredMetrics()
+	assert.Contains(t, scrape(ps), "stale-probe", "staleness expiration disabled")
 }
 
 func TestIncludeTimestamp(t *testing.T) {

--- a/internal/surfacers/prometheus/proto/config.pb.go
+++ b/internal/surfacers/prometheus/proto/config.pb.go
@@ -44,16 +44,36 @@ type SurfacerConf struct {
 	// Whether to disable all metrics expiration.
 	//
 	// Default behavior (recommended):
-	// By default, our goal is to expire timestamped metrics, which are more
-	// than 10 minutes old (see why below). If include_timestamp is not explicitly
-	// set to true or false, only gauge metrics will have timestamps, and only
-	// they will be expired. Similarly, if include_timestamp is explicitly set to
-	// false, no metrics will be expired, and if include_timestamp is explicitly
-	// set to true, all metrics will be expired.
+	// Metrics that we export with a timestamp are expired after 10 minutes of
+	// staleness, because Prometheus generates warnings while scraping metrics
+	// with timestamps that are more than 10m old. Which metrics carry a
+	// timestamp depends on include_timestamp above: gauges only by default, all
+	// metrics if it's explicitly true, none if it's explicitly false.
 	//
-	// Why do we expire timestamped metrics? Prometheus generates warnings while
-	// scraping metrics that have timestamps that are more than 10m old.
+	// Metrics without a timestamp are expired after
+	// stale_metrics_expiration_sec (4h by default), so that series belonging to
+	// probes and targets that have gone away don't stay around forever.
+	//
+	// Setting this field to true disables both of the above; setting it to false
+	// expires all metrics after 10 minutes of staleness.
 	DisableMetricsExpiration *bool `protobuf:"varint,5,opt,name=disable_metrics_expiration,json=disableMetricsExpiration" json:"disable_metrics_expiration,omitempty"`
+	// Delete metrics that haven't been updated for this long, even if we don't
+	// attach a timestamp to them.
+	//
+	// Timestamped metrics are expired after 10m regardless of this setting, as
+	// explained above. This option covers the rest -- most importantly counters,
+	// which don't carry a timestamp by default. Without it, a counter for a
+	// probe or a target that has gone away stays in the /metrics output forever.
+	//
+	// The default is deliberately generous (4h). Expiring too early is a
+	// correctness problem -- a series deleted in between two probe runs shows up
+	// as a gap and a counter reset for a probe that is working fine -- while
+	// expiring late only means a dead series lingers a bit longer. If you have
+	// probes that run less frequently than this, increase it accordingly.
+	//
+	// Set to 0 to keep non-timestamped metrics forever, which is what cloudprober
+	// did before this option was added.
+	StaleMetricsExpirationSec *int32 `protobuf:"varint,6,opt,name=stale_metrics_expiration_sec,json=staleMetricsExpirationSec,def=14400" json:"stale_metrics_expiration_sec,omitempty"`
 	// URL that prometheus scrapes metrics from.
 	MetricsUrl *string `protobuf:"bytes,3,opt,name=metrics_url,json=metricsUrl,def=/metrics" json:"metrics_url,omitempty"`
 	// Prefix to add to all metric names. For example setting this field to
@@ -70,8 +90,9 @@ type SurfacerConf struct {
 
 // Default values for SurfacerConf fields.
 const (
-	Default_SurfacerConf_MetricsBufferSize = int64(10000)
-	Default_SurfacerConf_MetricsUrl        = string("/metrics")
+	Default_SurfacerConf_MetricsBufferSize         = int64(10000)
+	Default_SurfacerConf_StaleMetricsExpirationSec = int32(14400)
+	Default_SurfacerConf_MetricsUrl                = string("/metrics")
 )
 
 func (x *SurfacerConf) Reset() {
@@ -125,6 +146,13 @@ func (x *SurfacerConf) GetDisableMetricsExpiration() bool {
 	return false
 }
 
+func (x *SurfacerConf) GetStaleMetricsExpirationSec() int32 {
+	if x != nil && x.StaleMetricsExpirationSec != nil {
+		return *x.StaleMetricsExpirationSec
+	}
+	return Default_SurfacerConf_StaleMetricsExpirationSec
+}
+
 func (x *SurfacerConf) GetMetricsUrl() string {
 	if x != nil && x.MetricsUrl != nil {
 		return *x.MetricsUrl
@@ -143,11 +171,12 @@ var File_github_com_cloudprober_cloudprober_internal_surfacers_prometheus_proto_
 
 const file_github_com_cloudprober_cloudprober_internal_surfacers_prometheus_proto_config_proto_rawDesc = "" +
 	"\n" +
-	"Sgithub.com/cloudprober/cloudprober/internal/surfacers/prometheus/proto/config.proto\x12\x1fcloudprober.surfacer.prometheus\"\x82\x02\n" +
+	"Sgithub.com/cloudprober/cloudprober/internal/surfacers/prometheus/proto/config.proto\x12\x1fcloudprober.surfacer.prometheus\"\xca\x02\n" +
 	"\fSurfacerConf\x125\n" +
 	"\x13metrics_buffer_size\x18\x01 \x01(\x03:\x0510000R\x11metricsBufferSize\x12+\n" +
 	"\x11include_timestamp\x18\x02 \x01(\bR\x10includeTimestamp\x12<\n" +
-	"\x1adisable_metrics_expiration\x18\x05 \x01(\bR\x18disableMetricsExpiration\x12)\n" +
+	"\x1adisable_metrics_expiration\x18\x05 \x01(\bR\x18disableMetricsExpiration\x12F\n" +
+	"\x1cstale_metrics_expiration_sec\x18\x06 \x01(\x05:\x0514400R\x19staleMetricsExpirationSec\x12)\n" +
 	"\vmetrics_url\x18\x03 \x01(\t:\b/metricsR\n" +
 	"metricsUrl\x12%\n" +
 	"\x0emetrics_prefix\x18\x04 \x01(\tR\rmetricsPrefixBHZFgithub.com/cloudprober/cloudprober/internal/surfacers/prometheus/proto"

--- a/internal/surfacers/prometheus/proto/config.pb.go
+++ b/internal/surfacers/prometheus/proto/config.pb.go
@@ -54,8 +54,9 @@ type SurfacerConf struct {
 	// stale_metrics_expiration_sec (4h by default), so that series belonging to
 	// probes and targets that have gone away don't stay around forever.
 	//
-	// Setting this field to true disables both of the above; setting it to false
-	// expires all metrics after 10 minutes of staleness.
+	// Setting this field to true disables both of the above. Setting it to false
+	// is the same as leaving it unset: expiration stays on, with the two
+	// deadlines described above.
 	DisableMetricsExpiration *bool `protobuf:"varint,5,opt,name=disable_metrics_expiration,json=disableMetricsExpiration" json:"disable_metrics_expiration,omitempty"`
 	// Delete metrics that haven't been updated for this long, even if we don't
 	// attach a timestamp to them.
@@ -72,7 +73,7 @@ type SurfacerConf struct {
 	// probes that run less frequently than this, increase it accordingly.
 	//
 	// Set to 0 to keep non-timestamped metrics forever, which is what cloudprober
-	// did before this option was added.
+	// did before this option was added. Negative values are rejected.
 	StaleMetricsExpirationSec *int32 `protobuf:"varint,6,opt,name=stale_metrics_expiration_sec,json=staleMetricsExpirationSec,def=14400" json:"stale_metrics_expiration_sec,omitempty"`
 	// URL that prometheus scrapes metrics from.
 	MetricsUrl *string `protobuf:"bytes,3,opt,name=metrics_url,json=metricsUrl,def=/metrics" json:"metrics_url,omitempty"`

--- a/internal/surfacers/prometheus/proto/config.proto
+++ b/internal/surfacers/prometheus/proto/config.proto
@@ -28,16 +28,37 @@ message SurfacerConf {
   // Whether to disable all metrics expiration.
   //
   // Default behavior (recommended):
-  // By default, our goal is to expire timestamped metrics, which are more
-  // than 10 minutes old (see why below). If include_timestamp is not explicitly
-  // set to true or false, only gauge metrics will have timestamps, and only
-  // they will be expired. Similarly, if include_timestamp is explicitly set to
-  // false, no metrics will be expired, and if include_timestamp is explicitly
-  // set to true, all metrics will be expired.
+  // Metrics that we export with a timestamp are expired after 10 minutes of
+  // staleness, because Prometheus generates warnings while scraping metrics
+  // with timestamps that are more than 10m old. Which metrics carry a
+  // timestamp depends on include_timestamp above: gauges only by default, all
+  // metrics if it's explicitly true, none if it's explicitly false.
   //
-  // Why do we expire timestamped metrics? Prometheus generates warnings while
-  // scraping metrics that have timestamps that are more than 10m old.
+  // Metrics without a timestamp are expired after
+  // stale_metrics_expiration_sec (4h by default), so that series belonging to
+  // probes and targets that have gone away don't stay around forever.
+  //
+  // Setting this field to true disables both of the above; setting it to false
+  // expires all metrics after 10 minutes of staleness.
   optional bool disable_metrics_expiration = 5;
+
+  // Delete metrics that haven't been updated for this long, even if we don't
+  // attach a timestamp to them.
+  //
+  // Timestamped metrics are expired after 10m regardless of this setting, as
+  // explained above. This option covers the rest -- most importantly counters,
+  // which don't carry a timestamp by default. Without it, a counter for a
+  // probe or a target that has gone away stays in the /metrics output forever.
+  //
+  // The default is deliberately generous (4h). Expiring too early is a
+  // correctness problem -- a series deleted in between two probe runs shows up
+  // as a gap and a counter reset for a probe that is working fine -- while
+  // expiring late only means a dead series lingers a bit longer. If you have
+  // probes that run less frequently than this, increase it accordingly.
+  //
+  // Set to 0 to keep non-timestamped metrics forever, which is what cloudprober
+  // did before this option was added.
+  optional int32 stale_metrics_expiration_sec = 6 [default = 14400];
 
   // URL that prometheus scrapes metrics from.
   optional string metrics_url = 3 [default = "/metrics"];

--- a/internal/surfacers/prometheus/proto/config.proto
+++ b/internal/surfacers/prometheus/proto/config.proto
@@ -38,8 +38,9 @@ message SurfacerConf {
   // stale_metrics_expiration_sec (4h by default), so that series belonging to
   // probes and targets that have gone away don't stay around forever.
   //
-  // Setting this field to true disables both of the above; setting it to false
-  // expires all metrics after 10 minutes of staleness.
+  // Setting this field to true disables both of the above. Setting it to false
+  // is the same as leaving it unset: expiration stays on, with the two
+  // deadlines described above.
   optional bool disable_metrics_expiration = 5;
 
   // Delete metrics that haven't been updated for this long, even if we don't
@@ -57,7 +58,7 @@ message SurfacerConf {
   // probes that run less frequently than this, increase it accordingly.
   //
   // Set to 0 to keep non-timestamped metrics forever, which is what cloudprober
-  // did before this option was added.
+  // did before this option was added. Negative values are rejected.
   optional int32 stale_metrics_expiration_sec = 6 [default = 14400];
 
   // URL that prometheus scrapes metrics from.


### PR DESCRIPTION
## Problem

Metrics expiration in the Prometheus surfacer was derived from `include_timestamp`. Metrics we export *without* a timestamp were never expired, on the reasoning that the 10m deadline exists only to avoid Prometheus's warning about samples with timestamps older than 10 minutes — no timestamp, nothing to expire.

That conflated two different problems:

1. *This sample's timestamp is too old for Prometheus.* — handled.
2. *This series belongs to a probe or target that no longer exists.* — not handled at all.

The second has nothing to do with timestamps. A counter for a target that has gone away stayed in the `/metrics` output, and in memory, for the life of the process.

## Change

Split the two concerns. A new per-type helper `expirationAge()` decides how long a metric is kept after its last update:

- **Timestamped** metrics → 10m, unchanged (Prometheus's constraint).
- **Everything else** → new `stale_metrics_expiration_sec`, defaulting to 4h.
- `stale_metrics_expiration_sec: 0` restores the old never-expire behavior; `disable_metrics_expiration: true` still turns off both deadlines. Negative values are rejected at startup rather than silently meaning "never".

`isTimestamped()` mirrors the `dataWriter` switch in `New()`, so the two can't drift apart.

## Why 4h

Counter expiration was originally disabled because of long interval probes, so the default is deliberately generous. The two failure directions are not symmetric:

- **Expiring too early is a correctness failure.** A series deleted in between two probe runs shows up as a gap and a counter reset on a probe that is working fine.
- **Expiring too late is a tidiness failure.** A dead series lingers a few extra hours. A frozen counter yields `rate() == 0` rather than garbage, so the real cost is just cloudprober's memory — which 4h still bounds.

4h leaves an hourly probe 4x of headroom. I didn't go higher because bounding memory under target churn is the point: a workload cycling pods would accumulate a full day of dead series at 24h.

## Behavior changes

| config | before | after |
|---|---|---|
| default: counters | never | 4h |
| default: histograms | 10m | 4h |
| default: gauges | 10m | 10m |
| `include_timestamp: false` | nothing expires | 4h for all |
| `include_timestamp: true` | all at 10m | all at 10m |
| `disable_metrics_expiration: true` | nothing expires | unchanged |
| `disable_metrics_expiration: false`, non-timestamped | 10m | 4h |

Rows worth calling out:

- **Distributions** are typed `"histogram"`, not `"counter"`, so they were already being expired at 10m despite carrying no timestamp. They now follow the same staleness deadline as counters.
- **`include_timestamp: false`** is the only row that isn't strictly "collect garbage that was never collected" — those deployments go from *nothing ever expires* to *everything expires at 4h*.
- **`disable_metrics_expiration: false`** now means what it says (expiration is not disabled) and composes with the new field, rather than pinning everything to 10m and silently ignoring `stale_metrics_expiration_sec`.

The last two both move in the keep-data-longer direction, and both escape hatches above cover anyone who disagrees.

## Performance

`deleteExpiredMetrics` used to remove keys from `pm.dataKeys` one at a time, rescanning the slice per key. That was fine when only gauges expired; now counters do, and those are the families with one data key per target. Removing a probe with many targets would make a single sweep quadratic on the goroutine that also serves `/metrics` and drains `emChan` — stalling scrapes and dropping EventMetrics. Expired keys are now collected into a set and filtered out in one pass.

## Notes

- The sweep interval is derived from the shortest deadline in effect, so a `stale_metrics_expiration_sec` under 10m isn't silently rounded up. It's computed before the sweep goroutine starts, so the goroutine doesn't read surfacer fields it doesn't own.
- Each sweep that deletes anything logs the count, so the one case that can surprise someone — a probe whose interval exceeds the staleness deadline — leaves a trail.
- The 4h default lives only in the config proto and is read through the generated getter, so there's no second copy to drift.
- `config.pb.go` was regenerated with the same toolchain the file was built with (protoc v6.33.5 / protoc-gen-go v1.36.11).

## Testing

`TestExpirationAge` replaces `TestDisableMetricsExpiration` and covers the gauge/counter split across every `include_timestamp` and `disable_metrics_expiration` combination. `TestStaleMetricsExpiration` drives the new deadline end to end through the config; `TestDeleteExpiredMetricsKeepsKeyOrder` pins the single-pass filter's ordering and `data`/`dataKeys` consistency across a partial expiry; `TestNegativeStaleMetricsExpiration` covers the validation. Full surfacer suite passes under `-race`; vet and gofmt clean.
