### PR TITLE
[security] Bump fast-uri to 3.1.7, brace-expansion to 1.1.18, nanoid to 3.3.18

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2463,9 +2463,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3538,9 +3538,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -5899,9 +5899,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/docs/package.json
+++ b/docs/package.json
@@ -69,6 +69,7 @@
     "yauzl": "^3.2.1",
     "lodash": "^4.18.0",
     "js-yaml": "^4.3.1",
+    "fast-uri": "^3.1.6",
     "markdown-it": "^14.2.0",
     "decompress": "npm:@xhmikosr/decompress@^11.1.3"
   },


### PR DESCRIPTION
Fixes the open dependabot alerts for `fast-uri` (SSRF via malformed IPv6 normalization and repeated percent-decoding) by pinning `fast-uri >= 3.1.6` in the existing `overrides` block; the lockfile now resolves it to 3.1.7.

Also bumps `brace-expansion` (1.1.16 -> 1.1.18) and `nanoid` (3.3.16 -> 3.3.18), whose auto-dismissed alerts `npm audit` still flagged. Both are within their existing semver ranges, so no `overrides` changes were needed for them.

`npm audit` now reports 0 vulnerabilities, and the docs hugo build passes.