### PR TITLE
[logger] Never block the caller on writes to stderr

### DIFF
--- a/cmd/cloudprober/main.go
+++ b/cmd/cloudprober/main.go
@@ -97,7 +97,7 @@ func setupProfiling() {
 				l.Critical(err.Error())
 			}
 		}
-		logger.Flush(time.Second)
+		logger.WaitForStderr(time.Second)
 		os.Exit(1)
 	}(f)
 }
@@ -108,7 +108,7 @@ func main() {
 
 	// Initialize logger after parsing flags.
 	l = logger.NewWithAttrs(slog.String("component", "global"))
-	defer logger.Flush(time.Second)
+	defer logger.WaitForStderr(time.Second)
 
 	if len(flag.Args()) > 0 {
 		l.Criticalf("Unexpected non-flag arguments: %v", flag.Args())
@@ -178,7 +178,7 @@ func main() {
 			l.Warningf("Received signal \"%v\", canceling the start context and waiting for %v before closing", sig, *stopTime)
 			cancelF()
 			time.Sleep(*stopTime)
-			logger.Flush(time.Second)
+			logger.WaitForStderr(time.Second)
 			os.Exit(0)
 		}()
 	}

--- a/cmd/cloudprober/main.go
+++ b/cmd/cloudprober/main.go
@@ -97,6 +97,7 @@ func setupProfiling() {
 				l.Critical(err.Error())
 			}
 		}
+		logger.Flush(time.Second)
 		os.Exit(1)
 	}(f)
 }
@@ -107,6 +108,7 @@ func main() {
 
 	// Initialize logger after parsing flags.
 	l = logger.NewWithAttrs(slog.String("component", "global"))
+	defer logger.Flush(time.Second)
 
 	if len(flag.Args()) > 0 {
 		l.Criticalf("Unexpected non-flag arguments: %v", flag.Args())
@@ -176,6 +178,7 @@ func main() {
 			l.Warningf("Received signal \"%v\", canceling the start context and waiting for %v before closing", sig, *stopTime)
 			cancelF()
 			time.Sleep(*stopTime)
+			logger.Flush(time.Second)
 			os.Exit(0)
 		}()
 	}

--- a/logger/asyncwriter.go
+++ b/logger/asyncwriter.go
@@ -24,8 +24,8 @@ import (
 	"time"
 )
 
-// maxQueuedLogBytes is the most log data we hold in memory while waiting for
-// stderr to accept it.
+// maxQueuedLogBytes (4 MiB) is the most log data we hold in memory while
+// waiting for stderr to accept it.
 const maxQueuedLogBytes = 4 << 20
 
 // asyncWriter is an io.Writer that never blocks the caller. Writes are queued
@@ -81,6 +81,9 @@ func (aw *asyncWriter) Write(p []byte) (int, error) {
 	aw.queued += len(p)
 	aw.mu.Unlock()
 
+	// Wake up the drain goroutine without blocking. If a wake-up is already
+	// pending, the send is skipped: the drain goroutine takes the whole queue,
+	// including this entry, when it handles that wake-up.
 	select {
 	case aw.ready <- struct{}{}:
 	default:
@@ -96,6 +99,8 @@ func (aw *asyncWriter) drain() {
 		aw.mu.Unlock()
 
 		for _, b := range batch {
+			// Nowhere to report a failed write to stderr; the synchronous
+			// path ignored these errors too.
 			aw.w.Write(b)
 			aw.mu.Lock()
 			aw.queued -= len(b)
@@ -112,21 +117,22 @@ func dropNotice(n int64) []byte {
 	return buf.Bytes()
 }
 
-// Flush waits until all queued entries have been written, or until timeout
-// expires. It reports whether the queue was fully written.
-func (aw *asyncWriter) Flush(timeout time.Duration) bool {
-	deadline := time.Now().Add(timeout)
-	for {
-		aw.mu.Lock()
-		queued := aw.queued
-		aw.mu.Unlock()
+func (aw *asyncWriter) pendingBytes() int {
+	aw.mu.Lock()
+	defer aw.mu.Unlock()
+	return aw.queued
+}
 
-		if queued == 0 {
-			return true
-		}
-		if time.Now().After(deadline) {
+// Wait waits until the drain goroutine has written all queued entries, or
+// until timeout expires. It doesn't write anything itself. It reports whether
+// all entries were written.
+func (aw *asyncWriter) Wait(timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for aw.pendingBytes() > 0 {
+		if !time.Now().Before(deadline) {
 			return false
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	return true
 }

--- a/logger/asyncwriter.go
+++ b/logger/asyncwriter.go
@@ -1,0 +1,132 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// maxQueuedLogBytes is the most log data we hold in memory while waiting for
+// stderr to accept it.
+const maxQueuedLogBytes = 4 << 20
+
+// asyncWriter is an io.Writer that never blocks the caller. Writes are queued
+// and written to the underlying writer, in order, by a single goroutine.
+//
+// Writes to stderr can block indefinitely if whatever reads the other end of
+// the pipe stalls (e.g. the container runtime's log writer on a node with a
+// stuck disk). Without this, every goroutine that logs, including probe
+// goroutines, would block behind that write. With it, only the drain
+// goroutine blocks; once the queue fills up, new entries are dropped and
+// counted, and a notice marking the gap precedes the next accepted entry.
+type asyncWriter struct {
+	w        io.Writer
+	maxBytes int
+
+	mu     sync.Mutex
+	queue  [][]byte
+	queued int // Bytes queued or being written.
+
+	ready   chan struct{} // Wakes up the drain goroutine.
+	dropped atomic.Int64  // Total entries dropped.
+	noted   int64         // Drops already covered by a notice.
+}
+
+func newAsyncWriter(w io.Writer, maxBytes int) *asyncWriter {
+	aw := &asyncWriter{
+		w:        w,
+		maxBytes: maxBytes,
+		ready:    make(chan struct{}, 1),
+	}
+	go aw.drain()
+	return aw
+}
+
+// Write queues p for writing and always returns len(p), nil. If the queue is
+// full, p is dropped.
+func (aw *asyncWriter) Write(p []byte) (int, error) {
+	aw.mu.Lock()
+	if aw.queued+len(p) > aw.maxBytes {
+		aw.dropped.Add(1)
+		aw.mu.Unlock()
+		return len(p), nil
+	}
+	// First entry accepted after drops: put a notice where the gap is.
+	if d := aw.dropped.Load(); d > aw.noted {
+		notice := dropNotice(d - aw.noted)
+		aw.queue = append(aw.queue, notice)
+		aw.queued += len(notice)
+		aw.noted = d
+	}
+	// Copy p: slog handlers reuse their buffers after Write returns.
+	aw.queue = append(aw.queue, bytes.Clone(p))
+	aw.queued += len(p)
+	aw.mu.Unlock()
+
+	select {
+	case aw.ready <- struct{}{}:
+	default:
+	}
+	return len(p), nil
+}
+
+func (aw *asyncWriter) drain() {
+	for range aw.ready {
+		aw.mu.Lock()
+		batch := aw.queue
+		aw.queue = nil
+		aw.mu.Unlock()
+
+		for _, b := range batch {
+			aw.w.Write(b)
+			aw.mu.Lock()
+			aw.queued -= len(b)
+			aw.mu.Unlock()
+		}
+	}
+}
+
+func dropNotice(n int64) []byte {
+	var buf bytes.Buffer
+	r := slog.NewRecord(time.Now(), slog.LevelWarn, "Dropped log entries because writes to stderr were blocked", 0)
+	r.AddAttrs(slog.String("system", defaultSystemName), slog.Int64("dropped_entries", n))
+	slogHandler(&buf).Handle(context.Background(), r)
+	return buf.Bytes()
+}
+
+// Flush waits until all queued entries have been written, or until timeout
+// expires. It reports whether the queue was fully written.
+func (aw *asyncWriter) Flush(timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		aw.mu.Lock()
+		queued := aw.queued
+		aw.mu.Unlock()
+
+		if queued == 0 {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/logger/asyncwriter_test.go
+++ b/logger/asyncwriter_test.go
@@ -73,14 +73,16 @@ func TestAsyncWriterBlockedWriter(t *testing.T) {
 	}
 
 	assert.Equal(t, int64(5), aw.dropped.Load())
-	assert.False(t, aw.Flush(50*time.Millisecond), "Flush with a blocked writer")
+	assert.False(t, aw.Wait(0), "Wait(0) with a blocked writer")
+	assert.False(t, aw.Wait(50*time.Millisecond), "Wait with a blocked writer")
 
 	close(bw.unblock)
-	assert.True(t, aw.Flush(5*time.Second), "Flush after unblocking")
+	assert.True(t, aw.Wait(5*time.Second), "Wait after unblocking")
+	assert.True(t, aw.Wait(0), "Wait(0) with nothing queued")
 
 	// The next accepted entry is preceded by a notice about the drops.
 	aw.Write([]byte(entry(15)))
-	assert.True(t, aw.Flush(5*time.Second))
+	assert.True(t, aw.Wait(5*time.Second))
 
 	lines := strings.Split(strings.TrimSuffix(bw.String(), "\n"), "\n")
 	if !assert.Len(t, lines, 12) {
@@ -103,7 +105,7 @@ func TestAsyncWriterCopiesInput(t *testing.T) {
 	copy(p, entry(1)) // Caller reuses its buffer, as slog does.
 
 	close(bw.unblock)
-	assert.True(t, aw.Flush(5*time.Second))
+	assert.True(t, aw.Wait(5*time.Second))
 	assert.Equal(t, entry(0), bw.String())
 }
 
@@ -124,7 +126,7 @@ func TestAsyncWriterConcurrentWrites(t *testing.T) {
 	}
 	wg.Wait()
 
-	assert.True(t, aw.Flush(5*time.Second))
+	assert.True(t, aw.Wait(5*time.Second))
 	assert.Equal(t, 1000, strings.Count(bw.String(), "\n"))
 	assert.Equal(t, int64(0), aw.dropped.Load())
 }

--- a/logger/asyncwriter_test.go
+++ b/logger/asyncwriter_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// blockingWriter blocks all writes until unblock is closed, like a stderr
+// pipe whose reader has stalled.
+type blockingWriter struct {
+	unblock chan struct{}
+
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	<-w.unblock
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *blockingWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+func entry(i int) string {
+	return fmt.Sprintf("entry-%02d\n", i) // 9 bytes
+}
+
+func TestAsyncWriterBlockedWriter(t *testing.T) {
+	bw := &blockingWriter{unblock: make(chan struct{})}
+	aw := newAsyncWriter(bw, 10*len(entry(0)))
+
+	// Room for 10 entries; the remaining 5 should be dropped, without
+	// blocking.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := range 15 {
+			n, err := aw.Write([]byte(entry(i)))
+			assert.NoError(t, err)
+			assert.Equal(t, len(entry(i)), n)
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Write blocked on a blocked writer")
+	}
+
+	assert.Equal(t, int64(5), aw.dropped.Load())
+	assert.False(t, aw.Flush(50*time.Millisecond), "Flush with a blocked writer")
+
+	close(bw.unblock)
+	assert.True(t, aw.Flush(5*time.Second), "Flush after unblocking")
+
+	// The next accepted entry is preceded by a notice about the drops.
+	aw.Write([]byte(entry(15)))
+	assert.True(t, aw.Flush(5*time.Second))
+
+	lines := strings.Split(strings.TrimSuffix(bw.String(), "\n"), "\n")
+	if !assert.Len(t, lines, 12) {
+		return
+	}
+	for i := range 10 {
+		assert.Equal(t, strings.TrimSuffix(entry(i), "\n"), lines[i])
+	}
+	assert.Contains(t, lines[10], "level=WARN")
+	assert.Contains(t, lines[10], "dropped_entries=5")
+	assert.Equal(t, strings.TrimSuffix(entry(15), "\n"), lines[11])
+}
+
+func TestAsyncWriterCopiesInput(t *testing.T) {
+	bw := &blockingWriter{unblock: make(chan struct{})}
+	aw := newAsyncWriter(bw, 1024)
+
+	p := []byte(entry(0))
+	aw.Write(p)
+	copy(p, entry(1)) // Caller reuses its buffer, as slog does.
+
+	close(bw.unblock)
+	assert.True(t, aw.Flush(5*time.Second))
+	assert.Equal(t, entry(0), bw.String())
+}
+
+func TestAsyncWriterConcurrentWrites(t *testing.T) {
+	bw := &blockingWriter{unblock: make(chan struct{})}
+	close(bw.unblock)
+	aw := newAsyncWriter(bw, maxQueuedLogBytes)
+
+	var wg sync.WaitGroup
+	for g := range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range 100 {
+				aw.Write([]byte(fmt.Sprintf("g%d-%d\n", g, i)))
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.True(t, aw.Flush(5*time.Second))
+	assert.Equal(t, 1000, strings.Count(bw.String(), "\n"))
+	assert.Equal(t, int64(0), aw.dropped.Load())
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -28,6 +28,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -102,7 +103,27 @@ var basePath string
 // We trim this path from the logged source function name.
 const basePackage = "github.com/cloudprober/cloudprober/"
 
-var defaultWritter = io.Writer(os.Stderr)
+// defaultWritter overrides the writer used by loggers created without
+// WithWriter. If nil, they write to stderr through an asyncWriter.
+var defaultWritter io.Writer
+
+var (
+	stderrOnce   sync.Once
+	stderrWriter *asyncWriter
+)
+
+func asyncStderr() *asyncWriter {
+	stderrOnce.Do(func() {
+		stderrWriter = newAsyncWriter(os.Stderr, maxQueuedLogBytes)
+	})
+	return stderrWriter
+}
+
+// Flush waits up to timeout for queued log entries to be written to stderr.
+// Call it before exiting the program to avoid losing the last few entries.
+func Flush(timeout time.Duration) {
+	asyncStderr().Flush(timeout)
+}
 
 var defaultLogStore atomic.Pointer[logstore.LogStore]
 
@@ -155,6 +176,9 @@ func parseMinLogLevel() slog.Level {
 func slogHandler(w io.Writer) slog.Handler {
 	if w == nil {
 		w = defaultWritter
+	}
+	if w == nil {
+		w = asyncStderr()
 	}
 	opts := &slog.HandlerOptions{
 		AddSource:   true,
@@ -469,6 +493,8 @@ func (l *Logger) logAttrs(level slog.Level, depth int, msg string, attrs ...slog
 	}
 
 	if level == criticalLevel {
+		// Bounded, so that a blocked stderr can't prevent the exit.
+		Flush(2 * time.Second)
 		if l != nil && l.gcpLogc != nil {
 			l.gcpLogc.Close()
 		}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -119,10 +119,11 @@ func asyncStderr() *asyncWriter {
 	return stderrWriter
 }
 
-// Flush waits up to timeout for queued log entries to be written to stderr.
-// Call it before exiting the program to avoid losing the last few entries.
-func Flush(timeout time.Duration) {
-	asyncStderr().Flush(timeout)
+// WaitForStderr waits up to timeout for queued log entries to be written to
+// stderr. Call it before exiting the program to avoid losing the last few
+// entries.
+func WaitForStderr(timeout time.Duration) {
+	asyncStderr().Wait(timeout)
 }
 
 var defaultLogStore atomic.Pointer[logstore.LogStore]
@@ -494,7 +495,7 @@ func (l *Logger) logAttrs(level slog.Level, depth int, msg string, attrs ...slog
 
 	if level == criticalLevel {
 		// Bounded, so that a blocked stderr can't prevent the exit.
-		Flush(2 * time.Second)
+		WaitForStderr(2 * time.Second)
 		if l != nil && l.gcpLogc != nil {
 			l.gcpLogc.Close()
 		}

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -197,7 +197,7 @@ func testLog(t *testing.T, funcName string, msg string, logAttr slog.Attr, strAt
 	} else {
 		defaultWritter = &buf
 		defer func() {
-			defaultWritter = os.Stderr
+			defaultWritter = nil
 		}()
 	}
 


### PR DESCRIPTION
If whatever reads the other end of stderr stalls (for example, the container runtime's log writer on a node with a stuck disk), a write to stderr blocks indefinitely. Every goroutine that logs then blocks behind that one write, including probe goroutines, so probing gradually stops. We saw this in production: `cloudprober_total` stepped down to zero over about 9 minutes while the node's logs went dark.

### Change

- Loggers created without `WithWriter` now write to stderr through a new `asyncWriter`. A single goroutine writes the queued entries in order. `Write` copies its input and never blocks.
- If the queue fills up (4 MiB), new entries are dropped and counted. A WARN entry with `dropped_entries=N` goes just before the next accepted entry, so the gap is marked in the log stream.
- Critical logs, and `main`'s exit paths, flush the queue before exiting. The flush has a timeout, so a stalled stderr can't block the exit either.
- Writers passed with `WithWriter` stay synchronous.

This follows zerolog's `diode.Writer` (the input copy, drops reported in the stream) and Docker's non-blocking log mode (a byte budget, dropping the newest entries). It's a buffered queue with no new dependencies.

### Testing

- Unit tests for a blocked writer (writes don't block, drops are counted, order is preserved, the notice lands at the gap, `Flush` times out), for the input copy, and for concurrent writes. They pass 30 times in a row under `-race`, and the full test suite passes.
- Manual run: an HTTP probe with 20 failing targets at a 100ms interval, with stderr going to a FIFO whose reader never reads.
  - **Before:** probing froze within seconds, with no exports at all over 35s.
  - **After:** probing ran at full rate, with 100 → 200 → 300 per target across three 10s exports. Only the drain goroutine was blocked in `pipe_write`.

### Follow-ups

- Export the drop count as a sysvar metric. Metrics kept flowing during the incident while logs were dark, so this metric would have made the stall visible.
- Route the `raw_stderr_output` relays in the external and command probes through the same writer.
