### PR TITLE
[reaper] Reap orphaned processes when we're init or a subreaper

### DIFF
--- a/cloudprober.go
+++ b/cloudprober.go
@@ -336,6 +336,11 @@ func RunOnce(ctx context.Context, names, format, indent string) error {
 }
 
 // Start starts a previously initialized Cloudprober.
+//
+// Note for embedders: if the process is init in its PID namespace (or a child
+// subreaper), Start also begins reaping orphaned child processes, since
+// nothing else will. That includes zombie children of the embedding binary
+// itself, if it leaves any unwaited-for for more than a few minutes.
 func Start(ctx context.Context) {
 	cloudProber.Lock()
 	defer cloudProber.Unlock()

--- a/cloudprober.go
+++ b/cloudprober.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cloudprober/cloudprober/common/tlsconfig"
 	"github.com/cloudprober/cloudprober/config"
 	configpb "github.com/cloudprober/cloudprober/config/proto"
+	"github.com/cloudprober/cloudprober/internal/reaper"
 	"github.com/cloudprober/cloudprober/internal/servers"
 	"github.com/cloudprober/cloudprober/internal/sysvars"
 	"github.com/cloudprober/cloudprober/logger"
@@ -338,6 +339,13 @@ func RunOnce(ctx context.Context, names, format, indent string) error {
 func Start(ctx context.Context) {
 	cloudProber.Lock()
 	defer cloudProber.Unlock()
+
+	// If we're init in our PID namespace (the usual case for our container
+	// images), orphaned processes -- e.g. browser processes left behind by the
+	// browser probe -- are reparented to us, and it's on us to reap them. This
+	// is a no-op if somebody else is collecting orphans, e.g. /pause with
+	// shareProcessNamespace on Kubernetes, or tini with docker's --init.
+	reaper.Start(ctx, logger.NewWithAttrs(slog.String("component", "reaper")))
 
 	// Default servers
 	srvMux := state.DefaultHTTPServeMux()

--- a/internal/reaper/reaper_linux.go
+++ b/internal/reaper/reaper_linux.go
@@ -75,6 +75,16 @@ const (
 	prGetChildSubreaper = 37
 )
 
+// procID identifies a process by its pid and its start time. The start time is
+// what keeps us from confusing a recycled pid with the zombie we first saw a
+// minute ago: the kernel doesn't record when a process died, so all we have is
+// when we first noticed it, and that's only sound if we can tell the two
+// apart.
+type procID struct {
+	pid       int
+	startTime uint64
+}
+
 type reaper struct {
 	procRoot string
 	pid      int
@@ -82,8 +92,8 @@ type reaper struct {
 	grace    time.Duration
 	l        *logger.Logger
 
-	// When we first saw a zombie child, keyed by pid.
-	seen map[int]time.Time
+	// When we first saw a zombie child.
+	seen map[procID]time.Time
 	// Reaps the given pid; overridden in tests.
 	reap func(pid int) error
 }
@@ -119,7 +129,7 @@ func Start(ctx context.Context, l *logger.Logger) {
 		interval: scanInterval,
 		grace:    gracePeriod,
 		l:        l,
-		seen:     make(map[int]time.Time),
+		seen:     make(map[procID]time.Time),
 		reap:     reapPid,
 	}
 	go r.run(ctx)
@@ -152,16 +162,16 @@ func (r *reaper) reapOrphans(now time.Time) {
 	}
 
 	var reaped []int
-	current := make(map[int]bool, len(zombies))
+	current := make(map[procID]bool, len(zombies))
 
-	for _, pid := range zombies {
-		current[pid] = true
+	for _, proc := range zombies {
+		current[proc] = true
 
-		firstSeen, ok := r.seen[pid]
+		firstSeen, ok := r.seen[proc]
 		if !ok {
 			// First time we're seeing this one; give its owner, if it has one,
 			// a chance to wait on it.
-			r.seen[pid] = now
+			r.seen[proc] = now
 			continue
 		}
 		if now.Sub(firstSeen) < r.grace {
@@ -169,22 +179,20 @@ func (r *reaper) reapOrphans(now time.Time) {
 		}
 
 		// syscall.ECHILD means somebody else got to it first, which is fine.
-		if err := r.reap(pid); err != nil && !errors.Is(err, syscall.ECHILD) {
-			r.l.Warningf("Error reaping orphaned child process %d: %v", pid, err)
+		if err := r.reap(proc.pid); err != nil && !errors.Is(err, syscall.ECHILD) {
+			r.l.Warningf("Error reaping orphaned child process %d: %v", proc.pid, err)
 			continue
 		}
-		reaped = append(reaped, pid)
+		delete(r.seen, proc)
+		reaped = append(reaped, proc.pid)
 	}
 
 	// Forget the zombies that are gone now, whether we reaped them or their
 	// owner did.
-	for pid := range r.seen {
-		if !current[pid] {
-			delete(r.seen, pid)
+	for proc := range r.seen {
+		if !current[proc] {
+			delete(r.seen, proc)
 		}
-	}
-	for _, pid := range reaped {
-		delete(r.seen, pid)
 	}
 
 	if len(reaped) > 0 {
@@ -192,15 +200,15 @@ func (r *reaper) reapOrphans(now time.Time) {
 	}
 }
 
-// zombieChildren returns the pids of our children that are in the zombie ("Z")
-// state, by scanning /proc.
-func (r *reaper) zombieChildren() ([]int, error) {
+// zombieChildren returns our children that are in the zombie ("Z") state, by
+// scanning /proc.
+func (r *reaper) zombieChildren() ([]procID, error) {
 	entries, err := os.ReadDir(r.procRoot)
 	if err != nil {
 		return nil, err
 	}
 
-	var zombies []int
+	var zombies []procID
 	for _, entry := range entries {
 		pid, err := strconv.Atoi(entry.Name())
 		if err != nil {
@@ -210,38 +218,44 @@ func (r *reaper) zombieChildren() ([]int, error) {
 		if err != nil {
 			continue // Process is gone already; nothing to reap.
 		}
-		state, ppid, err := parseStat(b)
+		state, ppid, startTime, err := parseStat(b)
 		if err != nil {
 			r.l.Warningf("Error parsing stat of the process %d: %v", pid, err)
 			continue
 		}
 		if state == 'Z' && ppid == r.pid {
-			zombies = append(zombies, pid)
+			zombies = append(zombies, procID{pid: pid, startTime: startTime})
 		}
 	}
 
 	return zombies, nil
 }
 
-// parseStat returns the process state and parent pid -- the 3rd and 4th fields
-// -- from the contents of /proc/<pid>/stat. Note that the 2nd field (comm) is
-// the executable name in parentheses and can itself contain spaces and
-// parentheses, so we start parsing after the last ")".
-func parseStat(b []byte) (byte, int, error) {
+// parseStat returns the process state, parent pid, and start time -- the 3rd,
+// 4th, and 22nd fields -- from the contents of /proc/<pid>/stat. Note that the
+// 2nd field (comm) is the executable name in parentheses and can itself
+// contain spaces and parentheses, so we start parsing after the last ")".
+func parseStat(b []byte) (byte, int, uint64, error) {
 	i := bytes.LastIndexByte(b, ')')
 	if i < 0 {
-		return 0, 0, fmt.Errorf("unexpected format, no \")\" in %q", string(b))
+		return 0, 0, 0, fmt.Errorf("unexpected format, no \")\" in %q", string(b))
 	}
 
+	// After comm, fields[0] is the 3rd field, so the 22nd is fields[19].
 	fields := strings.Fields(string(b[i+1:]))
-	if len(fields) < 2 {
-		return 0, 0, fmt.Errorf("unexpected format, no state and ppid in %q", string(b))
+	if len(fields) < 20 {
+		return 0, 0, 0, fmt.Errorf("unexpected format, only %d fields after comm in %q", len(fields), string(b))
 	}
 
 	ppid, err := strconv.Atoi(fields[1])
 	if err != nil {
-		return 0, 0, fmt.Errorf("bad ppid (%s): %v", fields[1], err)
+		return 0, 0, 0, fmt.Errorf("bad ppid (%s): %v", fields[1], err)
 	}
 
-	return fields[0][0], ppid, nil
+	startTime, err := strconv.ParseUint(fields[19], 10, 64)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("bad start time (%s): %v", fields[19], err)
+	}
+
+	return fields[0][0], ppid, startTime, nil
 }

--- a/internal/reaper/reaper_linux.go
+++ b/internal/reaper/reaper_linux.go
@@ -100,8 +100,9 @@ type reaper struct {
 
 	// When we first saw a zombie child.
 	seen map[procID]time.Time
-	// Reaps the given pid; overridden in tests.
-	reap func(pid int) error
+	// Reaps the given pid, returning the pid actually reaped (0 if there was
+	// nothing to reap). Overridden in tests.
+	reap func(pid int) (int, error)
 }
 
 // isSubreaper returns whether we've been marked a child subreaper, which gives
@@ -141,9 +142,8 @@ func Start(ctx context.Context, l *logger.Logger) {
 	go r.run(ctx)
 }
 
-func reapPid(pid int) error {
-	_, err := syscall.Wait4(pid, nil, syscall.WNOHANG, nil)
-	return err
+func reapPid(pid int) (int, error) {
+	return syscall.Wait4(pid, nil, syscall.WNOHANG, nil)
 }
 
 func (r *reaper) run(ctx context.Context) {
@@ -185,12 +185,21 @@ func (r *reaper) reapOrphans(now time.Time) {
 		}
 
 		// syscall.ECHILD means somebody else got to it first, which is fine.
-		if err := r.reap(proc.pid); err != nil && !errors.Is(err, syscall.ECHILD) {
+		wpid, err := r.reap(proc.pid)
+		if err != nil && !errors.Is(err, syscall.ECHILD) {
 			r.l.Warningf("Error reaping orphaned child process %d: %v", proc.pid, err)
 			continue
 		}
+
+		// Either way we're done with this sighting: it's gone, or the pid was
+		// recycled between the scan and the wait4 and our record of it is
+		// stale. We only claim to have reaped it if wait4 says we did --
+		// WNOHANG returns 0 for a child that's alive, which is what a recycled
+		// pid looks like from here.
 		delete(r.seen, proc)
-		reaped = append(reaped, proc.pid)
+		if wpid > 0 {
+			reaped = append(reaped, proc.pid)
+		}
 	}
 
 	// Forget the zombies that are gone now, whether we reaped them or their

--- a/internal/reaper/reaper_linux.go
+++ b/internal/reaper/reaper_linux.go
@@ -62,23 +62,29 @@ import (
 )
 
 const (
-	// How often we look for zombie children.
-	scanInterval = 30 * time.Second
+	// How often we look for zombie children. A zombie has to be seen in two
+	// scans a gracePeriod apart before we touch it, so there's nothing to gain
+	// from looking more often than this.
+	scanInterval = 60 * time.Second
 
 	// How long a zombie child has to stay unclaimed before we assume it's an
 	// orphan and reap it. This is what keeps us from racing with os/exec over
-	// the processes cloudprober starts itself; it's deliberately much longer
-	// than the milliseconds it takes cmd.Wait to reap them.
-	gracePeriod = 60 * time.Second
+	// the processes cloudprober starts itself, and it's deliberately far longer
+	// than the milliseconds cmd.Wait actually takes: the two failure modes are
+	// wildly asymmetric. Leaking a zombie for a few extra minutes costs
+	// nothing -- it took months of leaking for anyone to notice -- while
+	// reaping a process somebody was about to wait on breaks that probe run
+	// right away.
+	gracePeriod = 5 * time.Minute
 
 	// PR_GET_CHILD_SUBREAPER, from linux/prctl.h.
 	prGetChildSubreaper = 37
 )
 
 // procID identifies a process by its pid and its start time. The start time is
-// what keeps us from confusing a recycled pid with the zombie we first saw a
-// minute ago: the kernel doesn't record when a process died, so all we have is
-// when we first noticed it, and that's only sound if we can tell the two
+// what keeps us from confusing a recycled pid with the zombie we first saw
+// minutes ago: the kernel doesn't record when a process died, so all we have
+// is when we first noticed it, and that's only sound if we can tell the two
 // apart.
 type procID struct {
 	pid       int

--- a/internal/reaper/reaper_linux.go
+++ b/internal/reaper/reaper_linux.go
@@ -62,9 +62,10 @@ import (
 )
 
 const (
-	// How often we look for zombie children. A zombie has to be seen in two
-	// scans a gracePeriod apart before we touch it, so there's nothing to gain
-	// from looking more often than this.
+	// How often we look for zombie children. Scanning more often only shortens
+	// the wait between a zombie appearing and us first noticing it; the
+	// gracePeriod below dominates either way, so there's little to gain from
+	// reading all of /proc more frequently than this.
 	scanInterval = 60 * time.Second
 
 	// How long a zombie child has to stay unclaimed before we assume it's an
@@ -193,9 +194,15 @@ func (r *reaper) reapOrphans(now time.Time) {
 
 		// Either way we're done with this sighting: it's gone, or the pid was
 		// recycled between the scan and the wait4 and our record of it is
-		// stale. We only claim to have reaped it if wait4 says we did --
-		// WNOHANG returns 0 for a child that's alive, which is what a recycled
-		// pid looks like from here.
+		// stale. Only count it as reaped if wait4 says so -- it returns 0 for
+		// a live child (and -1 on ECHILD), so a pid recycled to a running
+		// process reaps nothing and shouldn't be logged as if it did.
+		//
+		// wait4 takes a pid, not a (pid, start time), so a pid recycled in
+		// that same window to a child that has *already* exited would be
+		// reaped out from under its owner. That needs a full pid-space
+		// wraparound between the scan and this call, and it isn't
+		// expressible through wait4 anyway.
 		delete(r.seen, proc)
 		if wpid > 0 {
 			reaped = append(reaped, proc.pid)
@@ -229,9 +236,13 @@ func (r *reaper) zombieChildren() ([]procID, error) {
 		if err != nil {
 			continue // Not a process directory.
 		}
+		// Almost always ENOENT, i.e. the process is gone and there's nothing to
+		// reap. A read that fails for any other reason drops this sighting and
+		// restarts the process's grace period on the next scan, which delays
+		// reaping rather than rushing it.
 		b, err := os.ReadFile(filepath.Join(r.procRoot, entry.Name(), "stat"))
 		if err != nil {
-			continue // Process is gone already; nothing to reap.
+			continue
 		}
 		state, ppid, startTime, err := parseStat(b)
 		if err != nil {

--- a/internal/reaper/reaper_linux.go
+++ b/internal/reaper/reaper_linux.go
@@ -1,0 +1,247 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+/*
+Package reaper reaps orphaned child processes that get reparented to
+cloudprober.
+
+Our container images run cloudprober itself as the entrypoint, which makes it
+PID 1 inside the container's PID namespace, and hence init: the kernel
+reparents orphaned processes to it, and it inherits init's duty of waiting on
+them. Processes that cloudprober starts itself are waited on by whoever started
+them (through os/exec), but their descendants are not. The browser probe is the
+worst offender: it runs "npx playwright test", playwright starts the browser in
+its own process group (it spawns it detached), and the browser forks further
+helper processes of its own. Whenever one of those outlives its parent, it is
+reparented to us, and with nobody waiting on it, it stays around as a zombie
+forever -- a handful of <defunct> browser processes per probe run, eventually
+exhausting the PID space.
+
+We can't just call wait4(-1): that would race with os/exec and steal the exit
+statuses of processes cloudprober started itself, making those probe runs fail.
+Instead we look for zombie children in /proc and reap only the ones that have
+been sitting unclaimed for gracePeriod. Everything cloudprober starts is waited
+on right away (all our callers block in cmd.Wait), so a zombie that is still
+around after that long has no owner coming for it.
+
+This only runs if orphans are actually being reparented to us, i.e. we're init
+in our PID namespace or a child subreaper. Anything else means somebody else is
+already doing this job -- /pause with shareProcessNamespace on Kubernetes, tini
+with docker's --init -- and setting one of those up remains a perfectly good
+way to sidestep this mechanism entirely.
+*/
+package reaper
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/cloudprober/cloudprober/logger"
+)
+
+const (
+	// How often we look for zombie children.
+	scanInterval = 30 * time.Second
+
+	// How long a zombie child has to stay unclaimed before we assume it's an
+	// orphan and reap it. This is what keeps us from racing with os/exec over
+	// the processes cloudprober starts itself; it's deliberately much longer
+	// than the milliseconds it takes cmd.Wait to reap them.
+	gracePeriod = 60 * time.Second
+
+	// PR_GET_CHILD_SUBREAPER, from linux/prctl.h.
+	prGetChildSubreaper = 37
+)
+
+type reaper struct {
+	procRoot string
+	pid      int
+	interval time.Duration
+	grace    time.Duration
+	l        *logger.Logger
+
+	// When we first saw a zombie child, keyed by pid.
+	seen map[int]time.Time
+	// Reaps the given pid; overridden in tests.
+	reap func(pid int) error
+}
+
+// isSubreaper returns whether we've been marked a child subreaper, which gives
+// us the same orphan-collecting duty as init. Cloudprober never sets this on
+// itself, but the attribute survives execve, so a supervisor could have set it
+// before starting us.
+func isSubreaper() bool {
+	var v int32
+	if _, _, errno := syscall.Syscall(syscall.SYS_PRCTL, prGetChildSubreaper, uintptr(unsafe.Pointer(&v)), 0); errno != 0 {
+		return false
+	}
+	return v != 0
+}
+
+// Start starts a background goroutine that reaps orphaned child processes that
+// have been reparented to us. It's a no-op unless we're the one collecting
+// orphans in the first place -- if we're neither init in our PID namespace nor
+// a child subreaper, orphans go to somebody else, who is responsible for
+// reaping them.
+func Start(ctx context.Context, l *logger.Logger) {
+	if os.Getpid() != 1 && !isSubreaper() {
+		l.Debugf("Not init or a subreaper; orphaned processes are not ours to reap.")
+		return
+	}
+
+	l.Infof("Collecting orphaned processes (pid: %d); starting the child process reaper.", os.Getpid())
+
+	r := &reaper{
+		procRoot: "/proc",
+		pid:      os.Getpid(),
+		interval: scanInterval,
+		grace:    gracePeriod,
+		l:        l,
+		seen:     make(map[int]time.Time),
+		reap:     reapPid,
+	}
+	go r.run(ctx)
+}
+
+func reapPid(pid int) error {
+	_, err := syscall.Wait4(pid, nil, syscall.WNOHANG, nil)
+	return err
+}
+
+func (r *reaper) run(ctx context.Context) {
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.reapOrphans(time.Now())
+		}
+	}
+}
+
+func (r *reaper) reapOrphans(now time.Time) {
+	zombies, err := r.zombieChildren()
+	if err != nil {
+		r.l.Warningf("Error looking for zombie child processes: %v", err)
+		return
+	}
+
+	var reaped []int
+	current := make(map[int]bool, len(zombies))
+
+	for _, pid := range zombies {
+		current[pid] = true
+
+		firstSeen, ok := r.seen[pid]
+		if !ok {
+			// First time we're seeing this one; give its owner, if it has one,
+			// a chance to wait on it.
+			r.seen[pid] = now
+			continue
+		}
+		if now.Sub(firstSeen) < r.grace {
+			continue
+		}
+
+		// syscall.ECHILD means somebody else got to it first, which is fine.
+		if err := r.reap(pid); err != nil && !errors.Is(err, syscall.ECHILD) {
+			r.l.Warningf("Error reaping orphaned child process %d: %v", pid, err)
+			continue
+		}
+		reaped = append(reaped, pid)
+	}
+
+	// Forget the zombies that are gone now, whether we reaped them or their
+	// owner did.
+	for pid := range r.seen {
+		if !current[pid] {
+			delete(r.seen, pid)
+		}
+	}
+	for _, pid := range reaped {
+		delete(r.seen, pid)
+	}
+
+	if len(reaped) > 0 {
+		r.l.Infof("Reaped %d orphaned child process(es): %v", len(reaped), reaped)
+	}
+}
+
+// zombieChildren returns the pids of our children that are in the zombie ("Z")
+// state, by scanning /proc.
+func (r *reaper) zombieChildren() ([]int, error) {
+	entries, err := os.ReadDir(r.procRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	var zombies []int
+	for _, entry := range entries {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue // Not a process directory.
+		}
+		b, err := os.ReadFile(filepath.Join(r.procRoot, entry.Name(), "stat"))
+		if err != nil {
+			continue // Process is gone already; nothing to reap.
+		}
+		state, ppid, err := parseStat(b)
+		if err != nil {
+			r.l.Warningf("Error parsing stat of the process %d: %v", pid, err)
+			continue
+		}
+		if state == 'Z' && ppid == r.pid {
+			zombies = append(zombies, pid)
+		}
+	}
+
+	return zombies, nil
+}
+
+// parseStat returns the process state and parent pid -- the 3rd and 4th fields
+// -- from the contents of /proc/<pid>/stat. Note that the 2nd field (comm) is
+// the executable name in parentheses and can itself contain spaces and
+// parentheses, so we start parsing after the last ")".
+func parseStat(b []byte) (byte, int, error) {
+	i := bytes.LastIndexByte(b, ')')
+	if i < 0 {
+		return 0, 0, fmt.Errorf("unexpected format, no \")\" in %q", string(b))
+	}
+
+	fields := strings.Fields(string(b[i+1:]))
+	if len(fields) < 2 {
+		return 0, 0, fmt.Errorf("unexpected format, no state and ppid in %q", string(b))
+	}
+
+	ppid, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("bad ppid (%s): %v", fields[1], err)
+	}
+
+	return fields[0][0], ppid, nil
+}

--- a/internal/reaper/reaper_linux_test.go
+++ b/internal/reaper/reaper_linux_test.go
@@ -1,0 +1,278 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package reaper
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cloudprober/cloudprober/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// PR_SET_CHILD_SUBREAPER, from linux/prctl.h.
+const prSetChildSubreaper = 36
+
+func TestParseStat(t *testing.T) {
+	tests := []struct {
+		desc      string
+		stat      string
+		wantState byte
+		wantPPID  int
+		wantErr   bool
+	}{
+		{
+			desc:      "simple",
+			stat:      "1234 (headless_shell) Z 1 1234 1234 0 -1 4194560 0 0",
+			wantState: 'Z',
+			wantPPID:  1,
+		},
+		{
+			desc:      "comm with spaces and parens",
+			stat:      "42 (node (js) worker) S 17 42 42 0 -1 4194304 0 0",
+			wantState: 'S',
+			wantPPID:  17,
+		},
+		{
+			desc:    "no comm",
+			stat:    "1234 Z 1 1234",
+			wantErr: true,
+		},
+		{
+			desc:    "truncated after comm",
+			stat:    "1234 (sh) Z",
+			wantErr: true,
+		},
+		{
+			desc:    "bad ppid",
+			stat:    "1234 (sh) Z init 1234",
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			state, ppid, err := parseStat([]byte(test.stat))
+			if test.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, string(test.wantState), string(state), "state")
+			assert.Equal(t, test.wantPPID, ppid, "ppid")
+		})
+	}
+}
+
+// testReaper sets up a reaper over a fake /proc, with the given processes,
+// each one described as "<state> <ppid>".
+func testReaper(t *testing.T, procs map[int]string) *reaper {
+	t.Helper()
+
+	procRoot := t.TempDir()
+	for pid, proc := range procs {
+		dir := filepath.Join(procRoot, fmt.Sprintf("%d", pid))
+		require.NoError(t, os.Mkdir(dir, 0755))
+		stat := fmt.Sprintf("%d (headless_shell) %s 0 0 0 -1 4194560", pid, proc)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "stat"), []byte(stat), 0644))
+	}
+	// Non-process entries in /proc should be ignored.
+	require.NoError(t, os.Mkdir(filepath.Join(procRoot, "sys"), 0755))
+
+	return &reaper{
+		procRoot: procRoot,
+		pid:      100,
+		grace:    time.Minute,
+		l:        &logger.Logger{},
+		seen:     make(map[int]time.Time),
+	}
+}
+
+func TestZombieChildren(t *testing.T) {
+	r := testReaper(t, map[int]string{
+		100: "S 1",   // us
+		101: "Z 100", // zombie child
+		102: "S 100", // running child
+		103: "Z 100", // zombie child
+		104: "Z 1",   // zombie, but not ours
+	})
+
+	zombies, err := r.zombieChildren()
+	assert.NoError(t, err)
+	sort.Ints(zombies)
+	assert.Equal(t, []int{101, 103}, zombies)
+}
+
+func TestReapOrphansWaitsForGracePeriod(t *testing.T) {
+	r := testReaper(t, map[int]string{
+		101: "Z 100",
+		102: "S 100",
+	})
+
+	var reaped []int
+	r.reap = func(pid int) error {
+		reaped = append(reaped, pid)
+		return nil
+	}
+
+	now := time.Now()
+
+	// First sighting: we only note the zombie, its owner may still wait on it.
+	r.reapOrphans(now)
+	assert.Empty(t, reaped, "reaped on first sighting")
+	assert.Contains(t, r.seen, 101)
+
+	// Still within the grace period.
+	r.reapOrphans(now.Add(r.grace - time.Second))
+	assert.Empty(t, reaped, "reaped within the grace period")
+
+	// Unclaimed for longer than the grace period: it's an orphan.
+	r.reapOrphans(now.Add(r.grace + time.Second))
+	assert.Equal(t, []int{101}, reaped)
+	assert.NotContains(t, r.seen, 101, "reaped pid not removed from seen")
+}
+
+func TestReapOrphansForgetsGoneZombies(t *testing.T) {
+	r := testReaper(t, map[int]string{101: "Z 100"})
+	r.reap = func(pid int) error { return nil }
+
+	r.reapOrphans(time.Now())
+	assert.Contains(t, r.seen, 101, "zombie not recorded")
+
+	// Zombie's owner reaped it before our grace period ran out.
+	require.NoError(t, os.RemoveAll(filepath.Join(r.procRoot, "101")))
+
+	r.reapOrphans(time.Now())
+	assert.NotContains(t, r.seen, 101, "vanished zombie not forgotten")
+}
+
+func TestReapOrphansIgnoresECHILD(t *testing.T) {
+	r := testReaper(t, map[int]string{101: "Z 100"})
+	r.grace = 0
+	r.reap = func(pid int) error { return syscall.ECHILD }
+
+	now := time.Now()
+	r.reapOrphans(now)
+	r.reapOrphans(now.Add(time.Second))
+
+	// ECHILD means somebody else got to it first; we're done with this pid.
+	assert.NotContains(t, r.seen, 101)
+}
+
+// TestReapRealZombie verifies the whole thing against a real zombie child and
+// the real /proc.
+func TestReapRealZombie(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	require.NoError(t, cmd.Start())
+	pid := cmd.Process.Pid
+
+	r := &reaper{
+		procRoot: "/proc",
+		pid:      os.Getpid(),
+		grace:    0,
+		l:        &logger.Logger{},
+		seen:     make(map[int]time.Time),
+		reap:     reapPid,
+	}
+
+	// Wait for the child to exit and become a zombie -- we never wait on it.
+	assert.Eventually(t, func() bool {
+		zombies, err := r.zombieChildren()
+		if err != nil {
+			return false
+		}
+		for _, z := range zombies {
+			if z == pid {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "child (%d) didn't show up as a zombie", pid)
+
+	// First scan notes it, second one reaps it (grace period is zero here).
+	r.reapOrphans(time.Now())
+	r.reapOrphans(time.Now())
+
+	zombies, err := r.zombieChildren()
+	assert.NoError(t, err)
+	assert.NotContains(t, zombies, pid, "zombie child was not reaped")
+}
+
+// TestOrphanedDetachedGrandchild reproduces what the browser probe runs into:
+// a grandchild that setsid'ed itself into a process group of its own (that's
+// how playwright starts browsers) is orphaned onto us, and we are the one
+// collecting orphans. Nothing but this reaper can wait on such a process.
+//
+// We can't be PID 1 in a test, so we make ourselves a child subreaper instead,
+// which gives us the same duty. That's a process-wide, inherited setting, so
+// this runs in a subprocess.
+func TestOrphanedDetachedGrandchild(t *testing.T) {
+	if os.Getenv("GO_CP_TEST_SUBREAPER") != "1" {
+		cmd := exec.Command(os.Args[0], "-test.run=TestOrphanedDetachedGrandchild", "-test.v")
+		cmd.Env = append(os.Environ(), "GO_CP_TEST_SUBREAPER=1")
+		out, err := cmd.CombinedOutput()
+		assert.NoError(t, err, "subprocess output:\n%s", out)
+		return
+	}
+
+	assert.False(t, isSubreaper(), "subreaper before we set it")
+
+	// PR_SET_CHILD_SUBREAPER (36): orphaned descendants are reparented to us
+	// instead of to init, exactly like they are to cloudprober as PID 1.
+	_, _, errno := syscall.Syscall(syscall.SYS_PRCTL, prSetChildSubreaper, 1, 0)
+	require.Zero(t, errno, "prctl(PR_SET_CHILD_SUBREAPER)")
+
+	// This is what makes Start run the reaper for a process that isn't PID 1.
+	assert.True(t, isSubreaper(), "subreaper after we set it")
+
+	// The outer shell exits right away, orphaning the setsid'ed grandchild.
+	cmd := exec.Command("/bin/sh", "-c", "setsid /bin/sh -c 'sleep 0.2' & exit 0")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	require.NoError(t, cmd.Run())
+
+	r := &reaper{
+		procRoot: "/proc",
+		pid:      os.Getpid(),
+		grace:    0,
+		l:        &logger.Logger{},
+		seen:     make(map[int]time.Time),
+		reap:     reapPid,
+	}
+
+	// The grandchild is not in any process group we know of, so waiting on the
+	// command's process group (what probes/common/command does) can't see it;
+	// it lands on us as a zombie and stays one until we reap it.
+	assert.Eventually(t, func() bool {
+		zombies, _ := r.zombieChildren()
+		return len(zombies) > 0
+	}, 5*time.Second, 10*time.Millisecond, "orphaned grandchild never showed up as our zombie child")
+
+	// First scan notes it, second one reaps it (grace period is zero here).
+	r.reapOrphans(time.Now())
+	r.reapOrphans(time.Now())
+
+	zombies, err := r.zombieChildren()
+	assert.NoError(t, err)
+	assert.Empty(t, zombies, "zombies left after reaping")
+}

--- a/internal/reaper/reaper_linux_test.go
+++ b/internal/reaper/reaper_linux_test.go
@@ -17,6 +17,7 @@
 package reaper
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -354,4 +355,80 @@ func TestOrphanedDetachedGrandchild(t *testing.T) {
 	zombies, err := r.zombieChildren()
 	assert.NoError(t, err)
 	assert.Empty(t, zombies, "zombies left after reaping")
+}
+
+func TestRun(t *testing.T) {
+	r := testReaper(t, map[int]string{101: "Z 100"})
+	r.interval = time.Millisecond
+	r.grace = 0
+
+	reaped := make(chan int, 1)
+	r.reap = func(pid int) (int, error) {
+		select {
+		case reaped <- pid:
+		default: // Already recorded; the loop keeps running until we cancel.
+		}
+		return pid, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.run(ctx)
+	}()
+
+	select {
+	case pid := <-reaped:
+		assert.Equal(t, 101, pid)
+	case <-time.After(5 * time.Second):
+		t.Fatal("run() never reaped the zombie")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("run() didn't return after its context was cancelled")
+	}
+}
+
+func TestZombieChildrenErrors(t *testing.T) {
+	t.Run("unreadable proc root", func(t *testing.T) {
+		r := testReaper(t, nil)
+		r.procRoot = filepath.Join(r.procRoot, "does-not-exist")
+
+		_, err := r.zombieChildren()
+		assert.Error(t, err)
+	})
+
+	t.Run("skips processes we can't read or parse", func(t *testing.T) {
+		r := testReaper(t, map[int]string{101: "Z 100"})
+
+		// A process that went away between the readdir and the read.
+		require.NoError(t, os.Mkdir(filepath.Join(r.procRoot, "102"), 0755))
+		// A stat file we can't make sense of.
+		require.NoError(t, os.Mkdir(filepath.Join(r.procRoot, "103"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(r.procRoot, "103", "stat"), []byte("garbage"), 0644))
+
+		zombies, err := r.zombieChildren()
+		assert.NoError(t, err)
+		assert.Equal(t, []procID{{101, 1010}}, zombies)
+	})
+}
+
+// An unexpected wait4 error leaves the sighting in place, to be retried on the
+// next scan rather than silently forgotten.
+func TestReapOrphansUnexpectedError(t *testing.T) {
+	r := testReaper(t, map[int]string{101: "Z 100"})
+	r.grace = 0
+	r.reap = func(pid int) (int, error) { return -1, syscall.EINVAL }
+
+	now := time.Now()
+	r.reapOrphans(now)
+	r.reapOrphans(now.Add(time.Second))
+
+	assert.Contains(t, r.seen, procID{101, 1010}, "sighting dropped after a failed reap")
 }

--- a/internal/reaper/reaper_linux_test.go
+++ b/internal/reaper/reaper_linux_test.go
@@ -157,9 +157,9 @@ func TestReapOrphansWaitsForGracePeriod(t *testing.T) {
 	})
 
 	var reaped []int
-	r.reap = func(pid int) error {
+	r.reap = func(pid int) (int, error) {
 		reaped = append(reaped, pid)
-		return nil
+		return pid, nil
 	}
 
 	now := time.Now()
@@ -181,7 +181,7 @@ func TestReapOrphansWaitsForGracePeriod(t *testing.T) {
 
 func TestReapOrphansForgetsGoneZombies(t *testing.T) {
 	r := testReaper(t, map[int]string{101: "Z 100"})
-	r.reap = func(pid int) error { return nil }
+	r.reap = func(pid int) (int, error) { return pid, nil }
 
 	r.reapOrphans(time.Now())
 	assert.Contains(t, r.seen, procID{101, 1010}, "zombie not recorded")
@@ -199,9 +199,9 @@ func TestReapOrphansRecycledPid(t *testing.T) {
 	r := testReaper(t, map[int]string{101: "Z 100"})
 
 	var reaped []int
-	r.reap = func(pid int) error {
+	r.reap = func(pid int) (int, error) {
 		reaped = append(reaped, pid)
-		return nil
+		return pid, nil
 	}
 
 	now := time.Now()
@@ -225,7 +225,7 @@ func TestReapOrphansRecycledPid(t *testing.T) {
 func TestReapOrphansIgnoresECHILD(t *testing.T) {
 	r := testReaper(t, map[int]string{101: "Z 100"})
 	r.grace = 0
-	r.reap = func(pid int) error { return syscall.ECHILD }
+	r.reap = func(pid int) (int, error) { return 0, syscall.ECHILD }
 
 	now := time.Now()
 	r.reapOrphans(now)
@@ -274,6 +274,27 @@ func TestReapRealZombie(t *testing.T) {
 	for _, z := range zombies {
 		assert.NotEqual(t, pid, z.pid, "zombie child was not reaped")
 	}
+}
+
+// A pid recycled to a live process between the scan and the wait4 is not
+// something we can reap, and we shouldn't claim we did.
+func TestReapOrphansLivePid(t *testing.T) {
+	r := testReaper(t, map[int]string{101: "Z 100"})
+	r.grace = 0
+
+	var reapCalls int
+	// What wait4(pid, WNOHANG) returns for a child that's alive.
+	r.reap = func(pid int) (int, error) {
+		reapCalls++
+		return 0, nil
+	}
+
+	now := time.Now()
+	r.reapOrphans(now)
+	r.reapOrphans(now.Add(time.Second))
+
+	assert.Equal(t, 1, reapCalls, "wait4 calls")
+	assert.NotContains(t, r.seen, procID{101, 1010}, "stale sighting not dropped")
 }
 
 // TestOrphanedDetachedGrandchild reproduces what the browser probe runs into:

--- a/internal/reaper/reaper_linux_test.go
+++ b/internal/reaper/reaper_linux_test.go
@@ -35,45 +35,59 @@ import (
 const prSetChildSubreaper = 36
 
 func TestParseStat(t *testing.T) {
+	// Fields 3 through 22 of /proc/<pid>/stat: state, ppid, and 17 fields we
+	// don't care about, ending in the start time.
+	statFields := func(state string, ppid int, startTime uint64) string {
+		return fmt.Sprintf("%s %d 1234 1234 0 -1 4194560 469 0 0 0 0 0 0 0 20 0 1 0 %d 16637952 1803", state, ppid, startTime)
+	}
+
 	tests := []struct {
-		desc      string
-		stat      string
-		wantState byte
-		wantPPID  int
-		wantErr   bool
+		desc          string
+		stat          string
+		wantState     byte
+		wantPPID      int
+		wantStartTime uint64
+		wantErr       bool
 	}{
 		{
-			desc:      "simple",
-			stat:      "1234 (headless_shell) Z 1 1234 1234 0 -1 4194560 0 0",
-			wantState: 'Z',
-			wantPPID:  1,
+			desc:          "simple",
+			stat:          "1234 (headless_shell) " + statFields("Z", 1, 64685302),
+			wantState:     'Z',
+			wantPPID:      1,
+			wantStartTime: 64685302,
 		},
 		{
-			desc:      "comm with spaces and parens",
-			stat:      "42 (node (js) worker) S 17 42 42 0 -1 4194304 0 0",
-			wantState: 'S',
-			wantPPID:  17,
+			desc:          "comm with spaces and parens",
+			stat:          "42 (node (js) worker) " + statFields("S", 17, 12345),
+			wantState:     'S',
+			wantPPID:      17,
+			wantStartTime: 12345,
 		},
 		{
 			desc:    "no comm",
-			stat:    "1234 Z 1 1234",
+			stat:    "1234 " + statFields("Z", 1, 64685302),
 			wantErr: true,
 		},
 		{
 			desc:    "truncated after comm",
-			stat:    "1234 (sh) Z",
+			stat:    "1234 (sh) Z 1 1234",
 			wantErr: true,
 		},
 		{
 			desc:    "bad ppid",
-			stat:    "1234 (sh) Z init 1234",
+			stat:    "1234 (sh) Z init 1234 1234 0 -1 4194560 469 0 0 0 0 0 0 0 20 0 1 0 64685302",
+			wantErr: true,
+		},
+		{
+			desc:    "bad start time",
+			stat:    "1234 (sh) Z 1 1234 1234 0 -1 4194560 469 0 0 0 0 0 0 0 20 0 1 0 boottime 16637952",
 			wantErr: true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			state, ppid, err := parseStat([]byte(test.stat))
+			state, ppid, startTime, err := parseStat([]byte(test.stat))
 			if test.wantErr {
 				assert.Error(t, err)
 				return
@@ -81,21 +95,20 @@ func TestParseStat(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, string(test.wantState), string(state), "state")
 			assert.Equal(t, test.wantPPID, ppid, "ppid")
+			assert.Equal(t, test.wantStartTime, startTime, "start time")
 		})
 	}
 }
 
 // testReaper sets up a reaper over a fake /proc, with the given processes,
-// each one described as "<state> <ppid>".
+// each one described as "<state> <ppid>". Start time is derived from the pid,
+// so a pid rewritten with writeProc gets a new one.
 func testReaper(t *testing.T, procs map[int]string) *reaper {
 	t.Helper()
 
 	procRoot := t.TempDir()
 	for pid, proc := range procs {
-		dir := filepath.Join(procRoot, fmt.Sprintf("%d", pid))
-		require.NoError(t, os.Mkdir(dir, 0755))
-		stat := fmt.Sprintf("%d (headless_shell) %s 0 0 0 -1 4194560", pid, proc)
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "stat"), []byte(stat), 0644))
+		writeProc(t, procRoot, pid, proc, uint64(pid*10))
 	}
 	// Non-process entries in /proc should be ignored.
 	require.NoError(t, os.Mkdir(filepath.Join(procRoot, "sys"), 0755))
@@ -105,8 +118,21 @@ func testReaper(t *testing.T, procs map[int]string) *reaper {
 		pid:      100,
 		grace:    time.Minute,
 		l:        &logger.Logger{},
-		seen:     make(map[int]time.Time),
+		seen:     make(map[procID]time.Time),
 	}
+}
+
+// writeProc writes a fake /proc/<pid>/stat for a process described as
+// "<state> <ppid>".
+func writeProc(t *testing.T, procRoot string, pid int, proc string, startTime uint64) {
+	t.Helper()
+
+	dir := filepath.Join(procRoot, fmt.Sprintf("%d", pid))
+	if err := os.Mkdir(dir, 0755); err != nil && !os.IsExist(err) {
+		t.Fatal(err)
+	}
+	stat := fmt.Sprintf("%d (headless_shell) %s 0 0 0 -1 4194560 469 0 0 0 0 0 0 0 20 0 1 0 %d 16637952 1803", pid, proc, startTime)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "stat"), []byte(stat), 0644))
 }
 
 func TestZombieChildren(t *testing.T) {
@@ -120,8 +146,8 @@ func TestZombieChildren(t *testing.T) {
 
 	zombies, err := r.zombieChildren()
 	assert.NoError(t, err)
-	sort.Ints(zombies)
-	assert.Equal(t, []int{101, 103}, zombies)
+	sort.Slice(zombies, func(i, j int) bool { return zombies[i].pid < zombies[j].pid })
+	assert.Equal(t, []procID{{101, 1010}, {103, 1030}}, zombies)
 }
 
 func TestReapOrphansWaitsForGracePeriod(t *testing.T) {
@@ -141,7 +167,7 @@ func TestReapOrphansWaitsForGracePeriod(t *testing.T) {
 	// First sighting: we only note the zombie, its owner may still wait on it.
 	r.reapOrphans(now)
 	assert.Empty(t, reaped, "reaped on first sighting")
-	assert.Contains(t, r.seen, 101)
+	assert.Contains(t, r.seen, procID{101, 1010})
 
 	// Still within the grace period.
 	r.reapOrphans(now.Add(r.grace - time.Second))
@@ -150,7 +176,7 @@ func TestReapOrphansWaitsForGracePeriod(t *testing.T) {
 	// Unclaimed for longer than the grace period: it's an orphan.
 	r.reapOrphans(now.Add(r.grace + time.Second))
 	assert.Equal(t, []int{101}, reaped)
-	assert.NotContains(t, r.seen, 101, "reaped pid not removed from seen")
+	assert.NotContains(t, r.seen, procID{101, 1010}, "reaped pid not removed from seen")
 }
 
 func TestReapOrphansForgetsGoneZombies(t *testing.T) {
@@ -158,13 +184,42 @@ func TestReapOrphansForgetsGoneZombies(t *testing.T) {
 	r.reap = func(pid int) error { return nil }
 
 	r.reapOrphans(time.Now())
-	assert.Contains(t, r.seen, 101, "zombie not recorded")
+	assert.Contains(t, r.seen, procID{101, 1010}, "zombie not recorded")
 
 	// Zombie's owner reaped it before our grace period ran out.
 	require.NoError(t, os.RemoveAll(filepath.Join(r.procRoot, "101")))
 
 	r.reapOrphans(time.Now())
-	assert.NotContains(t, r.seen, 101, "vanished zombie not forgotten")
+	assert.NotContains(t, r.seen, procID{101, 1010}, "vanished zombie not forgotten")
+}
+
+// A pid that gets recycled inside the grace period is a different process, and
+// its own grace period starts over.
+func TestReapOrphansRecycledPid(t *testing.T) {
+	r := testReaper(t, map[int]string{101: "Z 100"})
+
+	var reaped []int
+	r.reap = func(pid int) error {
+		reaped = append(reaped, pid)
+		return nil
+	}
+
+	now := time.Now()
+	r.reapOrphans(now)
+	assert.Contains(t, r.seen, procID{101, 1010}, "zombie not recorded")
+
+	// Owner reaped 101 and the pid was handed to a new process, which is now a
+	// zombie itself.
+	writeProc(t, r.procRoot, 101, "Z 100", 9999)
+
+	r.reapOrphans(now.Add(r.grace + time.Second))
+	assert.Empty(t, reaped, "reaped a recycled pid based on the old process's first sighting")
+	assert.NotContains(t, r.seen, procID{101, 1010}, "old process not forgotten")
+	assert.Contains(t, r.seen, procID{101, 9999}, "recycled pid not recorded afresh")
+
+	// It gets reaped on its own schedule.
+	r.reapOrphans(now.Add(2*r.grace + 2*time.Second))
+	assert.Equal(t, []int{101}, reaped)
 }
 
 func TestReapOrphansIgnoresECHILD(t *testing.T) {
@@ -177,7 +232,7 @@ func TestReapOrphansIgnoresECHILD(t *testing.T) {
 	r.reapOrphans(now.Add(time.Second))
 
 	// ECHILD means somebody else got to it first; we're done with this pid.
-	assert.NotContains(t, r.seen, 101)
+	assert.NotContains(t, r.seen, procID{101, 1010})
 }
 
 // TestReapRealZombie verifies the whole thing against a real zombie child and
@@ -192,7 +247,7 @@ func TestReapRealZombie(t *testing.T) {
 		pid:      os.Getpid(),
 		grace:    0,
 		l:        &logger.Logger{},
-		seen:     make(map[int]time.Time),
+		seen:     make(map[procID]time.Time),
 		reap:     reapPid,
 	}
 
@@ -203,7 +258,7 @@ func TestReapRealZombie(t *testing.T) {
 			return false
 		}
 		for _, z := range zombies {
-			if z == pid {
+			if z.pid == pid {
 				return true
 			}
 		}
@@ -216,7 +271,9 @@ func TestReapRealZombie(t *testing.T) {
 
 	zombies, err := r.zombieChildren()
 	assert.NoError(t, err)
-	assert.NotContains(t, zombies, pid, "zombie child was not reaped")
+	for _, z := range zombies {
+		assert.NotEqual(t, pid, z.pid, "zombie child was not reaped")
+	}
 }
 
 // TestOrphanedDetachedGrandchild reproduces what the browser probe runs into:
@@ -256,7 +313,7 @@ func TestOrphanedDetachedGrandchild(t *testing.T) {
 		pid:      os.Getpid(),
 		grace:    0,
 		l:        &logger.Logger{},
-		seen:     make(map[int]time.Time),
+		seen:     make(map[procID]time.Time),
 		reap:     reapPid,
 	}
 

--- a/internal/reaper/reaper_linux_test.go
+++ b/internal/reaper/reaper_linux_test.go
@@ -225,7 +225,8 @@ func TestReapOrphansRecycledPid(t *testing.T) {
 func TestReapOrphansIgnoresECHILD(t *testing.T) {
 	r := testReaper(t, map[int]string{101: "Z 100"})
 	r.grace = 0
-	r.reap = func(pid int) (int, error) { return 0, syscall.ECHILD }
+	// What syscall.Wait4 returns on ECHILD: the raw -1, not 0.
+	r.reap = func(pid int) (int, error) { return -1, syscall.ECHILD }
 
 	now := time.Now()
 	r.reapOrphans(now)

--- a/internal/reaper/reaper_nonlinux.go
+++ b/internal/reaper/reaper_nonlinux.go
@@ -1,0 +1,28 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+// Package reaper reaps orphaned child processes that get reparented to
+// cloudprober. It's implemented only on Linux; see reaper_linux.go.
+package reaper
+
+import (
+	"context"
+
+	"github.com/cloudprober/cloudprober/logger"
+)
+
+// Start is a no-op on non-Linux platforms.
+func Start(_ context.Context, _ *logger.Logger) {}

--- a/internal/reaper/reaper_nonlinux.go
+++ b/internal/reaper/reaper_nonlinux.go
@@ -25,4 +25,8 @@ import (
 )
 
 // Start is a no-op on non-Linux platforms.
-func Start(_ context.Context, _ *logger.Logger) {}
+func Start(_ context.Context, _ *logger.Logger) {
+	// Nothing to do here. Reaping orphans is built on procfs and wait4, and
+	// the deployments that make cloudprober init for a process tree -- our
+	// container images -- are Linux-only anyway.
+}

--- a/probes/common/command/runcmd_linux.go
+++ b/probes/common/command/runcmd_linux.go
@@ -62,16 +62,21 @@ func runCommand(ctx context.Context, cmd *exec.Cmd, childProcessWaitTime time.Du
 	err := cmd.Wait()
 
 	// Start a goroutine to wait on the processes in the process group, to
-	// avoid zombies. We use a timer to make sure we don't create an
-	// unbounded number of goroutines in case a command hangs even on SIGKILL.
+	// avoid zombies. We give up after childProcessWaitTime to make sure we
+	// don't create an unbounded number of goroutines in case a command hangs
+	// even on SIGKILL.
 	// Note that this covers only the processes still in our process group;
 	// anything that started a group of its own (browsers, for example) and
 	// then got reparented to us is handled by internal/reaper.
 	go func() {
-		timeout := time.NewTimer(childProcessWaitTime)
-		defer timeout.Stop()
+		// The deadline bounds the loop as a whole, reaps included: a process
+		// group that keeps producing dead children shouldn't keep this
+		// goroutine -- and we start one per run -- alive indefinitely.
+		// Whatever is left when we give up is picked up by internal/reaper,
+		// if we're the process collecting orphans.
+		deadline := time.Now().Add(childProcessWaitTime)
 
-		for {
+		for time.Now().Before(deadline) {
 			// An error here (ECHILD) means there is nothing left in the
 			// process group to wait for.
 			pid, err := syscall.Wait4(-cmd.Process.Pid, nil, syscall.WNOHANG, nil)
@@ -84,11 +89,7 @@ func runCommand(ctx context.Context, cmd *exec.Cmd, childProcessWaitTime time.Du
 			}
 			// Nothing has exited yet; check back in a bit instead of spinning
 			// on wait4 for the whole childProcessWaitTime.
-			select {
-			case <-timeout.C:
-				return
-			case <-time.After(childProcessPollInterval):
-			}
+			time.Sleep(childProcessPollInterval)
 		}
 	}()
 

--- a/probes/common/command/runcmd_linux.go
+++ b/probes/common/command/runcmd_linux.go
@@ -31,6 +31,10 @@ import (
 
 var defaultChildProcessWaitTime = 10 * time.Second
 
+// How long to wait between wait4 calls while the process group still has
+// running processes in it.
+const childProcessPollInterval = 100 * time.Millisecond
+
 func runCommand(ctx context.Context, cmd *exec.Cmd, childProcessWaitTime time.Duration) error {
 	if childProcessWaitTime == 0 {
 		childProcessWaitTime = defaultChildProcessWaitTime
@@ -60,18 +64,31 @@ func runCommand(ctx context.Context, cmd *exec.Cmd, childProcessWaitTime time.Du
 	// Start a goroutine to wait on the processes in the process group, to
 	// avoid zombies. We use a timer to make sure we don't create an
 	// unbounded number of goroutines in case a command hangs even on SIGKILL.
+	// Note that this covers only the processes still in our process group;
+	// anything that started a group of its own (browsers, for example) and
+	// then got reparented to us is handled by internal/reaper.
 	go func() {
-		var err error
-
 		timeout := time.NewTimer(childProcessWaitTime)
 		defer timeout.Stop()
-		for err == nil {
+
+		for {
+			// An error here (ECHILD) means there is nothing left in the
+			// process group to wait for.
+			pid, err := syscall.Wait4(-cmd.Process.Pid, nil, syscall.WNOHANG, nil)
+			if err != nil {
+				return
+			}
+			// We reaped one; there may be more that are ready right now.
+			if pid > 0 {
+				continue
+			}
+			// Nothing has exited yet; check back in a bit instead of spinning
+			// on wait4 for the whole childProcessWaitTime.
 			select {
 			case <-timeout.C:
 				return
-			default:
+			case <-time.After(childProcessPollInterval):
 			}
-			_, err = syscall.Wait4(-cmd.Process.Pid, nil, syscall.WNOHANG, nil)
 		}
 	}()
 


### PR DESCRIPTION
## Problem

Browser probe runs leak zombie processes. Reported in the field as ~28k `[headless_shell] <defunct>` on a long-running instance, a handful accumulating per probe run, all parented to cloudprober.

Playwright starts browsers **detached** ([`processLauncher.js`](https://github.com/microsoft/playwright/blob/main/packages/playwright-core/src/server/utils/processLauncher.ts): `detached: process.platform !== 'win32'`, i.e. `setsid()`), so the browser and the helper processes it forks — zygote, gpu, renderers, all named `headless_shell` — live in a process group of their own. When they outlive their parent they're reparented to whoever collects orphans, which is cloudprober itself when it's PID 1 in its container (our images have no init shim), and nothing ever waits on them.

Waiting on the command's process group, which is all `runcmd_linux.go` can do, structurally cannot see them.

## Why not the previous approaches

We tried this generically before and reverted it in #1132:

- **#1130** — `wait4(-1, WNOHANG)` on a timer. It also reaps our own direct children, stealing exit statuses that the external probe needs.
- **#1131** — mutual exclusion between the reaper and `runCommand` via an `RWMutex`. Go's `RWMutex` blocks new `RLock`s once a writer is queued, so a waiting reaper stalls probe execution.

The missing piece both times was knowing *whose* zombie it is. The kernel won't tell us, but `/proc` will.

## This change

`internal/reaper` scans `/proc` every 60s for zombie children and reaps only the ones still unclaimed 5 minutes later, with a plain `wait4(<pid>, WNOHANG)`. Every spawn site in the tree is already blocked in wait before its child can exit (`probes/common/command`, `probes/external` server mode, `internal/servers/external`, `internal/alerting/notifier`, `common/oauth` — all `cmd.Wait`/`Run`/`Output`, and `os/exec` reaps before draining pipes), so a zombie that old has no owner coming for it. No `wait4(-1)`, no locks, nothing in the probe path.

The grace period is deliberately generous because the two failure modes are asymmetric: leaking a zombie for a few extra minutes costs nothing (this leak ran for 5+ months before anyone noticed), while reaping a process somebody was about to wait on breaks that probe run immediately. Sightings are keyed on (pid, start time) from `/proc/<pid>/stat`, so a recycled pid can't inherit an older process's first-sighting time.

It runs only when orphans are actually reparented to us: PID 1 in our namespace, or a child subreaper (not inherited across `fork`, but preserved across `execve`). Otherwise `Start` returns immediately — so `shareProcessNamespace: true` on Kubernetes and `--init` on docker remain good ways to sidestep the mechanism entirely, with no scanning at all.

Also fixes a busy-spin in the existing process-group reaper: it polled `wait4` with no delay whenever the group still had live processes, which for the browser probe (`ChildProcessWaitTime` = `interval/2`) could mean a 100% CPU spin for minutes.

## Testing

`TestOrphanedDetachedGrandchild` reproduces the production shape in a subprocess: it makes itself a child subreaper (same duty as PID 1), orphans a `setsid`'ed grandchild in its own process group, confirms it lands as an unreapable zombie, and that the reaper clears it. Plus unit tests for `/proc/<pid>/stat` parsing (comm containing spaces and parens, malformed fields), the grace-period logic, pid recycling inside the grace window, `ECHILD`, and a real zombie against the real `/proc`.

Revisits #1128.

