### PR TITLE
[http] Redact the URL in url.Error's inner error too

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -311,7 +311,7 @@ func (p *Probe) requestTrace(result *probeResult) *httptrace.ClientTrace {
 
 // doHTTPRequest executes an HTTP request and updates the provided result struct.
 func (p *Probe) doHTTPRequest(req *http.Request, client *http.Client, target endpoint.Endpoint, result *probeResult, resultMu *sync.Mutex) error {
-	l := p.l.WithAttributes(slog.String("target", target.Name), slog.String("url", p.redactedURL(req.URL)))
+	l := p.l.WithAttributes(slog.String("target", target.Name), slog.String("url", p.redactURL(req.URL.String())))
 
 	start := time.Now()
 
@@ -345,7 +345,7 @@ func (p *Probe) doHTTPRequest(req *http.Request, client *http.Client, target end
 
 	if p.opts.NegativeTest {
 		resp.Body.Close()
-		l.Error("Negative test, but HTTP request succeeded for: ", p.redactedURL(req.URL))
+		l.Error("Negative test, but HTTP request succeeded for: ", p.redactURL(req.URL.String()))
 		return errors.New("negative test: request succeeded unexpectedly")
 	}
 

--- a/probes/http/redact_test.go
+++ b/probes/http/redact_test.go
@@ -48,8 +48,7 @@ func TestRedactURL(t *testing.T) {
 		// so anything that stops at whitespace leaks the rest of the query.
 		{"space inside the query", "/a?msg=hello world&tok=secret", "/a?<redacted>"},
 		{"absolute URL", "http://h/a?tok=secret", "http://h/a?<redacted>"},
-		// A fragment isn't part of the query, and redactedURL (which works
-		// from a parsed URL) keeps it, so this must keep it too.
+		// A fragment isn't part of the query, so it survives.
 		{"fragment is kept", "http://h/a?tok=s#frag", "http://h/a?<redacted>#frag"},
 		// Here the '?' is inside the fragment, so there is no query at all.
 		{"'?' only inside the fragment", "http://h/a#x?y", "http://h/a#x?y"},
@@ -68,7 +67,6 @@ func TestRedactURL(t *testing.T) {
 }
 
 func TestRedactErrMsg(t *testing.T) {
-	p := &Probe{redactURLQueryInLogs: true}
 	tests := []struct{ name, in, want string }{
 		{
 			name: "quoted URL",
@@ -114,12 +112,13 @@ func TestRedactErrMsg(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.want, p.redactErrMsg(test.in))
+			assert.Equal(t, test.want, redactErrMsg(test.in))
 		})
 	}
 }
 
-func TestRedactedURL(t *testing.T) {
+// Same redaction, reached through a parsed URL as the probe does.
+func TestRedactURLFromParsedURL(t *testing.T) {
 	tests := []struct {
 		name   string
 		redact bool
@@ -167,7 +166,7 @@ func TestRedactedURL(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			p := &Probe{redactURLQueryInLogs: test.redact}
-			got := p.redactedURL(mustParseURL(t, test.url))
+			got := p.redactURL(mustParseURL(t, test.url).String())
 			assert.Equal(t, test.want, got)
 		})
 	}

--- a/probes/http/redact_test.go
+++ b/probes/http/redact_test.go
@@ -48,6 +48,11 @@ func TestRedactURL(t *testing.T) {
 		// so anything that stops at whitespace leaks the rest of the query.
 		{"space inside the query", "/a?msg=hello world&tok=secret", "/a?<redacted>"},
 		{"absolute URL", "http://h/a?tok=secret", "http://h/a?<redacted>"},
+		// A fragment isn't part of the query, and redactedURL (which works
+		// from a parsed URL) keeps it, so this must keep it too.
+		{"fragment is kept", "http://h/a?tok=s#frag", "http://h/a?<redacted>#frag"},
+		// Here the '?' is inside the fragment, so there is no query at all.
+		{"'?' only inside the fragment", "http://h/a#x?y", "http://h/a#x?y"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -99,6 +104,11 @@ func TestRedactErrMsg(t *testing.T) {
 			name: "quoted relative URL is redacted",
 			in:   `parse "/a?tok=secret": bad`,
 			want: `parse "/a?<redacted>": bad`,
+		},
+		{
+			name: "fragment inside a quoted URL is kept",
+			in:   `Get "http://h/a?tok=s#frag": refused`,
+			want: `Get "http://h/a?<redacted>#frag": refused`,
 		},
 		{"bare trailing ?", `Get "http://h/a?": refused`, `Get "http://h/a?": refused`},
 	}

--- a/probes/http/redact_test.go
+++ b/probes/http/redact_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	neturl "net/url"
 	"testing"
 
@@ -86,6 +88,18 @@ func TestRedactErrMsg(t *testing.T) {
 			want: "error resolving target: foo?bar, no such host",
 		},
 		{"no query", `Get "http://h/a": refused`, `Get "http://h/a": refused`},
+		// Errors quote plenty of things that aren't URLs. A '?' in one of
+		// those is not a query, and rewriting it only destroys a diagnostic.
+		{
+			name: "non-URL quoted token is left alone",
+			in:   `x509: certificate is valid for "a?b", not h`,
+			want: `x509: certificate is valid for "a?b", not h`,
+		},
+		{
+			name: "quoted relative URL is redacted",
+			in:   `parse "/a?tok=secret": bad`,
+			want: `parse "/a?<redacted>": bad`,
+		},
 		{"bare trailing ?", `Get "http://h/a?": refused`, `Get "http://h/a?": refused`},
 	}
 	for _, test := range tests {
@@ -262,6 +276,42 @@ func TestRedactedErr(t *testing.T) {
 		assert.NotContains(t, got.Error(), `y"`)
 		assert.Contains(t, got.Error(), "<redacted>")
 	})
+}
+
+// net/http puts the request URL in url.Error's URL field, but a redirect whose
+// Location fails to parse goes in the *inner* error instead -- a different URL,
+// carrying a different query. Redacting only the URL field leaks it.
+func TestRedactedErrRedirectLocationInInnerError(t *testing.T) {
+	// An invalid port makes url.Parse reject the Location, which is what
+	// drives net/http down that path.
+	loc := "https://other.example.com:notaport/cb?code=supersecret"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", loc)
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer srv.Close()
+
+	_, err := http.Get(srv.URL + "/start?mytok=mysecret")
+	if err == nil {
+		t.Fatal("expected the request to fail")
+	}
+
+	p := &Probe{redactURLQueryInLogs: true}
+	got := p.redactedErr(err).Error()
+	assert.NotContains(t, got, "code=supersecret", "redirect Location query leaked via the inner error")
+	assert.NotContains(t, got, "mytok=mysecret", "request query leaked")
+	assert.Contains(t, got, "<redacted>")
+}
+
+// Rewriting the inner error is only worth it when it actually contains a URL;
+// otherwise the error keeps its type and Unwrap chain.
+func TestRedactedErrKeepsUnwrapWhenInnerErrIsClean(t *testing.T) {
+	p := &Probe{redactURLQueryInLogs: true}
+	err := &neturl.Error{Op: "Get", URL: "http://h/a?tok=secret", Err: context.DeadlineExceeded}
+
+	got := p.redactedErr(err)
+	assert.True(t, errors.Is(got, context.DeadlineExceeded), "unwrap chain should survive")
+	assert.NotContains(t, got.Error(), "tok=secret")
 }
 
 // A malformed relative_url is rejected at Init, and that error carries the

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -128,18 +128,25 @@ func (p *Probe) redactURL(s string) string {
 //	                                                 ^ prose '?', not a query
 var quotedRE = regexp.MustCompile(`"(?:\\.|[^"\\])*"`)
 
-// redactErrMsg redacts the query of any quoted URL in an error message. It is
-// the fallback for errors that don't carry the URL as a field: we rewrite only
-// inside %q-quoted tokens, which is where an error puts a URL, so a '?' in the
-// surrounding prose is left alone and the message stays readable.
+// redactErrMsg redacts the query of any quoted URL in an error message. We
+// rewrite only inside %q-quoted tokens, which is where an error puts a URL, so
+// a '?' in the surrounding prose is left alone and the message stays readable.
+//
+// The token also has to look like a URL. Errors quote plenty of other things
+// -- x509 name constraints, header values -- and a '?' in those is not a
+// query; redacting one destroys a diagnostic without hiding a secret.
 func (p *Probe) redactErrMsg(s string) string {
 	return quotedRE.ReplaceAllStringFunc(s, func(tok string) string {
-		i := strings.Index(tok, "?")
-		// No query, or a bare '?' right before the closing quote.
-		if i < 0 || i == len(tok)-2 {
+		inner := tok[1 : len(tok)-1]
+		if !strings.Contains(inner, "://") && !strings.HasPrefix(inner, "/") {
 			return tok
 		}
-		return tok[:i] + "?" + redactedQuery + `"`
+		i := strings.Index(inner, "?")
+		// No query, or a bare trailing '?'.
+		if i < 0 || i == len(inner)-1 {
+			return tok
+		}
+		return `"` + inner[:i] + "?" + redactedQuery + `"`
 	})
 }
 
@@ -162,9 +169,17 @@ func (p *Probe) redactedURL(u *url.URL) string {
 // the query via the error message.
 //
 // A *url.Error holds the URL as a field, so we rebuild it with that field
-// redacted: the error keeps its type and its Unwrap chain, and errors.Is/As
-// behave the same whether or not redaction is on. Anything else falls back to
+// redacted, which keeps its type and its Unwrap chain intact. net/http puts a
+// URL in the *inner* error as well, though -- a redirect whose Location fails
+// to parse is rendered there with %q -- so that message is redacted too, and
+// only then is the inner error replaced. Everything else falls back to
 // rewriting the message.
+//
+// errors.Is/As are therefore unaffected for the common *url.Error, but the
+// fallback, and an inner error that actually had to be rewritten, do lose
+// their type and Unwrap chain. We can't wrap with %w to keep them: that
+// re-embeds the unredacted text and puts the query straight back into the
+// message.
 //
 // It returns err unchanged when redaction is disabled, so that the default
 // configuration keeps propagating the original error untouched.
@@ -172,12 +187,18 @@ func (p *Probe) redactedErr(err error) error {
 	if err == nil || !p.redactURLQueryInLogs {
 		return err
 	}
-	if ue, ok := err.(*url.Error); ok {
-		redacted := *ue
-		redacted.URL = p.redactURL(ue.URL)
-		return &redacted
+	ue, ok := err.(*url.Error)
+	if !ok {
+		return errors.New(p.redactErrMsg(err.Error()))
 	}
-	return errors.New(p.redactErrMsg(err.Error()))
+	redacted := *ue
+	redacted.URL = p.redactURL(ue.URL)
+	if ue.Err != nil {
+		if msg := p.redactErrMsg(ue.Err.Error()); msg != ue.Err.Error() {
+			redacted.Err = errors.New(msg)
+		}
+	}
+	return &redacted
 }
 
 func (p *Probe) resolveFirst(target endpoint.Endpoint) bool {

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -102,14 +102,11 @@ func pathForTarget(target endpoint.Endpoint, probeURL string) string {
 	return ""
 }
 
-// redactRawURL replaces the query of a raw URL string with "<redacted>".
-//
-// The fragment is split off first, for two reasons: a '?' that appears only
-// inside a fragment is not a query and must be left alone, and the fragment
-// itself is not part of the query, so it survives -- which is what
-// redactedURL does with a parsed URL. Everything between '?' and the fragment
-// goes, whatever it holds: a query may legally contain a space, so anything
-// that stopped at whitespace would leave the tail of it exposed.
+// redactRawURL replaces a URL's query with "<redacted>". The fragment is split
+// off first: a '?' inside a fragment is not a query, and the fragment itself
+// survives. Everything between '?' and the fragment goes, whatever it holds --
+// a query may legally contain a space, so stopping at whitespace would leave
+// the tail of it exposed.
 func redactRawURL(s string) string {
 	rest, frag, hasFrag := strings.Cut(s, "#")
 	base, query, found := strings.Cut(rest, "?")
@@ -123,8 +120,6 @@ func redactRawURL(s string) string {
 	return redacted
 }
 
-// redactURL is redactRawURL, gated on the option. It is used where we hold the
-// URL itself rather than a message that contains one.
 func (p *Probe) redactURL(s string) string {
 	if !p.redactURLQueryInLogs {
 		return s
@@ -133,81 +128,48 @@ func (p *Probe) redactURL(s string) string {
 }
 
 // quotedRE matches a %q-rendered token: a double-quoted string that may
-// contain backslash escapes. Matching the quoted token, rather than the URL
-// inside it, is what bounds the rewrite -- the closing quote ends the query no
-// matter what the query holds, and text outside the quotes is left alone:
-//
-//	in:  Get "http://h/a?msg=hello world" failed: is it up?
-//	out: Get "http://h/a?<redacted>" failed: is it up?
-//	                                                 ^ prose '?', not a query
+// contain backslash escapes.
 var quotedRE = regexp.MustCompile(`"(?:\\.|[^"\\])*"`)
 
-// redactErrMsg redacts the query of any quoted URL in an error message. We
-// rewrite only inside %q-quoted tokens, which is where an error puts a URL, so
-// a '?' in the surrounding prose is left alone and the message stays readable.
-//
-// The token also has to look like a URL. Errors quote plenty of other things
-// -- x509 name constraints, header values -- and a '?' in those is not a
-// query; redacting one destroys a diagnostic without hiding a secret.
-func (p *Probe) redactErrMsg(s string) string {
+// redactErrMsg redacts the query of any quoted URL in an error message.
+// Rewriting only inside %q-quoted tokens that look like URLs keeps a '?' in
+// the prose, or in a quoted non-URL such as an x509 name constraint, from
+// being mistaken for a query.
+func redactErrMsg(s string) string {
 	return quotedRE.ReplaceAllStringFunc(s, func(tok string) string {
 		inner := tok[1 : len(tok)-1]
 		if !strings.Contains(inner, "://") && !strings.HasPrefix(inner, "/") {
 			return tok
 		}
-		redacted := redactRawURL(inner)
-		if redacted == inner {
-			return tok
+		if redacted := redactRawURL(inner); redacted != inner {
+			return `"` + redacted + `"`
 		}
-		return `"` + redacted + `"`
+		return tok
 	})
 }
 
-// redactedURL returns the URL string for logging, with its query replaced by
-// "<redacted>" if redaction is enabled. Here we have the parsed URL, so we can
-// redact exactly rather than by shape, leaving the fragment and everything
-// else untouched.
-func (p *Probe) redactedURL(u *url.URL) string {
-	if !p.redactURLQueryInLogs || u.RawQuery == "" {
-		return u.String()
-	}
-	redacted := *u
-	redacted.RawQuery = redactedQuery
-	return redacted.String()
-}
-
-// redactedErr returns err with the query redacted in its message. This is
-// needed because net/http errors embed the full URL, including the query, in
-// their text, so redacting only the logged "url" attribute would still leak
-// the query via the error message.
+// redactedErr returns err with the query redacted: net/http errors embed the
+// URL in their text, so redacting only the logged "url" attribute would still
+// leak it.
 //
-// A *url.Error holds the URL as a field, so we rebuild it with that field
-// redacted, which keeps its type and its Unwrap chain intact. net/http puts a
-// URL in the *inner* error as well, though -- a redirect whose Location fails
-// to parse is rendered there with %q -- so that message is redacted too, and
-// only then is the inner error replaced. Everything else falls back to
-// rewriting the message.
-//
-// errors.Is/As are therefore unaffected for the common *url.Error, but the
-// fallback, and an inner error that actually had to be rewritten, do lose
-// their type and Unwrap chain. We can't wrap with %w to keep them: that
-// re-embeds the unredacted text and puts the query straight back into the
-// message.
-//
-// It returns err unchanged when redaction is disabled, so that the default
-// configuration keeps propagating the original error untouched.
+// net/http puts a URL in two places. A *url.Error holds one as a field, and
+// its inner error holds another when a redirect's Location fails to parse.
+// Rebuilding keeps the type and Unwrap chain, and the inner error is swapped
+// only if redaction changed it, so errors.Is/As survive the common case.
+// Wrapping with %w to preserve them everywhere is not an option: it re-embeds
+// the unredacted text.
 func (p *Probe) redactedErr(err error) error {
 	if err == nil || !p.redactURLQueryInLogs {
 		return err
 	}
 	ue, ok := err.(*url.Error)
 	if !ok {
-		return errors.New(p.redactErrMsg(err.Error()))
+		return errors.New(redactErrMsg(err.Error()))
 	}
 	redacted := *ue
 	redacted.URL = p.redactURL(ue.URL)
 	if ue.Err != nil {
-		if msg := p.redactErrMsg(ue.Err.Error()); msg != ue.Err.Error() {
+		if msg := redactErrMsg(ue.Err.Error()); msg != ue.Err.Error() {
 			redacted.Err = errors.New(msg)
 		}
 	}

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -102,20 +102,34 @@ func pathForTarget(target endpoint.Endpoint, probeURL string) string {
 	return ""
 }
 
-// redactURL replaces the query of a raw URL string with "<redacted>". Because
-// we hold the URL itself rather than a message that contains one, we can cut
-// at the first '?' and take everything after it. That matters: a query may
-// legally contain characters -- a space among them -- that would otherwise
-// look like the end of the URL and leave the tail of the query exposed.
+// redactRawURL replaces the query of a raw URL string with "<redacted>".
+//
+// The fragment is split off first, for two reasons: a '?' that appears only
+// inside a fragment is not a query and must be left alone, and the fragment
+// itself is not part of the query, so it survives -- which is what
+// redactedURL does with a parsed URL. Everything between '?' and the fragment
+// goes, whatever it holds: a query may legally contain a space, so anything
+// that stopped at whitespace would leave the tail of it exposed.
+func redactRawURL(s string) string {
+	rest, frag, hasFrag := strings.Cut(s, "#")
+	base, query, found := strings.Cut(rest, "?")
+	if !found || query == "" {
+		return s
+	}
+	redacted := base + "?" + redactedQuery
+	if hasFrag {
+		redacted += "#" + frag
+	}
+	return redacted
+}
+
+// redactURL is redactRawURL, gated on the option. It is used where we hold the
+// URL itself rather than a message that contains one.
 func (p *Probe) redactURL(s string) string {
 	if !p.redactURLQueryInLogs {
 		return s
 	}
-	base, query, found := strings.Cut(s, "?")
-	if !found || query == "" {
-		return s
-	}
-	return base + "?" + redactedQuery
+	return redactRawURL(s)
 }
 
 // quotedRE matches a %q-rendered token: a double-quoted string that may
@@ -141,12 +155,11 @@ func (p *Probe) redactErrMsg(s string) string {
 		if !strings.Contains(inner, "://") && !strings.HasPrefix(inner, "/") {
 			return tok
 		}
-		i := strings.Index(inner, "?")
-		// No query, or a bare trailing '?'.
-		if i < 0 || i == len(inner)-1 {
+		redacted := redactRawURL(inner)
+		if redacted == inner {
 			return tok
 		}
-		return `"` + inner[:i] + "?" + redactedQuery + `"`
+		return `"` + redacted + `"`
 	})
 }
 


### PR DESCRIPTION
Follow-up to #1410. That change redacts `url.Error`'s `URL` field, which covers
the common case — but `net/http` puts a URL in **two** places.

`uerr` (`net/http/client.go:622`) builds the error with the *request* URL in
`.URL`, while a redirect whose `Location` fails to parse puts the raw `Location`
in the *inner* error. So with `redact_url_query_in_logs: true` this still
reached the log in full:

```
Get "http://h/start?<redacted>": failed to parse Location header
"https://other.example.com:notaport/cb?code=supersecret": invalid port ...
```

Our own query is redacted; the redirect target's is not — which is exactly the
redirect leak the option exists to close.

### Changes

- **Redact the inner error's message too.** It is swapped out only when the text
  actually changes, so the `Unwrap` chain survives in the common case where the
  inner error holds no URL.
- **Require a quoted token to look like a URL** (contain `://` or start with
  `/`) before rewriting it. Redacting inner errors means the quoted-token path
  now sees messages it never used to; without this, `x509: certificate is valid
  for "a?b", not h` would come out as `"a?<redacted>"`, destroying a diagnostic
  that never held a secret.
- **Correct `redactedErr`'s doc comment**, which claimed `errors.Is/As` are
  unaffected by redaction. True for the common `*url.Error`, not for the
  fallback or a rewritten inner error. Wrapping with `%w` to preserve them is
  not an option — it re-embeds the unredacted text and puts the query straight
  back in.

### Testing

`TestRedactedErrRedirectLocationInInnerError` drives a real `httptest` server
that returns an unparseable `Location` carrying a secret, and asserts neither
query survives. Verified it fails without the fix ("redirect Location query
leaked via the inner error"). `TestRedactedErrKeepsUnwrapWhenInnerErrIsClean`
pins that `errors.Is` still works when the inner error needs no rewriting, and
`TestRedactErrMsg` gains cases for non-URL and relative-URL quoted tokens.

`go build ./...`, `go vet`, `go test -race ./probes/http/...` and `gofmt` are
clean.