### PR TITLE
[docs] Fix stale links and versioned config index redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=cloudprober_cloudprober&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=cloudprober_cloudprober)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=cloudprober_cloudprober&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=cloudprober_cloudprober)
 
-Quick Links: [cloudprober.org](https://cloudprober.org) | [Start Monitoring Now](https://cloudprober.org/getting-started) | [Live Demo](https://browser-probe-demo.cloudprober.org/)
+Quick Links: [cloudprober.org](https://cloudprober.org) | [Start Monitoring Now](https://cloudprober.org/docs/overview/getting-started/) | [Live Demo](https://browser-probe-demo.cloudprober.org/)
 
 # Cloudprober: Reliable System Monitoring, Simplified!
 

--- a/docs/content/docs/config/_index.md
+++ b/docs/content/docs/config/_index.md
@@ -2,4 +2,4 @@
 title: "Configuration"
 ---
 
-{{% redirect dest="guide" %}}
+{{% redirect dest="guide/" %}}

--- a/docs/content/docs/how-to/alerting/index.md
+++ b/docs/content/docs/how-to/alerting/index.md
@@ -62,7 +62,7 @@ can do that using the `notify` config block:
 
 ```yaml
 # This example is in YAML format. You can use the original textpb format too.
-# See https://cloudprober.org/docs/config/alerting/cloudprober_alerting_AlertConf
+# See https://cloudprober.org/docs/config/alerting/#cloudprober_alerting_AlertConf
 probe:
   ...
   alert:

--- a/docs/content/docs/how-to/percentiles/index.md
+++ b/docs/content/docs/how-to/percentiles/index.md
@@ -83,7 +83,7 @@ Both prometheus and [stackdriver](/docs/surfacers/stackdriver/) support computin
 
 ### Stackdriver (Google Cloud Monitoring)
 
-Stackdriver automatically shows percentile aggregator for distribution metrics in metrics explorer ([example](/diagrams/metrics_explorer_percentile.png)). You can also use Stackdriver MQL to create percentiles (see [stackdriver documentation](/docs/surfacers/stackdriver/#accessing-the-data) for other usages of MQL for cloudprober metrics):
+Stackdriver automatically shows percentile aggregator for distribution metrics in metrics explorer. You can also use Stackdriver MQL to create percentiles (see [stackdriver documentation](/docs/surfacers/stackdriver/#accessing-the-data) for other usages of MQL for cloudprober metrics):
 
 ```shell
 fetch gce_instance

--- a/docs/content/docs/how-to/percentiles/index.md
+++ b/docs/content/docs/how-to/percentiles/index.md
@@ -42,7 +42,7 @@ probe {
 
 ## Configuring distributions
 
-As seen in the example above, for latencies you configure distribution at the probe level by adding a field called `latency_distribution`. Without this field, cloudprober exports only cumulative latencies. To create distributions from an external probe's data, take a look at the external probe's [documentation](/how-to/external-probe/#distributions).
+As seen in the example above, for latencies you configure distribution at the probe level by adding a field called `latency_distribution`. Without this field, cloudprober exports only cumulative latencies. To create distributions from an external probe's data, take a look at the external probe's [documentation](/docs/how-to/external-probe/#distributions).
 
 Format for the distribution field is in turn defined in [dist.proto](https://github.com/cloudprober/cloudprober/blob/master/metrics/proto/dist.proto).
 
@@ -79,11 +79,11 @@ message ExponentialBuckets {
 
 Now that we've configured cloudprober to generate distributions, how do we make use of this new information. This depends on the monitoring system (prometheus, stackdriver, postgres, etc) you're exporting your data to.
 
-Both prometheus and [stackdriver](/surfacers/stackdriver/) support computing and plotting percentiles from the distributions data. Stackdriver can natively create heatmaps from distributions while for prometheus you need to use grafana to create heatmaps.
+Both prometheus and [stackdriver](/docs/surfacers/stackdriver/) support computing and plotting percentiles from the distributions data. Stackdriver can natively create heatmaps from distributions while for prometheus you need to use grafana to create heatmaps.
 
 ### Stackdriver (Google Cloud Monitoring)
 
-Stackdriver automatically shows percentile aggregator for distribution metrics in metrics explorer ([example](/diagrams/metrics_explorer_percentile.png)). You can also use Stackdriver MQL to create percentiles (see [stackdriver documentation](/surfacers/stackdriver/#accessing-the-data) for other usages of MQL for cloudprober metrics):
+Stackdriver automatically shows percentile aggregator for distribution metrics in metrics explorer ([example](/diagrams/metrics_explorer_percentile.png)). You can also use Stackdriver MQL to create percentiles (see [stackdriver documentation](/docs/surfacers/stackdriver/#accessing-the-data) for other usages of MQL for cloudprober metrics):
 
 ```shell
 fetch gce_instance

--- a/docs/content/docs/how-to/rds/index..md
+++ b/docs/content/docs/how-to/rds/index..md
@@ -171,7 +171,7 @@ rds_server {
   }
 
   # Kubernetes targets are further discussed at:
-  # https://cloudprober.org/how-to/run-on-kubernetes/#kubernetes-targets
+  # https://cloudprober.org/docs/how-to/run-on-kubernetes/#kubernetes-targets
   provider {
     kubernetes_config {
       endpoints {}

--- a/docs/content/docs/surfacers/cloudwatch.md
+++ b/docs/content/docs/surfacers/cloudwatch.md
@@ -7,7 +7,7 @@ title: "Cloudwatch (AWS)"
 ---
 
 Cloudprober can natively export metrics to AWS Cloudwatch using the cloudwatch
-[surfacer](/docs/surfacers/overview/). Adding the cloudwatch surfacer to cloudprover
+[surfacer](/docs/surfacers/overview/). Adding the cloudwatch surfacer to cloudprober
 is as simple as adding the following stanza to the config:
 
 ```

--- a/docs/content/docs/surfacers/cloudwatch.md
+++ b/docs/content/docs/surfacers/cloudwatch.md
@@ -7,7 +7,7 @@ title: "Cloudwatch (AWS)"
 ---
 
 Cloudprober can natively export metrics to AWS Cloudwatch using the cloudwatch
-[surfacer](/surfacers/overview). Adding the cloudwatch surfacer to cloudprover
+[surfacer](/docs/surfacers/overview/). Adding the cloudwatch surfacer to cloudprover
 is as simple as adding the following stanza to the config:
 
 ```

--- a/docs/content/docs/surfacers/overview.md
+++ b/docs/content/docs/surfacers/overview.md
@@ -178,5 +178,5 @@ additional labels to cloudprober metrics.
 
 For external probes, Cloudprober also allows external programs to provide
 additional metrics. See
-[External Probe](https://cloudprober.org/how-to/external-probe) for more
+[External Probe](/docs/how-to/external-probe/) for more
 details.

--- a/docs/content/docs/surfacers/stackdriver.md
+++ b/docs/content/docs/surfacers/stackdriver.md
@@ -7,7 +7,7 @@ title: "Stackdriver (Google Cloud)"
 ---
 
 Cloudprober can natively export metrics to Google Cloud Monitoring (formerly,
-Stackdriver) using stackdriver [surfacer](/surfacers/overview). Adding
+Stackdriver) using stackdriver [surfacer](/docs/surfacers/overview/). Adding
 stackdriver surfacer to cloudprober is as simple as adding the following stanza
 to the config:
 

--- a/examples/surfacers/stackdriver_surfacer.cfg
+++ b/examples/surfacers/stackdriver_surfacer.cfg
@@ -26,7 +26,7 @@ surfacer {
 # that cloudprober is running on GCP (that's why no project specification), and
 # VMs or GKE nodes have write access for Stackdriver.
 # More on stackdriver surfacer:
-# https://cloudprober.org/surfacers/stackdriver/
+# https://cloudprober.org/docs/surfacers/stackdriver/
 surfacer {
     type: STACKDRIVER
     ignore_metrics_with_label {

--- a/tools/gen_config_docs.sh
+++ b/tools/gen_config_docs.sh
@@ -107,7 +107,7 @@ cat > ${BASE_PATH}/_index.md <<EOF
 title: "${INDEX_TITLE}"
 ---
 
-{{% redirect dest="overview" %}}
+{{% redirect dest="overview/" %}}
 EOF
 
 # Copy latest configs to non-versioned path as well to make sure

--- a/tools/gen_config_docs.sh
+++ b/tools/gen_config_docs.sh
@@ -94,7 +94,21 @@ EOF
 # Call the function with BASE_PATH
 generate_config_files "${BASE_PATH}" "${MENU_HDR}"
 
-cp ${ORIGINAL_DIR}/docs/content/docs/config/_index.md ${BASE_PATH}/
+# Write a version-specific index that redirects to this version's overview
+# page. Don't copy the non-versioned _index.md here: it redirects (via a
+# relative meta-refresh) to 'guide', which only exists at /docs/config/, so
+# the copied page would redirect versioned URLs to a 404.
+INDEX_TITLE="Configuration"
+if [[ "${DOCS_VERSION}" != "latest" ]]; then
+  INDEX_TITLE="Configuration (${DOCS_VERSION})"
+fi
+cat > ${BASE_PATH}/_index.md <<EOF
+---
+title: "${INDEX_TITLE}"
+---
+
+{{% redirect dest="overview" %}}
+EOF
 
 # Copy latest configs to non-versioned path as well to make sure
 # we don't break existing links.


### PR DESCRIPTION
## Summary

Fixes stale URLs in the docs that 404 (some surface in Google Search Console).

### Versioned config index pages redirect to a 404
`tools/gen_config_docs.sh` copied the non-versioned `docs/content/docs/config/_index.md` into each versioned config dir. That page meta-refreshes to a *relative* `guide` path, which only exists at `/docs/config/`. Under versioned paths it resolves to e.g. `/docs/config/v0.14.2/guide` → 404, so `/docs/config/v0.x.y/` rendered as an empty page that redirected into a 404.

The script now writes a version-specific `_index.md` that redirects to that version's `overview` page (which every version has, and which the version selector already uses as its default landing page).

### Stale links to pre-`/docs/` site paths
Several pages still linked to URLs from before the content tree moved under `/docs/` (plus one config comment pointing at a removed per-message config page). Updated to current paths in:
- `surfacers/cloudwatch.md`, `surfacers/stackdriver.md`: `/surfacers/overview`
- `surfacers/overview.md`: `cloudprober.org/how-to/external-probe`
- `how-to/percentiles`: `/how-to/external-probe`, `/surfacers/stackdriver`
- `how-to/rds`: run-on-kubernetes config comment
- `how-to/alerting`: alerting config comment

## Notes
- The already-deployed versioned index pages (v0.13.7–v0.14.5) are patched separately on the `gh-pages` branch (`gh-pages-fix-versioned-indexes`); this PR fixes the generator so future regenerations are correct.
- All rewritten link targets and anchors verified live.