### PR TITLE
[http] Close the response body when reading it fails

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -351,6 +351,10 @@ func (p *Probe) doHTTPRequest(req *http.Request, client *http.Client, target end
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
+		// Close here too. Returning without it holds the connection open
+		// instead of releasing it to the idle pool, so a server that keeps
+		// truncating responses would leak one connection per probe.
+		resp.Body.Close()
 		err = p.redactedErr(err)
 		l.WithAttributes(p.dynamicHeaderAttrs(req)...).Warning(err.Error())
 		return err

--- a/probes/http/response_body_test.go
+++ b/probes/http/response_body_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	configpb "github.com/cloudprober/cloudprober/probes/http/proto"
+	"github.com/cloudprober/cloudprober/probes/options"
+	"github.com/cloudprober/cloudprober/targets"
+	"github.com/cloudprober/cloudprober/targets/endpoint"
+	"github.com/stretchr/testify/assert"
+)
+
+// failingBody fails every read, the way a truncated or reset response does,
+// and records whether it was closed.
+type failingBody struct {
+	mu     sync.Mutex
+	closed bool
+}
+
+func (b *failingBody) Read([]byte) (int, error) {
+	return 0, errors.New("unexpected EOF")
+}
+
+func (b *failingBody) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.closed = true
+	return nil
+}
+
+func (b *failingBody) wasClosed() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.closed
+}
+
+type failingBodyTransport struct{ body *failingBody }
+
+func (t *failingBodyTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: 200, Body: t.body, Header: http.Header{}}, nil
+}
+
+// An unclosed body holds its connection out of the idle pool, so a server that
+// keeps truncating responses would leak one connection per probe.
+func TestResponseBodyClosedOnReadError(t *testing.T) {
+	p := &Probe{}
+	err := p.Init("close_test", &options.Options{
+		Targets:   targets.StaticTargets("test.com"),
+		Interval:  2 * time.Second,
+		Timeout:   time.Second,
+		ProbeConf: &configpb.ProbeConf{},
+	})
+	assert.NoError(t, err)
+
+	body := &failingBody{}
+	req, err := http.NewRequest("GET", "http://test.com/", nil)
+	assert.NoError(t, err)
+
+	gotErr := p.doHTTPRequest(req, &http.Client{Transport: &failingBodyTransport{body: body}},
+		endpoint.Endpoint{Name: "test.com"}, p.newResult(), nil)
+
+	assert.Error(t, gotErr, "a failed body read should return an error")
+	assert.True(t, body.wasClosed(), "response body must be closed on the read-error path")
+}


### PR DESCRIPTION
`doHTTPRequest` closes the response body on the negative-test path and on the
normal path, but the `io.ReadAll` error path returned without closing it:

```go
respBody, err := io.ReadAll(resp.Body)
if err != nil {
        err = p.redactedErr(err)
        l.WithAttributes(p.dynamicHeaderAttrs(req)...).Warning(err.Error())
        return err          // <- body never closed
}
```

An unclosed body holds its connection out of the idle pool, so a server that
keeps truncating or resetting responses leaks one connection per probe instead
of reusing them.

### Why not `defer resp.Body.Close()`

That would be the more idiomatic shape, but the success path closes the body
*before* `validators.RunValidators` runs, and validators are user-configured and
can be slow. Deferring would hold the connection open across them and change
when it returns to the idle pool. The explicit close keeps the existing timing.

### Testing

`TestResponseBodyClosedOnReadError` drives `doHTTPRequest` through a transport
whose response body fails every read, and asserts the body was closed. Verified
that it fails without the fix ("response body must be closed on the read-error
path") and passes with it.

`go build ./...`, `go vet`, `go test -race ./probes/http/...` and `gofmt` are all
clean.

Noticed while reviewing #1410; the bug predates it.