### PR TITLE
[surfacers.probestatus] Don't panic when the dashboard window is under a minute

### DIFF
--- a/internal/surfacers/probestatus/dashboard.go
+++ b/internal/surfacers/probestatus/dashboard.go
@@ -33,7 +33,9 @@ func dashboardDurations(maxDuration time.Duration) ([]time.Duration, []string) {
 			result = append(result, td)
 		}
 	}
-	if result[len(result)-1] != maxDuration {
+	// If maxDuration is smaller than the smallest base duration, result is
+	// empty at this point; maxDuration is still the right (only) choice.
+	if len(result) == 0 || result[len(result)-1] != maxDuration {
 		result = append(result, maxDuration)
 	}
 	return result, shortDur(result)

--- a/internal/surfacers/probestatus/dashboard_test.go
+++ b/internal/surfacers/probestatus/dashboard_test.go
@@ -27,6 +27,11 @@ func TestDashboardDurations(t *testing.T) {
 		168 * time.Hour: baseDurations[:8],
 		360 * time.Hour: append(append([]time.Duration{}, baseDurations[:8]...), 360*time.Hour),
 		720 * time.Hour: baseDurations,
+
+		// resolution_sec * timeseries_size can be smaller than the smallest
+		// base duration, e.g. resolution_sec: 1, timeseries_size: 30.
+		30 * time.Second: {30 * time.Second},
+		59 * time.Second: {59 * time.Second},
 	}
 
 	for maxD, wantDurations := range testData {


### PR DESCRIPTION
## Description

`dashboardDurations()` builds the duration list for the status page dashboard:

```go
for _, td := range baseDurations {
    if td <= maxDuration {
        result = append(result, td)
    }
}
if result[len(result)-1] != maxDuration {
```

`maxDuration` is `resolution_sec * timeseries_size`, and `baseDurations` starts
at one minute. If that product is under 60s, nothing is appended and
`result[len(result)-1]` indexes an empty slice.

`New()` calls it at probestatus.go:183 before returning, so this is a startup
panic rather than a bad page. With:

```
surfacer {
  type: PROBESTATUS
  probestatus_surfacer {
    resolution_sec: 1
    timeseries_size: 30
  }
}
```

cloudprober exits immediately:

```
panic: runtime error: index out of range [-1]

goroutine 1 [running]:
...probestatus.dashboardDurations(0x6fc23ac00)
	internal/surfacers/probestatus/dashboard.go:36
...probestatus.New(...)
	internal/surfacers/probestatus/probestatus.go:183
...surfacers.initSurfacer(...)
	surfacers/surfacers.go:238
...prober.Init(...)
	prober/prober.go:393
main.main()
	cmd/cloudprober/main.go:157
```

The defaults (60s x 4320) are far above the threshold, so this only shows up on
a deliberately short window -- a high-resolution, small-buffer setup.

## Fix

Handle the empty case. When `maxDuration` is below the smallest base duration
it is the only sensible entry in the list, so the existing `append` is right;
it just needs to not read the slice first.

## Tests

Two cases added to `TestDashboardDurations` (30s and 59s). Both panic against
current main and pass with the change.

## Verification

`go test ./internal/surfacers/probestatus/...` passes. Reverting dashboard.go
while keeping the new test cases reproduces the panic in the test run, so the
cases genuinely cover the guard rather than just passing alongside it. Also
confirmed the config above now starts normally and the status page renders with
a 30s dashboard option.

## Note

A zero `resolution_sec` or `timeseries_size` makes `maxDuration` 0, which no
longer panics with this change but produces a "0d" dashboard entry. That looked
like a separate question about validating the surfacer config in `New()`, so I
left it out of this PR -- happy to follow up if you'd like it rejected at
config time instead.
