### PR TITLE
[ci] Report the required check for docs-only pull requests

### DIFF
--- a/.github/workflows/go_docs_only.yml
+++ b/.github/workflows/go_docs_only.yml
@@ -1,0 +1,36 @@
+name: Go Build and Test (docs-only)
+
+# Branch protection requires the "Build and Test (ubuntu-latest)" context, but
+# go.yml ignores docs/**, so a docs-only pull request never produces it and sits
+# blocked forever on a check that will never report. This workflow reports that
+# one context for the changes go.yml skips.
+#
+# The paths here are the inverse of go.yml's paths-ignore and have to stay in
+# sync with it: anything added there needs adding here, or docs PRs go back to
+# hanging.
+#
+# On a PR that touches both docs and code, both workflows run and two check runs
+# share the name. That is safe in the direction that matters -- branch
+# protection reads the most recent run for a name, this one finishes in seconds
+# and the real build takes minutes, so the real result is the one that lands.
+#
+# Only ubuntu-latest is emitted, because only ubuntu-latest is required. If the
+# windows or macos contexts are ever added to branch protection, they need
+# adding here too.
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/hugo.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    # Must render exactly as the required context "Build and Test (ubuntu-latest)".
+    name: Build and Test (ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Documentation-only change; go.yml has nothing to build here."


### PR DESCRIPTION
Branch protection requires the `Build and Test (ubuntu-latest)` context. `go.yml` carries `paths-ignore: docs/**`. A docs-only PR therefore never triggers the workflow, the required context never reports, and GitHub blocks the merge on a check that will never arrive — `mergeable: MERGEABLE`, `mergeStateStatus: BLOCKED`, zero checks.

Every docs PR has needed an admin bypass to land. #1466 and #1471 both did.

This adds a companion workflow on the inverse paths whose only job is named to render as exactly that context.

### Why not the obvious alternatives

**Require the check only when code changes** — not expressible. `paths` triggers on *any* changed file matching; there is no "all changed files match" form.

**Gate `go.yml`'s job with `if:`** — worse than useless, for two independent reasons. A job skipped by `if:` is counted as **success** by branch protection, so it would quietly weaken the gate it is meant to preserve. And a top-level `if:` on a *matrixed* job skips before matrix expansion, so the per-os contexts are never created and the PR hangs exactly as it does today ([actions/runner#952](https://github.com/actions/runner/issues/952)). `build-and-test` is matrixed.

For the record, GitHub's own guidance here is just "avoid requiring workflows that can be skipped" — there is no documented fix, which is why this is a companion workflow rather than something tidier.

### The seam, and why it is safe

A PR touching **both** docs and code triggers both workflows, and two check runs share the name. Branch protection reads the most recent run for a given name; this job finishes in seconds and the real build takes minutes, so the real result is the one that lands. A failing build still blocks.

It only inverts if someone manually re-runs *this* workflow after the real build finishes.

### Two things that need to stay in sync

Both are called out in comments in the file:

- The paths are the inverse of `go.yml`'s `paths-ignore`. Anything added there needs adding here.
- Only `ubuntu-latest` is emitted, because only `ubuntu-latest` is required. Emitting windows and macos would assert builds that never ran. If those are ever added to branch protection, they need adding here.

### Verifying

This PR touches `.github/workflows/**`, which `go.yml` does *not* ignore, so the real build runs here and this one should merge without a bypass.

The docs-only path can't be exercised by this PR. Worth confirming with a trivial docs-only PR right after merge — that one should go green on its own, which is the whole point.