### PR TITLE
[web] Use TrimSuffix, not a TrimRight cutset, in verifyHeader

### DIFF
--- a/web/web_test.go
+++ b/web/web_test.go
@@ -166,7 +166,7 @@ func TestArtifactsLinksWithManualRegistration(t *testing.T) {
 
 func verifyHeader(t *testing.T, path string, got string) {
 	t.Helper()
-	wantHeader := strings.TrimRight(resources.RenderPage(path, ""), "</body>\n</html>\n")
+	wantHeader := strings.TrimSuffix(resources.RenderPage(path, ""), "\n</body>\n</html>\n")
 	assert.Contains(t, got, wantHeader)
 }
 


### PR DESCRIPTION
## Description

`verifyHeader` in `web/web_test.go` trims the closing tags off a rendered page
before asserting a handler's response contains it:

```go
wantHeader := strings.TrimRight(resources.RenderPage(path, ""), "</body>\n</html>\n")
```

`TrimRight` takes a cutset of characters, not a suffix. That cutset is
`{<, /, b, o, d, y, >, \n, h, t, m, l}`, which has no `r`. `verifyHeader`
renders with an empty body, so the page ends:

```
...<br><br><br><br>\n\n</body>\n</html>\n
```

The trim removes the intended suffix and then keeps going through the blank
line and the closing `>`, stopping at the `r` in the last `<br>`:

```
intended (TrimSuffix): 17 bytes removed -> "...<br><br><br><br>\n"
actual   (TrimRight):  19 bytes removed -> "...<br><br><br><br"
```

so the string passed to `assert.Contains` ends mid-tag.

## Fix

Use `strings.TrimSuffix` with the exact suffix.

To be clear about the impact: the assertion passes either way, and what it
establishes -- that the handler wrapped its output in `RenderPage` rather than
writing bare content -- is unaffected. Both sides of the comparison come from
`RenderPage`, so this was never checking header *content*; I confirmed that by
mutating the header template and watching the tests still pass.

What made it worth a patch is that the number of bytes trimmed depends on which
characters happen to end the rendered page. Any change to the page shell
silently changes what is asserted -- trimming into meaningful content, or
trimming considerably more if the new tail ends in a run of cutset characters.
It is a trap for whoever next touches that template rather than a live defect.

## Tests

No new tests. `go test ./web/...` passes.

The byte counts above were measured against `main` with a scratch test calling
`RenderPage("/", "")` and comparing `TrimRight` with `TrimSuffix` output; it is
not included here since it only asserts the behaviour of the stdlib call being
replaced.

## Verification

`go test ./web/...` passes before and after. I also verified that the mutation
described under Fix leaves the suite green both before and after this change,
i.e. the patch does not claim to add coverage it does not add.


