### PR TITLE
[probes.http] Only treat a header as dynamic if substitution changes it

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -66,7 +66,7 @@ type Probe struct {
 	targets []endpoint.Endpoint
 	method  string
 	url     string
-	// Canonical names of headers whose values carry a substitution token
+	// Canonical names of headers whose values change under substitution
 	// (e.g. @uuid@). Empty when no header is dynamic; len() also gates the
 	// per-send clone in prepareRequest.
 	dynamicHeaderNames []string

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -156,9 +156,13 @@ func dynamicHeaderSubst() map[string]string {
 // excluded: req.Host is not substituted, so a token there is warned about
 // and sent verbatim.
 func (p *Probe) initDynamicHeaders() {
+	// One sample resolution for the whole pass; the values we send are
+	// resolved per-send by applyDynamicHeaders.
+	subst := dynamicHeaderSubst()
+
 	seen := map[string]bool{}
 	add := func(name, val string) {
-		if nv, _ := strtemplate.SubstituteLabels(val, dynamicHeaderSubst()); nv == val {
+		if nv, _ := strtemplate.SubstituteLabels(val, subst); nv == val {
 			return
 		}
 		if name == "Host" {

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -136,17 +136,33 @@ func (p *Probe) setHeaders(req *http.Request, host string, port int) {
 	req.Host = hostHeader
 }
 
-// initDynamicHeaders records canonical names of headers whose values carry
-// a substitution token. Host is excluded: req.Host is not substituted, so
-// a literal '@' there is warned about and sent verbatim.
+// dynamicHeaderTokens maps a substitution token to its per-send resolver.
+var dynamicHeaderTokens = map[string]func() string{
+	"uuid": uuid.NewString,
+}
+
+func dynamicHeaderSubst() map[string]string {
+	subst := make(map[string]string, len(dynamicHeaderTokens))
+	for token, resolve := range dynamicHeaderTokens {
+		subst[token] = resolve()
+	}
+	return subst
+}
+
+// initDynamicHeaders records canonical names of headers whose values change
+// under substitution. We check that by running the substitution and seeing
+// if anything moved, so detection can't disagree with it -- a value with a
+// stray '@' but no token is not dynamic, however many '@'s it has. Host is
+// excluded: req.Host is not substituted, so a token there is warned about
+// and sent verbatim.
 func (p *Probe) initDynamicHeaders() {
 	seen := map[string]bool{}
 	add := func(name, val string) {
-		if !strings.Contains(val, "@") {
+		if nv, _ := strtemplate.SubstituteLabels(val, dynamicHeaderSubst()); nv == val {
 			return
 		}
 		if name == "Host" {
-			p.l.Warningf("http probe %q: Host header value %q contains '@' but Host substitution is not supported; value will be sent verbatim", p.name, val)
+			p.l.Warningf("http probe %q: Host header value carries a substitution token but Host substitution is not supported; value will be sent verbatim", p.name)
 			return
 		}
 		canon := http.CanonicalHeaderKey(name)
@@ -176,7 +192,7 @@ func (p *Probe) applyDynamicHeaders(req *http.Request) {
 				continue
 			}
 			if subst == nil {
-				subst = map[string]string{"uuid": uuid.NewString()}
+				subst = dynamicHeaderSubst()
 			}
 			if nv, _ := strtemplate.SubstituteLabels(v, subst); nv != v {
 				vv[i] = nv

--- a/probes/http/request_test.go
+++ b/probes/http/request_test.go
@@ -589,6 +589,7 @@ func TestDynamicHeaderSubstitution(t *testing.T) {
 				"X-Static":     "no-substitution-here",
 				"X-Unknown":    "@some_other_key@",
 				"X-Literal-At": "left@@right",
+				"X-Api-Key":    "aB3@dE7fG1hJ",
 			},
 			Headers:   []*configpb.ProbeConf_Header{{Name: &hostName, Value: &hostVal}},
 			UserAgent: proto.String("cloudprober/@uuid@"),
@@ -612,6 +613,7 @@ func TestDynamicHeaderSubstitution(t *testing.T) {
 			assert.Equal(t, "no-substitution-here", h.Get("X-Static"))
 			assert.Equal(t, "@some_other_key@", h.Get("X-Unknown"))
 			assert.Equal(t, "left@right", h.Get("X-Literal-At"))
+			assert.Equal(t, "aB3@dE7fG1hJ", h.Get("X-Api-Key"))
 			uuids = append(uuids, id)
 		}
 		assert.NotEqual(t, uuids[0], uuids[1], "consecutive requests reused the same @uuid@")
@@ -641,6 +643,43 @@ func TestDynamicHeaderSubstitution(t *testing.T) {
 	})
 }
 
+func TestInitDynamicHeaders(t *testing.T) {
+	tests := []struct {
+		val         string
+		wantDynamic bool
+	}{
+		{val: "no-substitution"},
+		{val: "@uuid@", wantDynamic: true},
+		{val: "trace-@uuid@-suffix", wantDynamic: true},
+		{val: "left@@right", wantDynamic: true}, // "@@" resolves to a literal '@'
+		// Stray '@'s and no token: substitution is a no-op, so the header
+		// is not dynamic and its value is never logged (issue #1449).
+		{val: "aB3@dE7fG1hJ"},
+		{val: "trailing@"},
+		{val: "@some_other_key@"},
+		{val: "user@example.com/path@v2"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.val, func(t *testing.T) {
+			p := &Probe{}
+			err := p.Init("http_test", &options.Options{
+				Targets:   targets.StaticTargets("test.com"),
+				Interval:  10 * time.Second,
+				Timeout:   time.Second,
+				ProbeConf: &configpb.ProbeConf{Header: map[string]string{"X-Test": test.val}},
+			})
+			assert.NoError(t, err)
+
+			var want []string
+			if test.wantDynamic {
+				want = []string{"X-Test"}
+			}
+			assert.Equal(t, want, p.dynamicHeaderNames)
+		})
+	}
+}
+
 func TestDynamicHeaderAttrs(t *testing.T) {
 	p := &Probe{}
 	err := p.Init("http_test", &options.Options{
@@ -651,6 +690,9 @@ func TestDynamicHeaderAttrs(t *testing.T) {
 			Header: map[string]string{
 				"X-Request-ID": "@uuid@",
 				"X-Static":     "no-substitution",
+				// Substitution is a no-op here, so it stays out of the
+				// logs (issue #1449).
+				"X-Api-Key": "aB3@dE7fG1hJ",
 			},
 		},
 	})
@@ -660,8 +702,10 @@ func TestDynamicHeaderAttrs(t *testing.T) {
 	assert.NoError(t, err)
 	req = p.prepareRequest(context.Background(), req)
 
+	assert.Equal(t, "aB3@dE7fG1hJ", req.Header.Get("X-Api-Key"), "stray '@' value must be sent verbatim")
+
 	attrs := p.dynamicHeaderAttrs(req)
-	assert.Equal(t, 1, len(attrs), "only X-Request-ID should be dynamic")
+	assert.Equal(t, 1, len(attrs), "only X-Request-ID's value should be logged")
 	if len(attrs) == 1 {
 		assert.Equal(t, "X-Request-Id", attrs[0].Key)
 		got := attrs[0].Value.String()


### PR DESCRIPTION
Fixes #1449.

We decided a header was dynamic with `strings.Contains(val, "@")`, but substitution only ever matches `@name@`. So a value with one stray `@` got marked dynamic, substituted to itself, and then logged on probe errors — which is how an API key with an `@` in it ended up in the logs.

Detection now runs the substitution and checks whether the value changed, instead of guessing from the presence of an `@`. That can't drift from `SubstituteLabels()`, because it *is* `SubstituteLabels()`.

A value that doesn't change under substitution isn't dynamic: it's sent verbatim, kept out of the error-log attributes, and no longer forces a per-send clone of the request. A value that does change stays tracked — including the `@@` → `@` escape, which carries no resolvable token but does alter what goes on the wire.
