### PR TITLE
[ci] Clean stale fingerprinted assets from the gh-pages tree

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -68,6 +68,13 @@ jobs:
           ls public
           cd public && git status
 
+      - name: Clean stale assets
+        # Hugo keeps fingerprinted assets it no longer emits, so stale
+        # bundles accumulate in the branch. Drop the ones no page in the
+        # rebuilt tree references; the versioned config docs, which are not
+        # rebuilt on every run, keep the bundles they still reference.
+        run: tools/clean_stale_assets.sh docs/public
+
       - name: Deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/latest_config_docs.yml
+++ b/.github/workflows/latest_config_docs.yml
@@ -85,6 +85,13 @@ jobs:
           ls public
           cd public && git status
 
+      - name: Clean stale assets
+        # Hugo keeps fingerprinted assets it no longer emits, so stale
+        # bundles accumulate in the branch. Drop the ones no page in the
+        # rebuilt tree references; the versioned config docs, which are not
+        # rebuilt on every run, keep the bundles they still reference.
+        run: tools/clean_stale_assets.sh docs/public
+
       - name: Deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/clean_stale_assets.sh
+++ b/tools/clean_stale_assets.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Delete fingerprinted assets that no page in the built site references.
+#
+# Hugo rewrites its output tree in place and never deletes files it no
+# longer emits, so every time an asset's content (and therefore its
+# fingerprint) changes -- e.g. the search bundle, which embeds the site
+# content -- a new index.min.<sha>.js / main.<sha>.css / *_hu<sha>_....webp
+# lands in the tree while the old one is kept. Over time that accumulates
+# hundreds of stale bundles in the gh-pages branch.
+#
+# Only fingerprint-named files are ever considered, and only when
+# unreferenced, so files that live on in the tree without being rebuilt by
+# this run -- in particular the versioned config docs, which reference the
+# bundles they were built with -- keep working.
+
+set -euo pipefail
+
+DRY_RUN=0
+if [[ "${1:-}" == "-n" ]]; then
+  DRY_RUN=1
+  shift
+fi
+DIR="${1:?usage: clean_stale_assets.sh [-n] <built-site-dir>}"
+
+cd "$DIR"
+
+# Fingerprint patterns: the asset pipeline emits <name>[.min].<sha>.js|css,
+# the image pipeline <name>_hu<sha>_<params>.webp|png|jpg|avif.
+FP='[A-Za-z0-9_/.-]*\.[0-9a-f]{64,}\.(js|css)|[A-Za-z0-9_/.-]*_hu[0-9a-f]{32}_[A-Za-z0-9_]*\.(webp|png|jpe?g|avif)'
+
+# Basenames referenced by any built file. HTML is minified with unquoted
+# attributes (src=https://...), so match bare filename patterns instead of
+# attribute syntax. The search bundle embeds page content, so scanning the
+# JS as well covers references from pages built in this run.
+referenced=$(grep -rhoE "$FP" \
+  --include='*.html' --include='*.css' --include='*.js' \
+  --include='*.json' --include='*.xml' . | sed 's|.*/||' | sort -u || true)
+
+deleted=0
+freed=0
+while IFS= read -r f; do
+  base=${f##*/}
+  if ! grep -qxF "$base" <<<"$referenced"; then
+    if [[ "$DRY_RUN" == 1 ]]; then
+      echo "would delete: $f"
+    else
+      freed=$((freed + $(stat -c%s "$f")))
+      rm "$f"
+      echo "deleted: $f"
+    fi
+    deleted=$((deleted + 1))
+  fi
+done < <(find . -path ./.git -prune -o -type f -print |
+  grep -E '\.[0-9a-f]{64,}\.(js|css)$|_hu[0-9a-f]{32}_[A-Za-z0-9_]+\.(webp|png|jpe?g|avif)$' || true)
+
+if [[ "$DRY_RUN" == 1 ]]; then
+  echo "dry run: $deleted stale assets found"
+else
+  echo "deleted $deleted stale assets ($((freed / 1024)) KiB)"
+fi

--- a/tools/clean_stale_assets.sh
+++ b/tools/clean_stale_assets.sh
@@ -16,26 +16,63 @@
 
 set -euo pipefail
 
+usage() {
+  echo "usage: clean_stale_assets.sh [-n|--dry-run] <built-site-dir>" >&2
+  exit 2
+}
+
 DRY_RUN=0
-if [[ "${1:-}" == "-n" ]]; then
-  DRY_RUN=1
-  shift
-fi
-DIR="${1:?usage: clean_stale_assets.sh [-n] <built-site-dir>}"
+DIR=""
+for arg in "$@"; do
+  case "$arg" in
+    -n|--dry-run) DRY_RUN=1 ;;
+    -h|--help) usage ;;
+    -*) echo "error: unknown flag: $arg" >&2; usage ;;
+    *)
+      [[ -z "$DIR" ]] || { echo "error: unexpected argument: $arg" >&2; usage; }
+      DIR="$arg"
+      ;;
+  esac
+done
+[[ -n "$DIR" ]] || usage
+[[ -d "$DIR" ]] || { echo "error: not a directory: $DIR" >&2; exit 2; }
 
 cd "$DIR"
 
 # Fingerprint patterns: the asset pipeline emits <name>[.min].<sha>.js|css,
 # the image pipeline <name>_hu<sha>_<params>.webp|png|jpg|avif.
 FP='[A-Za-z0-9_/.-]*\.[0-9a-f]{64,}\.(js|css)|[A-Za-z0-9_/.-]*_hu[0-9a-f]{32}_[A-Za-z0-9_]*\.(webp|png|jpe?g|avif)'
+CANDIDATES='\.[0-9a-f]{64,}\.(js|css)$|_hu[0-9a-f]{32}_[A-Za-z0-9_]+\.(webp|png|jpe?g|avif)$'
+
+# Fingerprint-named files on disk. grep -c exits 1 with a zero count when
+# there are none; that is a normal outcome, hence the `|| true`.
+candidate_count=$(find . -path ./.git -prune -o -type f -print |
+  grep -cE "$CANDIDATES" || true)
 
 # Basenames referenced by any built file. HTML is minified with unquoted
 # attributes (src=https://...), so match bare filename patterns instead of
 # attribute syntax. The search bundle embeds page content, so scanning the
 # JS as well covers references from pages built in this run.
+#
+# grep exits 1 on no matches and 2 on real errors (unreadable file, broken
+# pattern); only the former is tolerable. A partial scan must never feed
+# the deletion loop.
+grep_rc=0
 referenced=$(grep -rhoE "$FP" \
   --include='*.html' --include='*.css' --include='*.js' \
-  --include='*.json' --include='*.xml' . | sed 's|.*/||' | sort -u || true)
+  --include='*.json' --include='*.xml' . | sed 's|.*/||' | sort -u) || grep_rc=$?
+if (( grep_rc > 1 )); then
+  echo "error: reference scan failed (grep exit $grep_rc); refusing to delete" >&2
+  exit 1
+fi
+# A real built site always references its own bundles from its HTML. Zero
+# references alongside candidates means the tree or the scan is broken,
+# and proceeding would delete every asset.
+if (( candidate_count > 0 )) && [[ -z "$referenced" ]]; then
+  echo "error: $candidate_count fingerprinted assets but no references found;" \
+    "the tree or the scan is broken; refusing to delete" >&2
+  exit 1
+fi
 
 deleted=0
 freed=0
@@ -45,14 +82,15 @@ while IFS= read -r f; do
     if [[ "$DRY_RUN" == 1 ]]; then
       echo "would delete: $f"
     else
-      freed=$((freed + $(stat -c%s "$f")))
+      # wc -c is portable (GNU stat -c is not) and tolerates the file
+      # disappearing between find and here.
+      freed=$((freed + $(wc -c < "$f" 2>/dev/null || echo 0)))
       rm "$f"
       echo "deleted: $f"
     fi
     deleted=$((deleted + 1))
   fi
-done < <(find . -path ./.git -prune -o -type f -print |
-  grep -E '\.[0-9a-f]{64,}\.(js|css)$|_hu[0-9a-f]{32}_[A-Za-z0-9_]+\.(webp|png|jpe?g|avif)$' || true)
+done < <(find . -path ./.git -prune -o -type f -print | grep -E "$CANDIDATES" || true)
 
 if [[ "$DRY_RUN" == 1 ]]; then
   echo "dry run: $deleted stale assets found"


### PR DESCRIPTION
Hugo rewrites its output tree in place and never deletes fingerprinted assets it no longer emits. Every time an asset's content (and therefore its fingerprint) changes — e.g. the search bundle, which embeds the site content — a new `index.min.<sha>.js` / `main.<sha>.css` / `*_hu<sha>_*.webp` lands in the tree while the old one is kept. The gh-pages branch has accumulated **174 stale bundles (~63 MiB, tree is 92 MiB total)** this way.

## What

- `tools/clean_stale_assets.sh`: deletes fingerprint-named files in the built tree that no page references (scans html/css/js/json/xml; supports `-n`/`--dry-run` in any argument position). Fails closed: a reference scan that errors (grep exit 2), or finds zero references while candidates exist, aborts the run instead of deleting the asset set.
- Both site-deploy workflows (`hugo.yml`, `latest_config_docs.yml`) run it after the build, so the next deploy commit also carries the deletions.

## Why reference-based, not "wipe and rebuild"

The versioned config docs (`docs/config/v0.13.7` … `v0.14.5`) exist **only** as committed artifacts in the gh-pages tree — a normal docs push only regenerates `config/main` + `config/latest`, so wiping the tree would delete them. Those surviving pages also still reference the bundles they were built with (e.g. 117 pages under `v0.14.5` pin one old `index.min`), so cleanup must keep anything referenced from anywhere in the tree. The script only ever touches fingerprint-named files, and only when unreferenced, so HTML pages and non-fingerprinted files (`configdoc.js`, `CNAME`, …) are out of scope by construction.

## Verified against clones of the branches

- Dry run on current gh-pages: 174 stale assets found; exactly the referenced files kept
- Real run: 62.9 MiB freed (92M → 30M), second run is a no-op, versioned config docs / `configdoc.js` / `CNAME` / `robots.txt` untouched
- Simulated a page being rebuilt with the current bundle: the next run frees the old bundle it pinned
- Repro from review (fingerprinted files but no HTML at all): aborts with an error, deletes nothing

## Residue note

Bundles referenced by pages that are not rebuilt stay alive — that is intentional, but it only "drains" for pages that do get rebuilt (versioned config docs, via the `latest_config_docs.yml` dispatch). Pages in fully orphaned directories pin bundles forever; `docs/config/master/` (pre-branch-rename fossil, zero inbound links, not in the sitemap, not enumerable by the version selector) was removed from gh-pages as a one-off (`8230d999`), which freed the two bundles it exclusively pinned. Other unreachable top-level sections (`concepts/`, `getting-started/`, `surfacers/`, `how-to/`, `goto/`) remain: several are still link targets of current pages via stale URLs, so they need a content fix before removal — follow-up.
