### PR TITLE
[http] Hide URL passwords in error messages, and use it for proxy_url

### DIFF
--- a/probes/http/http.go
+++ b/probes/http/http.go
@@ -115,7 +115,7 @@ func (p *Probe) getTransport() (*http.Transport, error) {
 	if p.c.GetProxyUrl() != "" {
 		url, err := url.Parse(p.c.GetProxyUrl())
 		if err != nil {
-			return nil, fmt.Errorf("error parsing proxy URL (%s): %v", p.c.GetProxyUrl(), err)
+			return nil, errors.New(redactErrMsg(err.Error()))
 		}
 		transport.Proxy = http.ProxyURL(url)
 

--- a/probes/http/proxy_url_test.go
+++ b/probes/http/proxy_url_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package http
+
+import (
+	"testing"
+	"time"
+
+	configpb "github.com/cloudprober/cloudprober/probes/http/proto"
+	"github.com/cloudprober/cloudprober/probes/options"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestProxyURLParseErrorHidesPassword(t *testing.T) {
+	p := &Probe{
+		// Invalid port, so url.Parse rejects it.
+		c:    &configpb.ProbeConf{ProxyUrl: proto.String("http://user:hunter2@proxy.example.com:notaport/")},
+		opts: &options.Options{Timeout: time.Second},
+	}
+
+	_, err := p.getTransport()
+	if err == nil {
+		t.Fatal("expected a parse error for the malformed proxy_url")
+	}
+
+	assert.NotContains(t, err.Error(), "hunter2", "proxy password leaked into the error")
+	// The reason and the rest of the URL survive, so the message stays useful.
+	assert.Contains(t, err.Error(), "invalid port")
+	assert.Contains(t, err.Error(), "proxy.example.com")
+}

--- a/probes/http/redact_test.go
+++ b/probes/http/redact_test.go
@@ -66,6 +66,23 @@ func TestRedactURL(t *testing.T) {
 	})
 }
 
+func TestStripURLPassword(t *testing.T) {
+	tests := []struct{ name, in, want string }{
+		{"password hidden", "http://user:pw@h/a", "http://user:***@h/a"},
+		{"username alone is kept", "http://user@h/a", "http://user@h/a"},
+		{"no userinfo", "http://h/a", "http://h/a"},
+		{"port is not userinfo", "http://h:8080/a", "http://h:8080/a"},
+		{"'@' in the path is not userinfo", "http://h/a@b", "http://h/a@b"},
+		{"unparseable URL still handled", "http://user:pw@h:notaport/", "http://user:***@h:notaport/"},
+		{"no scheme", "/a?x=1", "/a?x=1"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, stripURLPassword(test.in))
+		})
+	}
+}
+
 func TestRedactErrMsg(t *testing.T) {
 	tests := []struct{ name, in, want string }{
 		{
@@ -102,6 +119,11 @@ func TestRedactErrMsg(t *testing.T) {
 			name: "quoted relative URL is redacted",
 			in:   `parse "/a?tok=secret": bad`,
 			want: `parse "/a?<redacted>": bad`,
+		},
+		{
+			name: "password is hidden, reason kept",
+			in:   `parse "http://user:pw@h:notaport/": invalid port`,
+			want: `parse "http://user:***@h:notaport/": invalid port`,
 		},
 		{
 			name: "fragment inside a quoted URL is kept",

--- a/probes/http/request.go
+++ b/probes/http/request.go
@@ -127,21 +127,45 @@ func (p *Probe) redactURL(s string) string {
 	return redactRawURL(s)
 }
 
+// stripURLPassword replaces the password in a raw URL's userinfo with "***",
+// the way net/http does before putting a URL into an error. net/url does not:
+// url.Parse embeds the string it was handed, password and all. We work on the
+// raw string because the URL that reaches us is often one Parse rejected.
+func stripURLPassword(s string) string {
+	i := strings.Index(s, "://")
+	if i < 0 {
+		return s
+	}
+	authority := s[i+3:]
+	if end := strings.IndexAny(authority, "/?#"); end >= 0 {
+		authority = authority[:end]
+	}
+	at := strings.LastIndex(authority, "@")
+	if at < 0 {
+		return s
+	}
+	colon := strings.Index(authority[:at], ":")
+	if colon < 0 {
+		return s
+	}
+	return s[:i+3+colon+1] + "***" + s[i+3+at:]
+}
+
 // quotedRE matches a %q-rendered token: a double-quoted string that may
 // contain backslash escapes.
 var quotedRE = regexp.MustCompile(`"(?:\\.|[^"\\])*"`)
 
-// redactErrMsg redacts the query of any quoted URL in an error message.
-// Rewriting only inside %q-quoted tokens that look like URLs keeps a '?' in
-// the prose, or in a quoted non-URL such as an x509 name constraint, from
-// being mistaken for a query.
+// redactErrMsg makes the URLs in an error message safe to log: it hides the
+// password and the query of every quoted URL. Rewriting only inside %q-quoted
+// tokens that look like URLs keeps a '?' in the prose, or in a quoted non-URL
+// such as an x509 name constraint, from being mistaken for a query.
 func redactErrMsg(s string) string {
 	return quotedRE.ReplaceAllStringFunc(s, func(tok string) string {
 		inner := tok[1 : len(tok)-1]
 		if !strings.Contains(inner, "://") && !strings.HasPrefix(inner, "/") {
 			return tok
 		}
-		if redacted := redactRawURL(inner); redacted != inner {
+		if redacted := redactRawURL(stripURLPassword(inner)); redacted != inner {
 			return `"` + redacted + `"`
 		}
 		return tok


### PR DESCRIPTION
`net/http` replaces a URL's password with `***` before putting it in an error.
`net/url` does not — `url.Parse` embeds the string it was handed, password and
all. So a URL we *parse but never fetch* keeps its credentials all the way into
the log.

`proxy_url` is the case that hits: the message included the URL twice, once from
the config value and once from `url.Parse`.

```
before: error parsing proxy URL (http://user:hunter2@proxy.example.com:notaport/):
          parse "http://user:hunter2@proxy.example.com:notaport/": invalid port ":notaport" after host

after:  parse "http://user:***@proxy.example.com:notaport/": invalid port ":notaport" after host
```

### Change

Rather than a one-off, this teaches the existing helper from #1410/#1477 to hide
passwords alongside queries, so `redactErrMsg` now makes *any* URL in a message
safe to log — and `proxy_url` just calls it. The reason and the rest of the URL
survive, which the earlier version of this PR lost by dropping the error
entirely.

It works on the raw string, because the URL that reaches us is often one
`url.Parse` rejected, and it leaves a bare username alone — that isn't the
secret.

### Testing

`TestStripURLPassword` covers userinfo, bare username, `@` in the path, a port
mistaken for a password, and unparseable URLs.
`TestProxyURLParseErrorHidesPassword` asserts the password is gone while
`invalid port` and the host remain.

`go build ./...`, `go vet`, `go test -race ./probes/http/...`, `gofmt` clean.