### PR TITLE
[web] Scope the status-list cell rule to status-list tables

### DIFF
--- a/web/static/cloudprober.css
+++ b/web/static/cloudprober.css
@@ -27,7 +27,7 @@ table.status-list {
 }
 
 table.status-list td,
-th {
+table.status-list th {
   border: 1px solid gray;
   padding: 0.25em 0.5em;
   max-width: 300px;


### PR DESCRIPTION
## Description

In `web/static/cloudprober.css`:

```css
table.status-list td,
th {
  border: 1px solid gray;
  padding: 0.25em 0.5em;
  max-width: 300px;
  word-wrap: break-word;
}
```

Only the first half of the selector list is scoped. The bare `th` matches every
table header on every page that loads this stylesheet, not just status-list
tables.

In practice every table in the tree uses `class="status-list"` except the logs
table (`web/logs.go`, `class="logs-table"`), so that is the one that picks the
rule up unintentionally.

## Impact

Nothing renders differently today, and I want to be clear about that rather than
overstate it. `.logs-table th` declares its own `border` and `padding`, which win
on specificity; only `max-width` and `word-wrap` leak through, and neither binds
because the logs column widths come from the `td` rules.

Measured on `/logs` before and after, headers Time / Level / Source / Message /
Attributes:

```
before: max-width 300px, overflow-wrap break-word, widths 106 56 99 554 203
after:  max-width none,  overflow-wrap normal,     widths 106 56 99 554 203
```

So this is a trap for the next non-status-list table added to these pages rather
than a bug anyone is hitting.

## Fix

Scope the second half of the selector the same way as the first.

## Tests

No tests -- there is no CSS test setup in the repo and this changes no rendered
output.

## Verification

Built and ran against a live prober, comparing computed styles before and after.

- `/logs`: the two leaked properties are gone, rendered column widths identical
  (numbers above).
- `/config-running`: all 13 `table.status-list th` cells still get
  `1px solid gray`, `max-width: 300px`, the 0.25em padding and `word-wrap:
  break-word`, i.e. the intended styling is unchanged.
