### PR TITLE
[logger] Export dropped-entry count and route raw stderr through the async writer

### DIFF
--- a/internal/sysvars/runtime.go
+++ b/internal/sysvars/runtime.go
@@ -48,6 +48,9 @@ func counterRuntimeVars(dataChan chan *metrics.EventMetrics, ts time.Time, m *ru
 	em.AddMetric("mallocs", metrics.NewInt(int64(m.Mallocs)))
 	em.AddMetric("frees", metrics.NewInt(int64(m.Frees)))
 
+	// Log entries dropped because writes to stderr were blocked.
+	em.AddMetric("dropped_log_entries", metrics.NewInt(logger.DroppedEntries()))
+
 	dataChan <- em
 	l.Debug(em.String())
 }

--- a/internal/sysvars/runtime_test.go
+++ b/internal/sysvars/runtime_test.go
@@ -27,7 +27,7 @@ func TestCounterRuntimeVars(t *testing.T) {
 		t.Errorf("Metrics kind is not cumulative.")
 	}
 
-	for _, name := range []string{"uptime_msec", "gc_time_msec", "mallocs", "frees"} {
+	for _, name := range []string{"uptime_msec", "gc_time_msec", "mallocs", "frees", "dropped_log_entries"} {
 		if em.Metric(name) == nil {
 			t.Errorf("Expected metric \"%s\" not defined in EventMetrics: %s", name, em.String())
 		}

--- a/logger/asyncwriter_test.go
+++ b/logger/asyncwriter_test.go
@@ -130,3 +130,39 @@ func TestAsyncWriterConcurrentWrites(t *testing.T) {
 	assert.Equal(t, 1000, strings.Count(bw.String(), "\n"))
 	assert.Equal(t, int64(0), aw.dropped.Load())
 }
+
+// Observing the stderr writer must work without one: starting it just to
+// answer a question would start its drain goroutine in processes that never
+// log to stderr.
+func TestObserversWithoutWriter(t *testing.T) {
+	assert.Zero(t, droppedEntries(nil), "droppedEntries(nil)")
+	assert.True(t, waitForStderr(nil, 0), "waitForStderr(nil)")
+}
+
+func TestObserversWithWriter(t *testing.T) {
+	bw := &blockingWriter{unblock: make(chan struct{})}
+	aw := newAsyncWriter(bw, len(entry(0))) // Room for one entry.
+
+	aw.Write([]byte(entry(0))) // Queued, and then blocked in the writer.
+	aw.Write([]byte(entry(1))) // Dropped: no room left.
+
+	assert.Equal(t, int64(1), droppedEntries(aw))
+	assert.False(t, waitForStderr(aw, 0), "waitForStderr with a blocked writer")
+
+	close(bw.unblock)
+	assert.True(t, waitForStderr(aw, 5*time.Second), "waitForStderr after unblocking")
+	assert.Equal(t, entry(0), bw.String())
+}
+
+func TestStderrWriter(t *testing.T) {
+	w := Stderr()
+	if w == nil {
+		t.Fatal("Stderr() = nil, want the async stderr writer")
+	}
+	assert.True(t, w == Stderr(), "Stderr() returned a different writer")
+
+	// The exported observers read the writer Stderr() returns, which the
+	// call above has certainly started by now.
+	assert.Equal(t, asyncStderr().dropped.Load(), DroppedEntries())
+	WaitForStderr(time.Second)
+}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -126,6 +126,19 @@ func WaitForStderr(timeout time.Duration) {
 	asyncStderr().Wait(timeout)
 }
 
+// DroppedEntries returns the number of log entries dropped so far because
+// writes to stderr were blocked and the queue was full.
+func DroppedEntries() int64 {
+	return asyncStderr().dropped.Load()
+}
+
+// Stderr returns the writer that loggers use for stderr. Writes to it are
+// queued and never block the caller, so use it instead of os.Stderr on hot
+// paths, e.g. while relaying a probe process's stderr.
+func Stderr() io.Writer {
+	return asyncStderr()
+}
+
 var defaultLogStore atomic.Pointer[logstore.LogStore]
 
 // SetDefaultLogStore sets the default log store that all new loggers will use.

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -109,27 +109,45 @@ var defaultWritter io.Writer
 
 var (
 	stderrOnce   sync.Once
-	stderrWriter *asyncWriter
+	stderrWriter atomic.Pointer[asyncWriter]
 )
 
+// asyncStderr returns the writer used for stderr logs, creating it, and its
+// drain goroutine, on first use.
 func asyncStderr() *asyncWriter {
 	stderrOnce.Do(func() {
-		stderrWriter = newAsyncWriter(os.Stderr, maxQueuedLogBytes)
+		stderrWriter.Store(newAsyncWriter(os.Stderr, maxQueuedLogBytes))
 	})
-	return stderrWriter
+	return stderrWriter.Load()
 }
 
 // WaitForStderr waits up to timeout for queued log entries to be written to
 // stderr. Call it before exiting the program to avoid losing the last few
-// entries.
+// entries. It does nothing if nothing has logged to stderr yet.
 func WaitForStderr(timeout time.Duration) {
-	asyncStderr().Wait(timeout)
+	waitForStderr(stderrWriter.Load(), timeout)
+}
+
+func waitForStderr(aw *asyncWriter, timeout time.Duration) bool {
+	if aw == nil {
+		return true
+	}
+	return aw.Wait(timeout)
 }
 
 // DroppedEntries returns the number of log entries dropped so far because
-// writes to stderr were blocked and the queue was full.
+// writes to stderr were blocked and the queue was full. Unlike Stderr, it
+// only observes the stderr writer and never starts it, so it returns 0 if
+// nothing has logged to stderr yet.
 func DroppedEntries() int64 {
-	return asyncStderr().dropped.Load()
+	return droppedEntries(stderrWriter.Load())
+}
+
+func droppedEntries(aw *asyncWriter) int64 {
+	if aw == nil {
+		return 0
+	}
+	return aw.dropped.Load()
 }
 
 // Stderr returns the writer that loggers use for stderr. Writes to it are

--- a/probes/common/command/command.go
+++ b/probes/common/command/command.go
@@ -122,7 +122,7 @@ func (c *Command) setupStreaming(cmd *exec.Cmd, l *logger.Logger) (func(), error
 
 		for scanner.Scan() {
 			if c.RawStderrOutput {
-				fmt.Fprintln(os.Stderr, scanner.Text())
+				fmt.Fprintln(logger.Stderr(), scanner.Text())
 			} else {
 				l.WarningAttrs("process stderr", slog.String("process_stderr", scanner.Text()), slog.String("process_path", c.CmdLine[0]))
 			}

--- a/probes/common/command/command_test.go
+++ b/probes/common/command/command_test.go
@@ -187,3 +187,33 @@ func TestProcessStderr(t *testing.T) {
 	}
 	assert.True(t, found, "ProcessStderr did not receive the expected stderr line, got: %v", stderr)
 }
+
+// TestRawStderrOutput verifies that, with RawStderrOutput set, the child's
+// stderr lines are relayed through the logger's stderr writer (queued, so a
+// stalled stderr can't block the relay goroutine or the probe), and that
+// ProcessStderr still sees them. The relayed lines land on the test binary's
+// own stderr, which is why this test's output carries a stray
+// "Running test command." line.
+func TestRawStderrOutput(t *testing.T) {
+	var stderr []string
+	p := &Command{
+		CmdLine:                []string{os.Args[0], "-test.run=TestShellProcessSuccess", "--", "/test/cmd"},
+		EnvVars:                []string{"GO_CP_TEST_PROCESS=1"},
+		ProcessStreamingOutput: func([]byte) {},
+		RawStderrOutput:        true,
+		ProcessStderr: func(line []byte) {
+			stderr = append(stderr, string(line))
+		},
+	}
+
+	_, err := p.Execute(context.Background(), nil)
+	assert.NoError(t, err)
+
+	found := false
+	for _, line := range stderr {
+		if strings.Contains(line, "Running test command.") {
+			found = true
+		}
+	}
+	assert.True(t, found, "ProcessStderr did not receive the expected stderr line, got: %v", stderr)
+}

--- a/probes/external/external_server.go
+++ b/probes/external/external_server.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/cloudprober/cloudprober/common/strtemplate"
+	"github.com/cloudprober/cloudprober/logger"
 	configpb "github.com/cloudprober/cloudprober/probes/external/proto"
 	"github.com/cloudprober/cloudprober/probes/external/serverutils"
 	"github.com/cloudprober/cloudprober/targets/endpoint"
@@ -113,7 +114,7 @@ func (p *Probe) startCmdIfNotRunning(startCtx context.Context) error {
 		for {
 			if scanner.Scan() {
 				if rawStderr {
-					fmt.Fprintln(os.Stderr, scanner.Text())
+					fmt.Fprintln(logger.Stderr(), scanner.Text())
 				} else {
 					p.l.WarningAttrs("process stderr", slog.String("process_stderr", scanner.Text()), slog.String("process_path", cmd.Path))
 				}


### PR DESCRIPTION
Follow-up to #1481, which made writes to stderr non-blocking. Two loose ends from that PR.

### Export the drop count

`logger.DroppedEntries()` exposes the counter from the async writer, and sysvars exports it as the cumulative metric `dropped_log_entries`.

During the incident that motivated #1481, metrics kept flowing while the logs were dark. That makes this counter the signal that would have shown the stall: log entries are only dropped when stderr writes are blocked and the 4 MiB queue is full.

### Raw process stderr

With `raw_stderr_output` set, the external and command probes wrote a process's stderr lines straight to `os.Stderr`. A stalled stderr blocked that relay goroutine, which then blocked the probe's child process once its stderr pipe filled up. In `command.go`, the probe run waits on that goroutine as well, so the stall reached the probe directly.

Both sites now write to `logger.Stderr()`, so these lines are queued like every other log write, and they no longer interleave mid-line with logger output.

### Testing

`go test -race` passes for the logger, sysvars, external and command packages, and the full suite passes. The sysvars counter test now asserts the new metric.
