### PR TITLE
[surfacers/probestatus] Ignore sub-second graph_res instead of dividing by zero

### DIFF
--- a/internal/surfacers/probestatus/graph.go
+++ b/internal/surfacers/probestatus/graph.go
@@ -79,7 +79,10 @@ func graphOptsFromURL(qv url.Values, maxDuration time.Duration, l *logger.Logger
 		}
 	}
 
-	if gopts.res == 0 {
+	// Graph data carries the resolution as a whole number of seconds, so a
+	// sub-second (or negative) resolution can't be represented. Fall back to
+	// the computed resolution instead of letting it truncate to zero.
+	if gopts.res < time.Second {
 		gopts.res = graphResolution(gopts.endTime, gopts.duration)
 	}
 

--- a/internal/surfacers/probestatus/graph_test.go
+++ b/internal/surfacers/probestatus/graph_test.go
@@ -276,6 +276,27 @@ func TestGraphOptsFromURL(t *testing.T) {
 				res:      time.Minute,
 			},
 		},
+		{
+			// Sub-second resolution truncates to 0 seconds in graphData;
+			// fall back to the computed resolution.
+			q: map[string][]string{
+				"graph_res": {"500ms"},
+			},
+			gopts: &graphOptions{
+				duration: maxDuration,
+				res:      5 * time.Minute,
+			},
+		},
+		{
+			// Same for a negative resolution.
+			q: map[string][]string{
+				"graph_res": {"-5s"},
+			},
+			gopts: &graphOptions{
+				duration: maxDuration,
+				res:      5 * time.Minute,
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description

`graphData` carries the graph resolution as a whole number of seconds:

```go
type graphData struct {
	...
	ResSeconds int // Used by HTML template
}
```

filled with `int(gopts.res.Seconds())`. `graphOptsFromURL` normalises a zero
`graph_res`:

```go
if gopts.res == 0 {
	gopts.res = graphResolution(gopts.endTime, gopts.duration)
}
```

but any non-zero value below a second gets through and truncates to `0`:

```
graph_res=500ms -> res=500ms   ResSeconds=0
graph_res=0s    -> res=5m0s    ResSeconds=300   (already handled)
graph_res=1s    -> res=1s      ResSeconds=1
graph_res=-5s   -> res=-5s     ResSeconds=-5
```

`syncGraphLines` then divides by it, twice:

```go
lpadding := int(t.Sub(minStartTime).Seconds()) / gd.ResSeconds
...
rpadding := int(maxEndTime.Sub(t).Seconds()) / gd.ResSeconds
```

so `/status?graph_res=500ms` panics with `integer divide by zero`.

Two things worth being precise about, since they narrow it:

- Those divisions only run when `needLeftPadding` / `needRightPadding` are set,
  i.e. when a probe has targets whose series start or end at different times. A
  probe with a single target, or with targets in lockstep, is unaffected.
- `computeGraphPoints` already guards its own use of the resolution
  (`step == 0 -> step = 1`), so the graph loop itself is fine. `syncGraphLines`
  is the only unguarded consumer.

A negative `graph_res` doesn't panic but is equally meaningless -- it yields
negative padding counts.

## Fix

Extend the existing fallback from `== 0` to `< time.Second`. Sub-second
resolution cannot be represented in `ResSeconds` at all, so falling back to the
computed resolution is the same thing the zero case already does, and it covers
negatives in the same comparison.

I kept this at the source rather than guarding the two divisions, since
`ResSeconds` being 0 is the actual defect and guarding the divisions would just
paper over it. Happy to add defensive guards there as well if you would rather
have both.

## Tests

Two cases added to `TestGraphOptsFromURL`, for `500ms` and `-5s`, both
expecting the computed fallback. Both fail against current main:

```
--- FAIL: TestGraphOptsFromURL/graph_res=500ms
    expected: res:300000000000
    actual  : res:500000000
```

## Verification

`go test ./internal/surfacers/probestatus/...` passes.

I confirmed the panic itself separately by calling `syncGraphLines` with
`ResSeconds: 0` and two targets with differing start times, which panics with
`runtime error: integer divide by zero`; that scratch test isn't included since
it asserts the behaviour of the state this change makes unreachable.
