### PR TITLE
[web] Compact the page header's info block from four lines to two

### DIFF
--- a/web/resources/header.go
+++ b/web/resources/header.go
@@ -53,11 +53,13 @@ func headerData(linksPrefix string) headerTmplData {
 	startTime := sysvars.StartTime().Truncate(time.Millisecond)
 	uptime := time.Since(startTime).Truncate(time.Millisecond)
 
-	// version and buildTimestamp are set through -ldflags, so a plain "go
-	// build" binary has neither. Drop the tag and its tooltip in that case
-	// instead of rendering an empty version or a "built at" of the zero time.
-	versionTitle := ""
-	if builtAt := state.BuildTimestamp(); !builtAt.IsZero() {
+	// version and buildTimestamp come from the same -ldflags block, so a plain
+	// "go build" binary has neither, and the old template rendered an empty
+	// version and a "built at" of the zero time. The build time hangs off the
+	// version tag as a tooltip, so it needs a tag to hang on: guard on both,
+	// rather than computing a title the template can never reach.
+	version, versionTitle := state.Version(), ""
+	if builtAt := state.BuildTimestamp(); version != "" && !builtAt.IsZero() {
 		versionTitle = "Built at " + builtAt.String()
 	}
 
@@ -78,7 +80,7 @@ func headerData(linksPrefix string) headerTmplData {
 	}
 
 	return headerTmplData{
-		Version:              state.Version(),
+		Version:              version,
 		VersionTitle:         versionTitle,
 		Uptime:               humanizeDuration(uptime),
 		UptimeTitle:          "Started " + startTime.String(),

--- a/web/resources/header.go
+++ b/web/resources/header.go
@@ -27,19 +27,19 @@ import (
 )
 
 type headerTmplData struct {
-	Version, BuiltAt, StartTime, Uptime, StatusLink, LinksPrefix, IncludeMetricsLink, IncludeArtifactsLink, RightDiv interface{}
+	Version, VersionTitle, Uptime, UptimeTitle, StatusLink, LinksPrefix string
+	IncludeMetricsLink, IncludeArtifactsLink                            bool
 }
 
 var t = template.Must(template.New("header").Parse(`
 <header>
   <a href="https://cloudprober.org"><img class="logo" src="{{.LinksPrefix}}static/cloudprober-horizontal.svg" alt="Cloudprober" width="170" height="60"></a>
+  {{if .Version}}<div class="version"{{if .VersionTitle}} title="{{.VersionTitle}}"{{end}}>{{.Version}}</div>{{end}}
 </header> 
 <hr/>
 <div style="float:left">
-  <b>Started</b>: {{.StartTime}} -- up {{.Uptime}}<br/>
-  <b>Version</b>: {{.Version}}<br>
-  <b>Built at</b>: {{.BuiltAt}}<br>
-  <b>Other Links </b>(<a href="{{.LinksPrefix}}links">all</a>):
+  <div class="uptime" title="{{.UptimeTitle}}"><b>Uptime</b>: {{.Uptime}}</div>
+  <b>Links</b> (<a href="{{.LinksPrefix}}links">all</a>):
   	<a href="{{.LinksPrefix}}{{.StatusLink}}">/status</a>,
 	<a href="{{.LinksPrefix}}config-running">/config</a> (<a href="{{.LinksPrefix}}config-parsed">parsed</a> | <a href="{{.LinksPrefix}}config">raw</a>),
 	<a href="{{.LinksPrefix}}logs">/logs</a>,
@@ -52,6 +52,14 @@ var t = template.Must(template.New("header").Parse(`
 func headerData(linksPrefix string) headerTmplData {
 	startTime := sysvars.StartTime().Truncate(time.Millisecond)
 	uptime := time.Since(startTime).Truncate(time.Millisecond)
+
+	// version and buildTimestamp are set through -ldflags, so a plain "go
+	// build" binary has neither. Drop the tag and its tooltip in that case
+	// instead of rendering an empty version or a "built at" of the zero time.
+	versionTitle := ""
+	if builtAt := state.BuildTimestamp(); !builtAt.IsZero() {
+		versionTitle = "Built at " + builtAt.String()
+	}
 
 	includeMetrics := false
 	includeArtifacts := false
@@ -71,14 +79,47 @@ func headerData(linksPrefix string) headerTmplData {
 
 	return headerTmplData{
 		Version:              state.Version(),
-		BuiltAt:              state.BuildTimestamp(),
-		StartTime:            startTime,
-		Uptime:               uptime,
+		VersionTitle:         versionTitle,
+		Uptime:               humanizeDuration(uptime),
+		UptimeTitle:          "Started " + startTime.String(),
 		StatusLink:           statusLink,
 		LinksPrefix:          linksPrefix,
 		IncludeMetricsLink:   includeMetrics,
 		IncludeArtifactsLink: includeArtifacts,
 	}
+}
+
+// humanizeDuration formats d using its two most significant units, e.g. "3d 4h"
+// or "12m 30s", dropping the smaller one when it is zero. Go's
+// Duration.String() stops at hours, which turns a long uptime into something
+// like "2562047h47m16.854s". Days are deliberately the largest unit: a "year"
+// is 365 or 365.25 days depending on who is reading, while "423d" is
+// unambiguous and still scans.
+func humanizeDuration(d time.Duration) string {
+	if d < time.Second {
+		return "0s"
+	}
+
+	var major, minor int
+	var majorUnit, minorUnit string
+	switch {
+	case d >= 24*time.Hour:
+		major, majorUnit = int(d/(24*time.Hour)), "d"
+		minor, minorUnit = int(d/time.Hour)%24, "h"
+	case d >= time.Hour:
+		major, majorUnit = int(d/time.Hour), "h"
+		minor, minorUnit = int(d/time.Minute)%60, "m"
+	case d >= time.Minute:
+		major, majorUnit = int(d/time.Minute), "m"
+		minor, minorUnit = int(d/time.Second)%60, "s"
+	default:
+		return fmt.Sprintf("%ds", int(d/time.Second))
+	}
+
+	if minor == 0 {
+		return fmt.Sprintf("%d%s", major, majorUnit)
+	}
+	return fmt.Sprintf("%d%s %d%s", major, majorUnit, minor, minorUnit)
 }
 
 func Header(linksPrefix string) template.HTML {

--- a/web/resources/header_test.go
+++ b/web/resources/header_test.go
@@ -48,13 +48,12 @@ func TestHeader(t *testing.T) {
 	expected := `
 <header>
   <a href="https://cloudprober.org"><img class="logo" src="static/cloudprober-horizontal.svg" alt="Cloudprober" width="170" height="60"></a>
+  <div class="version" title="Built at 2023-10-01 12:00:00 &#43;0000 UTC">v1.0.0</div>
 </header> 
 <hr/>
 <div style="float:left">
-  <b>Started</b>: 0001-01-01 00:00:00 &#43;0000 UTC -- up 2562047h47m16.854s<br/>
-  <b>Version</b>: v1.0.0<br>
-  <b>Built at</b>: 2023-10-01 12:00:00 &#43;0000 UTC<br>
-  <b>Other Links </b>(<a href="links">all</a>):
+  <div class="uptime" title="Started 0001-01-01 00:00:00 &#43;0000 UTC"><b>Uptime</b>: 106751d 23h</div>
+  <b>Links</b> (<a href="links">all</a>):
   	<a href="status">/status</a>,
 	<a href="config-running">/config</a> (<a href="config-parsed">parsed</a> | <a href="config">raw</a>),
 	<a href="logs">/logs</a>,
@@ -82,26 +81,35 @@ func TestHeaderData(t *testing.T) {
 		buildTimestamp      time.Time
 		links               []string
 		wantStatusLink      string
+		wantVersionTitle    string
 		expectMetricsLink   bool
 		expectArtifactsLink bool
 	}{
 		{
-			name:           "No links",
-			version:        "v1.0.0",
-			buildTimestamp: time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC),
-			links:          []string{},
+			// No -ldflags: no version tag, and no "built at" tooltip on it.
+			name:  "Unset version and build timestamp",
+			links: []string{},
 		},
 		{
-			name:           "Status link",
-			version:        "v1.0.0",
-			buildTimestamp: time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC),
-			links:          []string{"/my/probe/status"},
-			wantStatusLink: "my/probe/status",
+			name:             "No links",
+			version:          "v1.0.0",
+			buildTimestamp:   time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC),
+			links:            []string{},
+			wantVersionTitle: "Built at 2023-10-01 12:00:00 +0000 UTC",
+		},
+		{
+			name:             "Status link",
+			version:          "v1.0.0",
+			buildTimestamp:   time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC),
+			links:            []string{"/my/probe/status"},
+			wantStatusLink:   "my/probe/status",
+			wantVersionTitle: "Built at 2023-10-01 12:00:00 +0000 UTC",
 		},
 		{
 			name:                "Metrics link",
 			version:             "v1.0.0",
 			buildTimestamp:      time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC),
+			wantVersionTitle:    "Built at 2023-10-01 12:00:00 +0000 UTC",
 			links:               []string{"/metrics"},
 			expectMetricsLink:   true,
 			expectArtifactsLink: false,
@@ -110,6 +118,7 @@ func TestHeaderData(t *testing.T) {
 			name:                "Artifacts link",
 			version:             "v1.0.0",
 			buildTimestamp:      time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC),
+			wantVersionTitle:    "Built at 2023-10-01 12:00:00 +0000 UTC",
 			links:               []string{"/artifacts"},
 			expectMetricsLink:   false,
 			expectArtifactsLink: true,
@@ -118,6 +127,7 @@ func TestHeaderData(t *testing.T) {
 			name:                "Both links",
 			version:             "v1.0.0",
 			buildTimestamp:      time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC),
+			wantVersionTitle:    "Built at 2023-10-01 12:00:00 +0000 UTC",
 			links:               []string{"/metrics", "/artifacts"},
 			expectMetricsLink:   true,
 			expectArtifactsLink: true,
@@ -143,8 +153,10 @@ func TestHeaderData(t *testing.T) {
 				}
 			}
 
+			// sysvars.StartTime() is the zero time here, so time.Since()
+			// saturates at the max duration and the uptime is a constant.
 			wantStartTime := sysvars.StartTime().Truncate(time.Millisecond)
-			wantUptime := time.Since(wantStartTime).Truncate(time.Millisecond)
+			wantUptime := humanizeDuration(time.Since(wantStartTime).Truncate(time.Millisecond))
 			if tt.wantStatusLink == "" {
 				tt.wantStatusLink = "status"
 			}
@@ -152,9 +164,9 @@ func TestHeaderData(t *testing.T) {
 			for _, linksPrefix := range []string{"", "../"} {
 				data := headerData(linksPrefix)
 				assert.Equal(t, tt.version, data.Version)
-				assert.Equal(t, tt.buildTimestamp, data.BuiltAt)
-				assert.Equal(t, wantStartTime, data.StartTime)
+				assert.Equal(t, tt.wantVersionTitle, data.VersionTitle)
 				assert.Equal(t, wantUptime, data.Uptime)
+				assert.Equal(t, "Started "+wantStartTime.String(), data.UptimeTitle)
 				assert.Equal(t, tt.expectMetricsLink, data.IncludeMetricsLink)
 				assert.Equal(t, tt.expectArtifactsLink, data.IncludeArtifactsLink)
 				assert.Equal(t, linksPrefix, data.LinksPrefix)
@@ -178,6 +190,36 @@ func TestLinkPrefixFromCurrentPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
 			assert.Equal(t, tt.expected, LinkPrefixFromCurrentPath(tt.path))
+		})
+	}
+}
+
+func TestHumanizeDuration(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{d: 0, want: "0s"},
+		{d: 900 * time.Millisecond, want: "0s"},
+		{d: -5 * time.Second, want: "0s"}, // clock skew
+		{d: 45 * time.Second, want: "45s"},
+		{d: 12*time.Minute + 30*time.Second, want: "12m 30s"},
+		{d: 12 * time.Minute, want: "12m"},
+		{d: 4*time.Hour + 12*time.Minute, want: "4h 12m"},
+		{d: 4 * time.Hour, want: "4h"},
+		{d: 3*24*time.Hour + 4*time.Hour, want: "3d 4h"},
+		{d: 3 * 24 * time.Hour, want: "3d"},
+		// Sub-unit remainders are dropped, not rounded.
+		{d: 3*24*time.Hour + 59*time.Minute, want: "3d"},
+		// Days keep counting rather than rolling over into years.
+		{d: 423*24*time.Hour + 4*time.Hour, want: "423d 4h"},
+		// What time.Since() saturates to for a zero start time.
+		{d: time.Duration(1<<63 - 1), want: "106751d 23h"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			assert.Equal(t, tt.want, humanizeDuration(tt.d))
 		})
 	}
 }

--- a/web/resources/header_test.go
+++ b/web/resources/header_test.go
@@ -91,6 +91,13 @@ func TestHeaderData(t *testing.T) {
 			links: []string{},
 		},
 		{
+			// The tooltip hangs off the version tag, so a build timestamp
+			// without a version has nothing to attach to.
+			name:           "Build timestamp but no version",
+			buildTimestamp: time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC),
+			links:          []string{},
+		},
+		{
 			name:             "No links",
 			version:          "v1.0.0",
 			buildTimestamp:   time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC),
@@ -218,7 +225,7 @@ func TestHumanizeDuration(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.want, func(t *testing.T) {
+		t.Run(tt.d.String(), func(t *testing.T) {
 			assert.Equal(t, tt.want, humanizeDuration(tt.d))
 		})
 	}

--- a/web/resources/templates_test.go
+++ b/web/resources/templates_test.go
@@ -115,13 +115,12 @@ func TestRenderPage(t *testing.T) {
 
 <header>
   <a href="https://cloudprober.org"><img class="logo" src="static/cloudprober-horizontal.svg" alt="Cloudprober" width="170" height="60"></a>
+  <div class="version">v1.0.0</div>
 </header> 
 <hr/>
 <div style="float:left">
-  <b>Started</b>: 0001-01-01 00:00:00 &#43;0000 UTC -- up 2562047h47m16.854s<br/>
-  <b>Version</b>: v1.0.0<br>
-  <b>Built at</b>: 0001-01-01 00:00:00 &#43;0000 UTC<br>
-  <b>Other Links </b>(<a href="links">all</a>):
+  <div class="uptime" title="Started 0001-01-01 00:00:00 &#43;0000 UTC"><b>Uptime</b>: 106751d 23h</div>
+  <b>Links</b> (<a href="links">all</a>):
   	<a href="status">/status</a>,
 	<a href="config-running">/config</a> (<a href="config-parsed">parsed</a> | <a href="config">raw</a>),
 	<a href="logs">/logs</a>,
@@ -153,13 +152,12 @@ test body
 
 <header>
   <a href="https://cloudprober.org"><img class="logo" src="../../static/cloudprober-horizontal.svg" alt="Cloudprober" width="170" height="60"></a>
+  <div class="version">v1.0.0</div>
 </header> 
 <hr/>
 <div style="float:left">
-  <b>Started</b>: 0001-01-01 00:00:00 &#43;0000 UTC -- up 2562047h47m16.854s<br/>
-  <b>Version</b>: v1.0.0<br>
-  <b>Built at</b>: 0001-01-01 00:00:00 &#43;0000 UTC<br>
-  <b>Other Links </b>(<a href="../../links">all</a>):
+  <div class="uptime" title="Started 0001-01-01 00:00:00 &#43;0000 UTC"><b>Uptime</b>: 106751d 23h</div>
+  <b>Links</b> (<a href="../../links">all</a>):
   	<a href="../../status">/status</a>,
 	<a href="../../config-running">/config</a> (<a href="../../config-parsed">parsed</a> | <a href="../../config">raw</a>),
 	<a href="../../logs">/logs</a>,

--- a/web/static/cloudprober.css
+++ b/web/static/cloudprober.css
@@ -15,8 +15,11 @@ header .version {
   color: grey;
 }
 
-/* Carries the start time as a title tooltip; hint that it is hoverable. */
-.uptime {
+/* Both carry a timestamp in a title tooltip -- the start time and the build
+   time -- but the build one is only there when it was set at build time. Key
+   the affordance off the attribute so it never hints at an absent tooltip. */
+.uptime[title],
+header .version[title] {
   cursor: help;
 }
 

--- a/web/static/cloudprober.css
+++ b/web/static/cloudprober.css
@@ -10,6 +10,16 @@ header .logo {
   height: auto;
 }
 
+header .version {
+  font-size: 12px;
+  color: grey;
+}
+
+/* Carries the start time as a title tooltip; hint that it is hoverable. */
+.uptime {
+  cursor: help;
+}
+
 .debugging {
   font-size: 12px;
 }


### PR DESCRIPTION
The block under the header rule carried Started, Version, Built at and Other
Links -- four lines of mostly cold metadata pushing the actual page content
down. Only two of those facts get read at a glance.

Before:

```
[cloudprober wordmark]
────────────────────────────────────────────────────────────
Started: 2026-09-07 11:36:48.498 -0700 PDT -- up 2562047h47m16.854s
Version: v0.14.5-23-gcecedded
Built at: 2026-09-07 11:36:46 -0700 PDT
Other Links (all): /status, /config (parsed | raw), /logs, /metrics, /alerts
```

After:

```
[cloudprober wordmark]
v0.14.5-23-gcecedded          ← title="Built at 2026-09-07 11:36:46 -0700 PDT"
────────────────────────────────────────────────────────────
Uptime: 5s                    ← title="Started 2026-09-07 11:36:48.498 -0700 PDT"
Links (all): /status, /config (parsed | raw), /logs, /metrics, /alerts
```

### What changed

**Version moves under the wordmark** as a small grey tag, where it reads as part
of the identity rather than as a fourth status line. The build timestamp is
metadata *about* the version, not a peer of it, so it becomes that tag's
tooltip.

**Uptime stays in the body**, above the links -- it is the one live value in the
group, and burying it in a tooltip or shrinking it into the header corner made
it easy to miss. Its absolute start time moves into a tooltip.

**Uptime is now readable.** Go's `Duration.String()` stops at hours, so a
long-running instance reported `2562047h47m16.854s`. `humanizeDuration()` shows
the two most significant units instead: `45s`, `12m 30s`, `4h 12m`, `3d 4h`.
Days are the largest unit on purpose -- a "year" is 365 or 365.25 days depending
on who is reading, while `423d` is unambiguous and still scans.

**The unset-ldflags case is handled.** `version` and `buildTimestamp` are only
set through `-ldflags`, so a plain `go build` binary (and `tools/build.sh`) has
neither, and the old template rendered an empty version plus a `Built at` of
`0001-01-01 00:00:00 +0000 UTC`. The tag and its tooltip are now dropped
entirely in that case.

**"Other Links" loses the "Other".** It distinguished the links from the three
info lines above them; with those gone there is nothing left for them to be
other than. "Links" also matches both the `/links` URL and that page's own
"All Links" heading.

Along the way, `headerTmplData` gets real `string` and `bool` fields instead of
`interface{}`, and loses `RightDiv`, unused since it was added.

### Notes

- The header is shared by /status, /alerts, /logs, /config-* and the artifacts
  browser, so all of them pick this up.
- Tooltips use the plain `title` attribute rather than the existing
  `.tooltip`/`.tooltiptext` pair, which has no `position: relative` on the
  anchor and only lands correctly in the short status-table cells it was
  written for. Tradeoff: `title` does not surface on touch devices, which
  seemed acceptable for build metadata.

### Testing

`go test ./web/... ./internal/surfacers/probestatus/... ./probes/browser/artifacts/...`
passes; goldens in `header_test.go` and `templates_test.go` updated. Added
`TestHumanizeDuration` (unit boundaries, zero, negative/clock-skew, and the
saturated value the goldens depend on) and an unset-version/timestamp case to
`TestHeaderData`. Also verified against a locally built binary with real
`-ldflags` values, on /status and /alerts.