### PR TITLE
[surfacers.probestatus] Put the doctype first so /status leaves quirks mode

### DIFF
--- a/internal/surfacers/probestatus/html_tmpl.go
+++ b/internal/surfacers/probestatus/html_tmpl.go
@@ -14,12 +14,11 @@
 
 package probestatus
 
-var htmlTmpl = `
+var htmlTmpl = `<!DOCTYPE html>
 <html>
-<!DOCTYPE html>
-<meta charset="utf-8">
 
 <head>
+<meta charset="utf-8">
 
 <script>
   var startTime = '{{.StartTime}}';

--- a/internal/surfacers/probestatus/probestatus_test.go
+++ b/internal/surfacers/probestatus/probestatus_test.go
@@ -337,6 +337,11 @@ func TestSurfacerWriteData(t *testing.T) {
 			for _, keyword := range tt.wantNotContains {
 				assert.NotContains(t, got, keyword)
 			}
+
+			// The doctype only takes effect if it comes before anything
+			// else; browsers ignore a late one and fall back to quirks mode.
+			assert.True(t, strings.HasPrefix(got, "<!DOCTYPE html>"),
+				"page should start with the doctype, got: %.30q", got)
 		})
 	}
 }


### PR DESCRIPTION
## Description

The status page template declares a doctype, but after `<html>`:

```
var htmlTmpl = `
<html>
<!DOCTYPE html>
<meta charset="utf-8">
```

A doctype is only honoured when it precedes everything else in the document, so
browsers discard this one and fall back to quirks mode. Measured on `/status`
against current main (Chromium):

```js
document.compatMode   // "BackCompat"
document.doctype      // null
```

Quirks mode changes the box model and several table layout rules, so the page
is being laid out under different rules than the CSS was written for.

## Fix

Move the doctype to the very start of the template, and move the charset meta
inside `<head>` where it belongs. After:

```js
document.compatMode   // "CSS1Compat"
document.doctype      // "html"
document.characterSet // "UTF-8"
```

## Tests

`TestSurfacerWriteData` now asserts the rendered page starts with the doctype.
It fails against the current template with:

```
page should start with the doctype, got: "\n<html>\n<!DOCTYPE html>\n<meta "
```

## Verification

`go test ./internal/surfacers/probestatus/...` passes.

Built and ran against a live prober, then compared `/status` before and after
in a browser: `compatMode` flips from `BackCompat` to `CSS1Compat` as above, and
full-page screenshots of the two are visually identical -- the header, links,
Success Ratio heading and probe selector all render the same. I checked this
specifically because leaving quirks mode can shift layout, and here it does not.

This only covers the probestatus template. The pages rendered through
`web/resources.RenderPage` (`/config-running`, `/alerts`, `/links`, `/logs`) have
no doctype at all and are also in quirks mode, and
`probes/browser/artifacts/web/template.go` builds its own shell -- happy to send
those separately if you would like them fixed too.
