### PR TITLE
[rds/kubernetes] Time out API server calls, and share one lister across the four resource types

### DIFF
--- a/internal/rds/kubernetes/client.go
+++ b/internal/rds/kubernetes/client.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/cloudprober/cloudprober/common/oauth"
 	"github.com/cloudprober/cloudprober/common/tlsconfig"
@@ -36,6 +37,11 @@ var (
 	LocalCACert    = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	LocalTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )
+
+// apiCallTimeout is the overall timeout (connection, headers, and body) for a
+// call to the Kubernetes API server. Without it, an API server that accepts
+// the connection but never responds stalls the lister's refresh loop forever.
+const apiCallTimeout = 30 * time.Second
 
 // client encapsulates an in-cluster kubeapi client.
 type client struct {
@@ -143,6 +149,7 @@ func newClientWithoutToken(cfg *configpb.ProviderConfig, l *logger.Logger) (*cli
 
 	c.httpC = &http.Client{
 		Transport: transport,
+		Timeout:   apiCallTimeout,
 	}
 
 	if err := c.initAPIHost(); err != nil {

--- a/internal/rds/kubernetes/client_test.go
+++ b/internal/rds/kubernetes/client_test.go
@@ -17,8 +17,11 @@ package kubernetes
 import (
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	tlsconfigpb "github.com/cloudprober/cloudprober/common/tlsconfig/proto"
 	cpb "github.com/cloudprober/cloudprober/internal/rds/kubernetes/proto"
@@ -117,6 +120,31 @@ func TestNewClientWithTLS(t *testing.T) {
 	if tc.httpC == nil || tc.httpC.Transport.(*http.Transport).TLSClientConfig == nil {
 		t.Errorf("Client's HTTP client or TLS config are unexpectedly nil.")
 	}
+
+	assert.Equal(t, apiCallTimeout, tc.httpC.Timeout, "HTTP client timeout")
+}
+
+// TestGetURLTimeout verifies that a call to an API server that accepts the
+// connection but never responds gives up instead of blocking forever.
+func TestGetURLTimeout(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	httpC := ts.Client()
+	httpC.Timeout = 100 * time.Millisecond
+
+	tc := &client{
+		cfg:     &cpb.ProviderConfig{},
+		apiHost: strings.TrimPrefix(ts.URL, "https://"),
+		httpC:   httpC,
+	}
+
+	start := time.Now()
+	_, err := tc.getURL("api/v1/pods")
+	assert.ErrorContains(t, err, "Client.Timeout")
+	assert.Less(t, time.Since(start), 5*time.Second, "getURL should return as soon as the timeout fires")
 }
 
 func TestClientHTTPRequest(t *testing.T) {

--- a/internal/rds/kubernetes/endpoints.go
+++ b/internal/rds/kubernetes/endpoints.go
@@ -15,81 +15,16 @@
 package kubernetes
 
 import (
-	"encoding/json"
 	"fmt"
-	"math/rand"
 	"strconv"
-	"strings"
-	"sync"
 	"time"
 
-	configpb "github.com/cloudprober/cloudprober/internal/rds/kubernetes/proto"
 	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
-	"github.com/cloudprober/cloudprober/internal/rds/server/filter"
 	"github.com/cloudprober/cloudprober/logger"
 	"google.golang.org/protobuf/proto"
 )
 
-type epLister struct {
-	c         *configpb.Endpoints
-	namespace string
-	kClient   *client
-
-	mu    sync.RWMutex // Mutex for names and cache
-	keys  []resourceKey
-	cache map[resourceKey]*epInfo
-	l     *logger.Logger
-}
-
-func epURL(ns string) string {
-	if ns == "" {
-		return "api/v1/endpoints"
-	}
-	return fmt.Sprintf("api/v1/namespaces/%s/endpoints", ns)
-}
-
-func (lister *epLister) listResources(req *pb.ListResourcesRequest) ([]*pb.Resource, error) {
-	var resources []*pb.Resource
-
-	var epName string
-	tok := strings.SplitN(req.GetResourcePath(), "/", 2)
-	if len(tok) == 2 {
-		epName = tok[1]
-	}
-
-	allFilters, err := filter.ParseFilters(req.GetFilter(), SupportedFilters.RegexFilterKeys, "")
-	if err != nil {
-		return nil, err
-	}
-
-	nameFilter, nsFilter, labelsFilter := allFilters.RegexFilters["name"], allFilters.RegexFilters["namespace"], allFilters.LabelsFilter
-
-	lister.mu.RLock()
-	defer lister.mu.RUnlock()
-
-	for _, key := range lister.keys {
-		if epName != "" && key.name != epName {
-			continue
-		}
-
-		if nameFilter != nil && !nameFilter.Match(key.name, lister.l) {
-			continue
-		}
-
-		epi := lister.cache[key]
-		if nsFilter != nil && !nsFilter.Match(epi.Metadata.Namespace, lister.l) {
-			continue
-		}
-		if labelsFilter != nil && !labelsFilter.Match(epi.Metadata.Labels, lister.l) {
-			continue
-		}
-
-		resources = append(resources, epi.resources(allFilters.RegexFilters["port"], lister.l)...)
-	}
-
-	lister.l.Debugf("kubernetes.endpoints.listResources: returning %d resources", len(resources))
-	return resources, nil
-}
+type epLister = resourceLister[*epInfo]
 
 type epSubset struct {
 	Addresses []struct {
@@ -111,12 +46,21 @@ type epInfo struct {
 	Subsets  []epSubset
 }
 
+func (epi *epInfo) metadata() kMetadata {
+	return epi.Metadata
+}
+
 // resources returns RDS resources corresponding to an endpoints resource. Each
 // endpoints object can have multiple endpoint subsets and each subset in turn
 // is composed of multiple addresses and ports. If an endpoint subset as 3
 // addresses and 2 ports, there will be 6 resources corresponding to that
 // subset.
-func (epi *epInfo) resources(portFilter *filter.RegexFilter, l *logger.Logger) (resources []*pb.Resource) {
+func (epi *epInfo) resources(f *listFilters, l *logger.Logger) (resources []*pb.Resource) {
+	if !f.matchesObject(epi.Metadata, l) {
+		return nil
+	}
+
+	portFilter := f.regex("port")
 	for _, eps := range epi.Subsets {
 		// There is usually one port, but there can be multiple ports, e.g. 9313
 		// and 9314.
@@ -157,67 +101,15 @@ func (epi *epInfo) resources(portFilter *filter.RegexFilter, l *logger.Logger) (
 	return
 }
 
-func parseEndpointsJSON(resp []byte) (keys []resourceKey, endpoints map[resourceKey]*epInfo, err error) {
-	var itemList struct {
-		Items []*epInfo
-	}
-
-	if err = json.Unmarshal(resp, &itemList); err != nil {
-		return
-	}
-
-	keys = make([]resourceKey, len(itemList.Items))
-	endpoints = make(map[resourceKey]*epInfo)
-	for i, item := range itemList.Items {
-		keys[i] = resourceKey{item.Metadata.Namespace, item.Metadata.Name}
-		endpoints[keys[i]] = item
-	}
-
-	return
-}
-
-func (lister *epLister) expand() {
-	resp, err := lister.kClient.getURL(epURL(lister.namespace))
-	if err != nil {
-		lister.l.Warningf("epLister.expand(): error while getting endpoints list from API: %v", err)
-	}
-
-	keys, endpoints, err := parseEndpointsJSON(resp)
-	if err != nil {
-		lister.l.Warningf("epLister.expand(): error while parsing endpoints API response (%s): %v", string(resp), err)
-	}
-
-	lister.l.Debugf("epLister.expand(): got %d endpoints", len(keys))
-
-	lister.mu.Lock()
-	defer lister.mu.Unlock()
-	lister.keys = keys
-	lister.cache = endpoints
-}
-
-func newEndpointsLister(c *configpb.Endpoints, namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) (*epLister, error) {
+func newEndpointsLister(namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) *epLister {
 	lister := &epLister{
-		c:         c,
-		namespace: namespace,
-		kClient:   kc,
-		l:         l,
+		kind:       "endpoints",
+		apiPrefix:  "api/v1",
+		namespace:  namespace,
+		kClient:    kc,
+		nameInPath: true,
+		l:          l,
 	}
-
-	go func() {
-		lister.expand()
-		// Introduce a random delay between 0-reEvalInterval before
-		// starting the refresh loop. If there are multiple cloudprober
-		// gceInstances, this will make sure that each instance calls GCE
-		// API at a different point of time.
-		rand.Seed(time.Now().UnixNano())
-		randomDelaySec := rand.Intn(int(reEvalInterval.Seconds()))
-		time.Sleep(time.Duration(randomDelaySec) * time.Second)
-		ticker := time.NewTicker(reEvalInterval)
-		defer ticker.Stop()
-		for range ticker.C {
-			lister.expand()
-		}
-	}()
-
-	return lister, nil
+	lister.start(reEvalInterval)
+	return lister
 }

--- a/internal/rds/kubernetes/endpoints_test.go
+++ b/internal/rds/kubernetes/endpoints_test.go
@@ -15,7 +15,7 @@ func TestParseEndpoints(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error reading test data file: %s", epListFile)
 	}
-	_, epByKey, err := parseEndpointsJSON(data)
+	_, epByKey, err := parseResourceList[*epInfo](data, nil)
 	if err != nil {
 		t.Fatalf("error reading test data file: %s", epListFile)
 	}
@@ -129,7 +129,10 @@ func TestEndpointsToResources(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resources := epi.resources(portFilter, nil)
+	f := &listFilters{Filters: &filter.Filters{
+		RegexFilters: map[string]*filter.RegexFilter{"port": portFilter},
+	}}
+	resources := epi.resources(f, nil)
 
 	// We'll get 4 resources = 2 ports x 2 IPs
 	if len(resources) != 4 {

--- a/internal/rds/kubernetes/ingresses.go
+++ b/internal/rds/kubernetes/ingresses.go
@@ -15,81 +15,16 @@
 package kubernetes
 
 import (
-	"encoding/json"
 	"fmt"
-	"math/rand"
 	"strings"
-	"sync"
 	"time"
 
-	configpb "github.com/cloudprober/cloudprober/internal/rds/kubernetes/proto"
 	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
-	"github.com/cloudprober/cloudprober/internal/rds/server/filter"
 	"github.com/cloudprober/cloudprober/logger"
 	"google.golang.org/protobuf/proto"
 )
 
-type ingressesLister struct {
-	c         *configpb.Ingresses
-	namespace string
-	kClient   *client
-
-	mu    sync.RWMutex // Mutex for names and cache
-	keys  []resourceKey
-	cache map[resourceKey]*ingressInfo
-	l     *logger.Logger
-}
-
-func ingressesURL(ns string) string {
-	if ns == "" {
-		return "apis/networking.k8s.io/v1/ingresses"
-	}
-	return fmt.Sprintf("apis/networking.k8s.io/v1/namespaces/%s/ingresses", ns)
-}
-
-func (lister *ingressesLister) listResources(req *pb.ListResourcesRequest) ([]*pb.Resource, error) {
-	var resources []*pb.Resource
-
-	var resName string
-	tok := strings.SplitN(req.GetResourcePath(), "/", 2)
-	if len(tok) == 2 {
-		resName = tok[1]
-	}
-
-	allFilters, err := filter.ParseFilters(req.GetFilter(), SupportedFilters.RegexFilterKeys, "")
-	if err != nil {
-		return nil, err
-	}
-
-	nameFilter, nsFilter, labelsFilter := allFilters.RegexFilters["name"], allFilters.RegexFilters["namespace"], allFilters.LabelsFilter
-
-	lister.mu.RLock()
-	defer lister.mu.RUnlock()
-
-	for _, key := range lister.keys {
-		if resName != "" && key.name != resName {
-			continue
-		}
-
-		ingress := lister.cache[key]
-		if nsFilter != nil && !nsFilter.Match(ingress.Metadata.Namespace, lister.l) {
-			continue
-		}
-
-		for _, res := range ingress.resources() {
-			if nameFilter != nil && !nameFilter.Match(res.GetName(), lister.l) {
-				continue
-			}
-			if labelsFilter != nil && !labelsFilter.Match(res.GetLabels(), lister.l) {
-				continue
-			}
-			resources = append(resources, res)
-		}
-	}
-
-	lister.l.Debugf("kubernetes.listResources: returning %d ingresses", len(resources))
-	return resources, nil
-}
+type ingressesLister = resourceLister[*ingressInfo]
 
 type ingressRule struct {
 	Host string
@@ -110,8 +45,18 @@ type ingressInfo struct {
 	}
 }
 
+func (i *ingressInfo) metadata() kMetadata {
+	return i.Metadata
+}
+
 // resources returns RDS resources corresponding to an ingress resource.
-func (i *ingressInfo) resources() (resources []*pb.Resource) {
+//
+// Unlike the other resource types, the name and labels filters are applied to
+// the expanded resources rather than to the ingress object: an ingress expands
+// into one resource per rule path, each with a derived name and its own fqdn
+// and relative_url labels, and filtering on the object would make those
+// unselectable.
+func (i *ingressInfo) resources(f *listFilters, l *logger.Logger) (resources []*pb.Resource) {
 	resName := i.Metadata.Name
 	baseLabels := i.Metadata.Labels
 
@@ -128,14 +73,19 @@ func (i *ingressInfo) resources() (resources []*pb.Resource) {
 		}
 	}
 
-	if len(i.Spec.Rules) == 0 {
-		return []*pb.Resource{
-			{
-				Name:   proto.String(resName),
-				Labels: baseLabels,
-				Ip:     proto.String(ip),
-			},
+	appendIfMatches := func(res *pb.Resource) {
+		if f.matchesResource(res, l) {
+			resources = append(resources, res)
 		}
+	}
+
+	if len(i.Spec.Rules) == 0 {
+		appendIfMatches(&pb.Resource{
+			Name:   proto.String(resName),
+			Labels: baseLabels,
+			Ip:     proto.String(ip),
+		})
+		return
 	}
 
 	for _, rule := range i.Spec.Rules {
@@ -159,7 +109,7 @@ func (i *ingressInfo) resources() (resources []*pb.Resource) {
 				labels["relative_url"] = p.Path
 			}
 
-			resources = append(resources, &pb.Resource{
+			appendIfMatches(&pb.Resource{
 				Name:   proto.String(nameWithPath),
 				Labels: labels,
 				Ip:     proto.String(ip),
@@ -170,67 +120,15 @@ func (i *ingressInfo) resources() (resources []*pb.Resource) {
 	return
 }
 
-func parseIngressesJSON(resp []byte) (keys []resourceKey, ingresses map[resourceKey]*ingressInfo, err error) {
-	var itemList struct {
-		Items []*ingressInfo
-	}
-
-	if err = json.Unmarshal(resp, &itemList); err != nil {
-		return
-	}
-
-	keys = make([]resourceKey, len(itemList.Items))
-	ingresses = make(map[resourceKey]*ingressInfo)
-	for i, item := range itemList.Items {
-		keys[i] = resourceKey{item.Metadata.Namespace, item.Metadata.Name}
-		ingresses[keys[i]] = item
-	}
-
-	return
-}
-
-func (lister *ingressesLister) expand() {
-	resp, err := lister.kClient.getURL(ingressesURL(lister.namespace))
-	if err != nil {
-		lister.l.Warningf("ingressesLister.expand(): error while getting ingresses list from API: %v", err)
-	}
-
-	keys, ingresses, err := parseIngressesJSON(resp)
-	if err != nil {
-		lister.l.Warningf("ingressesLister.expand(): error while parsing ingresses API response (%s): %v", string(resp), err)
-	}
-
-	lister.l.Debugf("ingressesLister.expand(): got %d ingresses", len(keys))
-
-	lister.mu.Lock()
-	defer lister.mu.Unlock()
-	lister.keys = keys
-	lister.cache = ingresses
-}
-
-func newIngressesLister(c *configpb.Ingresses, namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) (*ingressesLister, error) {
+func newIngressesLister(namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) *ingressesLister {
 	lister := &ingressesLister{
-		c:         c,
-		kClient:   kc,
-		namespace: namespace,
-		l:         l,
+		kind:       "ingresses",
+		apiPrefix:  "apis/networking.k8s.io/v1",
+		namespace:  namespace,
+		kClient:    kc,
+		nameInPath: true,
+		l:          l,
 	}
-
-	go func() {
-		lister.expand()
-		// Introduce a random delay between 0-reEvalInterval before
-		// starting the refresh loop. If there are multiple cloudprober
-		// gceInstances, this will make sure that each instance calls GCE
-		// API at a different point of time.
-		rand.Seed(time.Now().UnixNano())
-		randomDelaySec := rand.Intn(int(reEvalInterval.Seconds()))
-		time.Sleep(time.Duration(randomDelaySec) * time.Second)
-		ticker := time.NewTicker(reEvalInterval)
-		defer ticker.Stop()
-		for range ticker.C {
-			lister.expand()
-		}
-	}()
-
-	return lister, nil
+	lister.start(reEvalInterval)
+	return lister
 }

--- a/internal/rds/kubernetes/ingresses_test.go
+++ b/internal/rds/kubernetes/ingresses_test.go
@@ -46,7 +46,7 @@ func listerFromDataFile(t *testing.T) *ingressesLister {
 	if err != nil {
 		t.Fatalf("error reading test data file: %s", ingressesListFile)
 	}
-	keys, ingresses, err := parseIngressesJSON(data)
+	keys, ingresses, err := parseResourceList[*ingressInfo](data, nil)
 
 	if err != nil {
 		t.Fatalf("Error while parsing ingresses JSON data: %v", err)

--- a/internal/rds/kubernetes/kubernetes.go
+++ b/internal/rds/kubernetes/kubernetes.go
@@ -151,40 +151,18 @@ func New(c *configpb.ProviderConfig, l *logger.Logger) (*Provider, error) {
 
 	reEvalInterval := time.Duration(c.GetReEvalSec()) * time.Second
 
-	// Enable Pods lister if configured.
+	// Enable a lister for each resource type that is configured.
 	if c.GetPods() != nil {
-		lr, err := newPodsLister(c.GetPods(), c.GetNamespace(), reEvalInterval, client, l)
-		if err != nil {
-			return nil, err
-		}
-		p.listers[ResourceTypes.Pods] = lr
+		p.listers[ResourceTypes.Pods] = newPodsLister(c.GetNamespace(), reEvalInterval, client, l)
 	}
-
-	// Enable Endpoints lister if configured.
 	if c.GetEndpoints() != nil {
-		lr, err := newEndpointsLister(c.GetEndpoints(), c.GetNamespace(), reEvalInterval, client, l)
-		if err != nil {
-			return nil, err
-		}
-		p.listers[ResourceTypes.Endpoints] = lr
+		p.listers[ResourceTypes.Endpoints] = newEndpointsLister(c.GetNamespace(), reEvalInterval, client, l)
 	}
-
-	// Enable Services lister if configured.
 	if c.GetServices() != nil {
-		lr, err := newServicesLister(c.GetServices(), c.GetNamespace(), reEvalInterval, client, l)
-		if err != nil {
-			return nil, err
-		}
-		p.listers[ResourceTypes.Services] = lr
+		p.listers[ResourceTypes.Services] = newServicesLister(c.GetNamespace(), reEvalInterval, client, l)
 	}
-
-	// Enable Ingresses lister if configured.
 	if c.GetIngresses() != nil {
-		lr, err := newIngressesLister(c.GetIngresses(), c.GetNamespace(), reEvalInterval, client, l)
-		if err != nil {
-			return nil, err
-		}
-		p.listers[ResourceTypes.Ingresses] = lr
+		p.listers[ResourceTypes.Ingresses] = newIngressesLister(c.GetNamespace(), reEvalInterval, client, l)
 	}
 
 	return p, nil

--- a/internal/rds/kubernetes/lister.go
+++ b/internal/rds/kubernetes/lister.go
@@ -1,0 +1,226 @@
+// Copyright 2019 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+
+	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
+	"github.com/cloudprober/cloudprober/internal/rds/server/filter"
+	"github.com/cloudprober/cloudprober/logger"
+)
+
+// resourceInfo is implemented by the Kubernetes objects that we cache:
+// podInfo, epInfo, serviceInfo, and ingressInfo. It provides the two things
+// the shared lister machinery needs from each object type: its metadata, and
+// how it expands into RDS resources.
+type resourceInfo interface {
+	metadata() kMetadata
+
+	// resources expands a Kubernetes object into the RDS resources it
+	// represents: zero or more, depending on the type. Implementations are
+	// responsible for applying the name and labels filters, as the two are
+	// intertwined with the expansion (see listFilters.matchesObject).
+	resources(f *listFilters, l *logger.Logger) []*pb.Resource
+}
+
+// listFilters holds everything a lister needs from a ListResources request:
+// the filters, and the object name if the request's resource path named one
+// (e.g. "services/service-a").
+type listFilters struct {
+	*filter.Filters
+	name   string
+	ipType pb.IPConfig_IPType
+}
+
+func parseListFilters(req *pb.ListResourcesRequest) (*listFilters, error) {
+	filters, err := filter.ParseFilters(req.GetFilter(), SupportedFilters.RegexFilterKeys, "")
+	if err != nil {
+		return nil, err
+	}
+
+	f := &listFilters{Filters: filters, ipType: req.GetIpConfig().GetIpType()}
+	if tok := strings.SplitN(req.GetResourcePath(), "/", 2); len(tok) == 2 {
+		f.name = tok[1]
+	}
+	return f, nil
+}
+
+// regex returns the regex filter for a key, nil if the request didn't set it.
+func (f *listFilters) regex(key string) *filter.RegexFilter {
+	return f.RegexFilters[key]
+}
+
+// matchesObject reports whether a Kubernetes object's own name and labels pass
+// the request's name and labels filters. Pods, endpoints, and services filter
+// this way, on the object. Ingresses don't use it: they expand into resources
+// whose names and labels are derived per rule, so they filter the expanded
+// resources instead.
+func (f *listFilters) matchesObject(md kMetadata, l *logger.Logger) bool {
+	if nameFilter := f.regex("name"); nameFilter != nil && !nameFilter.Match(md.Name, l) {
+		return false
+	}
+	if f.LabelsFilter != nil && !f.LabelsFilter.Match(md.Labels, l) {
+		return false
+	}
+	return true
+}
+
+// matchesResource is matchesObject's counterpart for resources that have
+// already been expanded. Ingresses filter this way.
+func (f *listFilters) matchesResource(res *pb.Resource, l *logger.Logger) bool {
+	if nameFilter := f.regex("name"); nameFilter != nil && !nameFilter.Match(res.GetName(), l) {
+		return false
+	}
+	if f.LabelsFilter != nil && !f.LabelsFilter.Match(res.GetLabels(), l) {
+		return false
+	}
+	return true
+}
+
+// resourceLister caches one Kubernetes resource type and refreshes it from the
+// API server every reEvalInterval. Everything that varies by resource type is
+// either a field here or lives in the type's resources() method.
+type resourceLister[T resourceInfo] struct {
+	kind      string // e.g. "pods"; used in the API URL and in log messages
+	apiPrefix string // e.g. "api/v1"
+	namespace string // empty means all namespaces
+	kClient   *client
+
+	// keep, if set, filters objects at parse time. Only pods use it, to cache
+	// only the pods that are running.
+	keep func(T) bool
+
+	// nameInPath indicates that a request's resource path may name a single
+	// object, e.g. "services/service-a". Pods don't support that today.
+	nameInPath bool
+
+	mu    sync.RWMutex // protects keys and cache
+	keys  []resourceKey
+	cache map[resourceKey]T
+	l     *logger.Logger
+}
+
+func (rl *resourceLister[T]) url() string {
+	if rl.namespace == "" {
+		return fmt.Sprintf("%s/%s", rl.apiPrefix, rl.kind)
+	}
+	return fmt.Sprintf("%s/namespaces/%s/%s", rl.apiPrefix, rl.namespace, rl.kind)
+}
+
+func (rl *resourceLister[T]) listResources(req *pb.ListResourcesRequest) ([]*pb.Resource, error) {
+	f, err := parseListFilters(req)
+	if err != nil {
+		return nil, err
+	}
+
+	nsFilter := f.regex("namespace")
+
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+
+	var resources []*pb.Resource
+	for _, key := range rl.keys {
+		if rl.nameInPath && f.name != "" && key.name != f.name {
+			continue
+		}
+
+		info := rl.cache[key]
+		if nsFilter != nil && !nsFilter.Match(info.metadata().Namespace, rl.l) {
+			continue
+		}
+
+		resources = append(resources, info.resources(f, rl.l)...)
+	}
+
+	rl.l.Debugf("kubernetes.%s.listResources: returning %d resources", rl.kind, len(resources))
+	return resources, nil
+}
+
+// parseResourceList parses an API server list response into cache keys and the
+// objects they map to. Objects rejected by keep are left out of both.
+func parseResourceList[T resourceInfo](resp []byte, keep func(T) bool) ([]resourceKey, map[resourceKey]T, error) {
+	var itemList struct {
+		Items []T
+	}
+
+	if err := json.Unmarshal(resp, &itemList); err != nil {
+		return nil, nil, err
+	}
+
+	keys := make([]resourceKey, 0, len(itemList.Items))
+	cache := make(map[resourceKey]T, len(itemList.Items))
+	for _, item := range itemList.Items {
+		if keep != nil && !keep(item) {
+			continue
+		}
+		md := item.metadata()
+		key := resourceKey{md.Namespace, md.Name}
+		keys = append(keys, key)
+		cache[key] = item
+	}
+
+	return keys, cache, nil
+}
+
+// expand refreshes the cache from the API server. If the refresh fails we keep
+// the resources we already have: an empty cache means "these targets are gone"
+// to everyone downstream, which is not what a failed API call tells us.
+func (rl *resourceLister[T]) expand() {
+	resp, err := rl.kClient.getURL(rl.url())
+	if err != nil {
+		rl.l.Warningf("kubernetes.%s: error getting %s list from API, keeping existing resources: %v", rl.kind, rl.kind, err)
+		return
+	}
+
+	keys, cache, err := parseResourceList(resp, rl.keep)
+	if err != nil {
+		rl.l.Warningf("kubernetes.%s: error parsing %s API response (%s), keeping existing resources: %v", rl.kind, rl.kind, string(resp), err)
+		return
+	}
+
+	rl.l.Debugf("kubernetes.%s: got %d %s", rl.kind, len(keys), rl.kind)
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	rl.keys = keys
+	rl.cache = cache
+}
+
+// start does the initial expansion and then refreshes in the background.
+func (rl *resourceLister[T]) start(reEvalInterval time.Duration) {
+	go func() {
+		rl.expand()
+
+		// Introduce a random delay between 0-reEvalInterval before starting
+		// the refresh loop. If there are multiple cloudprober instances, this
+		// makes sure that each one calls the API server at a different point
+		// of time.
+		if reEvalInterval > 0 {
+			time.Sleep(time.Duration(rand.Int63n(int64(reEvalInterval))))
+		}
+
+		ticker := time.NewTicker(reEvalInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			rl.expand()
+		}
+	}()
+}

--- a/internal/rds/kubernetes/pods.go
+++ b/internal/rds/kubernetes/pods.go
@@ -15,73 +15,14 @@
 package kubernetes
 
 import (
-	"encoding/json"
-	"fmt"
-	"math/rand"
-	"sync"
 	"time"
 
-	configpb "github.com/cloudprober/cloudprober/internal/rds/kubernetes/proto"
 	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
-	"github.com/cloudprober/cloudprober/internal/rds/server/filter"
 	"github.com/cloudprober/cloudprober/logger"
 	"google.golang.org/protobuf/proto"
 )
 
-type podsLister struct {
-	c         *configpb.Pods
-	namespace string
-	kClient   *client
-
-	mu    sync.RWMutex // Mutex for names and cache
-	keys  []resourceKey
-	cache map[resourceKey]*podInfo
-	l     *logger.Logger
-}
-
-func podsURL(ns string) string {
-	if ns == "" {
-		return "api/v1/pods"
-	}
-	return fmt.Sprintf("api/v1/namespaces/%s/pods", ns)
-}
-
-func (pl *podsLister) listResources(req *pb.ListResourcesRequest) ([]*pb.Resource, error) {
-	var resources []*pb.Resource
-
-	allFilters, err := filter.ParseFilters(req.GetFilter(), SupportedFilters.RegexFilterKeys, "")
-	if err != nil {
-		return nil, err
-	}
-
-	nameFilter, nsFilter, labelsFilter := allFilters.RegexFilters["name"], allFilters.RegexFilters["namespace"], allFilters.LabelsFilter
-
-	pl.mu.RLock()
-	defer pl.mu.RUnlock()
-
-	for _, key := range pl.keys {
-		if nameFilter != nil && !nameFilter.Match(key.name, pl.l) {
-			continue
-		}
-
-		pod := pl.cache[key]
-		if nsFilter != nil && !nsFilter.Match(pod.Metadata.Namespace, pl.l) {
-			continue
-		}
-		if labelsFilter != nil && !labelsFilter.Match(pod.Metadata.Labels, pl.l) {
-			continue
-		}
-
-		resources = append(resources, &pb.Resource{
-			Name:   proto.String(key.name),
-			Ip:     proto.String(pod.Status.PodIP),
-			Labels: pod.Metadata.Labels,
-		})
-	}
-
-	pl.l.Debugf("kubernetes.listResources: returning %d pods", len(resources))
-	return resources, nil
-}
+type podsLister = resourceLister[*podInfo]
 
 type podInfo struct {
 	Metadata kMetadata
@@ -91,71 +32,40 @@ type podInfo struct {
 	}
 }
 
-func parsePodsJSON(resp []byte) (keys []resourceKey, pods map[resourceKey]*podInfo, err error) {
-	var itemList struct {
-		Items []*podInfo
-	}
-
-	if err = json.Unmarshal(resp, &itemList); err != nil {
-		return
-	}
-
-	keys = make([]resourceKey, 0, len(itemList.Items))
-	pods = make(map[resourceKey]*podInfo)
-	for _, item := range itemList.Items {
-		if item.Status.Phase != "Running" {
-			continue
-		}
-		key := resourceKey{item.Metadata.Namespace, item.Metadata.Name}
-		keys = append(keys, key)
-		pods[key] = item
-	}
-
-	return
+func (pi *podInfo) metadata() kMetadata {
+	return pi.Metadata
 }
 
-func (pl *podsLister) expand() {
-	resp, err := pl.kClient.getURL(podsURL(pl.namespace))
-	if err != nil {
-		pl.l.Warningf("podsLister.expand(): error while getting pods list from API: %v", err)
-	}
-
-	keys, pods, err := parsePodsJSON(resp)
-	if err != nil {
-		pl.l.Warningf("podsLister.expand(): error while parsing pods API response (%s): %v", string(resp), err)
-	}
-
-	pl.l.Debugf("podsLister.expand(): got %d pods", len(keys))
-
-	pl.mu.Lock()
-	defer pl.mu.Unlock()
-	pl.keys = keys
-	pl.cache = pods
+// runningPod is the pods lister's parse-time filter: we cache only the pods
+// that are running.
+func runningPod(pi *podInfo) bool {
+	return pi.Status.Phase == "Running"
 }
 
-func newPodsLister(c *configpb.Pods, namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) (*podsLister, error) {
+// resources returns the RDS resource for a pod. Pods map one-to-one.
+func (pi *podInfo) resources(f *listFilters, l *logger.Logger) []*pb.Resource {
+	if !f.matchesObject(pi.Metadata, l) {
+		return nil
+	}
+
+	return []*pb.Resource{
+		{
+			Name:   proto.String(pi.Metadata.Name),
+			Ip:     proto.String(pi.Status.PodIP),
+			Labels: pi.Metadata.Labels,
+		},
+	}
+}
+
+func newPodsLister(namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) *podsLister {
 	pl := &podsLister{
-		c:         c,
+		kind:      "pods",
+		apiPrefix: "api/v1",
 		namespace: namespace,
 		kClient:   kc,
+		keep:      runningPod,
 		l:         l,
 	}
-
-	go func() {
-		pl.expand()
-		// Introduce a random delay between 0-reEvalInterval before
-		// starting the refresh loop. If there are multiple cloudprober
-		// gceInstances, this will make sure that each instance calls GCE
-		// API at a different point of time.
-		rand.Seed(time.Now().UnixNano())
-		randomDelaySec := rand.Intn(int(reEvalInterval.Seconds()))
-		time.Sleep(time.Duration(randomDelaySec) * time.Second)
-		ticker := time.NewTicker(reEvalInterval)
-		defer ticker.Stop()
-		for range ticker.C {
-			pl.expand()
-		}
-	}()
-
-	return pl, nil
+	pl.start(reEvalInterval)
+	return pl
 }

--- a/internal/rds/kubernetes/pods_test.go
+++ b/internal/rds/kubernetes/pods_test.go
@@ -116,7 +116,7 @@ func TestParseResourceList(t *testing.T) {
 		t.Fatalf("error reading test data file: %s", podsListFile)
 	}
 
-	keys, cache, err := parsePodsJSON(data)
+	keys, cache, err := parseResourceList(data, runningPod)
 	if err != nil {
 		t.Fatalf("Error while parsing pods JSON data: %v", err)
 	}

--- a/internal/rds/kubernetes/services.go
+++ b/internal/rds/kubernetes/services.go
@@ -15,81 +15,17 @@
 package kubernetes
 
 import (
-	"encoding/json"
 	"fmt"
-	"math/rand"
 	"strconv"
-	"strings"
-	"sync"
 	"time"
 
-	configpb "github.com/cloudprober/cloudprober/internal/rds/kubernetes/proto"
 	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
 	"github.com/cloudprober/cloudprober/internal/rds/server/filter"
 	"github.com/cloudprober/cloudprober/logger"
 	"google.golang.org/protobuf/proto"
 )
 
-type servicesLister struct {
-	c         *configpb.Services
-	namespace string
-	kClient   *client
-
-	mu    sync.RWMutex // Mutex for names and cache
-	keys  []resourceKey
-	cache map[resourceKey]*serviceInfo
-	l     *logger.Logger
-}
-
-func servicesURL(ns string) string {
-	if ns == "" {
-		return "api/v1/services"
-	}
-	return fmt.Sprintf("api/v1/namespaces/%s/services", ns)
-}
-
-func (lister *servicesLister) listResources(req *pb.ListResourcesRequest) ([]*pb.Resource, error) {
-	var resources []*pb.Resource
-
-	var svcName string
-	tok := strings.SplitN(req.GetResourcePath(), "/", 2)
-	if len(tok) == 2 {
-		svcName = tok[1]
-	}
-
-	allFilters, err := filter.ParseFilters(req.GetFilter(), SupportedFilters.RegexFilterKeys, "")
-	if err != nil {
-		return nil, err
-	}
-
-	nameFilter, nsFilter, labelsFilter := allFilters.RegexFilters["name"], allFilters.RegexFilters["namespace"], allFilters.LabelsFilter
-
-	lister.mu.RLock()
-	defer lister.mu.RUnlock()
-
-	for _, key := range lister.keys {
-		if svcName != "" && key.name != svcName {
-			continue
-		}
-
-		if nameFilter != nil && !nameFilter.Match(key.name, lister.l) {
-			continue
-		}
-
-		svc := lister.cache[key]
-		if nsFilter != nil && !nsFilter.Match(svc.Metadata.Namespace, lister.l) {
-			continue
-		}
-		if labelsFilter != nil && !labelsFilter.Match(svc.Metadata.Labels, lister.l) {
-			continue
-		}
-
-		resources = append(resources, svc.resources(allFilters.RegexFilters["port"], req.GetIpConfig().GetIpType(), lister.l)...)
-	}
-
-	lister.l.Debugf("kubernetes.listResources: returning %d services", len(resources))
-	return resources, nil
-}
+type servicesLister = resourceLister[*serviceInfo]
 
 type loadBalancerStatus struct {
 	Ingress []struct {
@@ -110,6 +46,10 @@ type serviceInfo struct {
 	Status struct {
 		LoadBalancer loadBalancerStatus
 	}
+}
+
+func (si *serviceInfo) metadata() kMetadata {
+	return si.Metadata
 }
 
 func (si *serviceInfo) matchPorts(portFilter *filter.RegexFilter, l *logger.Logger) ([]int, map[int]string) {
@@ -138,8 +78,12 @@ func (si *serviceInfo) matchPorts(portFilter *filter.RegexFilter, l *logger.Logg
 // service name.
 // b) If there are multiple ports, we create one RDS resource for each port and
 // name each resource as: <service_name>_<port_name>
-func (si *serviceInfo) resources(portFilter *filter.RegexFilter, reqIPType pb.IPConfig_IPType, l *logger.Logger) (resources []*pb.Resource) {
-	ports, portNameMap := si.matchPorts(portFilter, l)
+func (si *serviceInfo) resources(f *listFilters, l *logger.Logger) (resources []*pb.Resource) {
+	if !f.matchesObject(si.Metadata, l) {
+		return nil
+	}
+
+	ports, portNameMap := si.matchPorts(f.regex("port"), l)
 	for _, port := range ports {
 		resName := si.Metadata.Name
 		if len(ports) != 1 {
@@ -152,7 +96,7 @@ func (si *serviceInfo) resources(portFilter *filter.RegexFilter, reqIPType pb.IP
 			Labels: si.Metadata.Labels,
 		}
 
-		if reqIPType == pb.IPConfig_PUBLIC {
+		if f.ipType == pb.IPConfig_PUBLIC {
 			// If there is no ingress IP, skip the resource.
 			if len(si.Status.LoadBalancer.Ingress) == 0 {
 				continue
@@ -172,67 +116,15 @@ func (si *serviceInfo) resources(portFilter *filter.RegexFilter, reqIPType pb.IP
 	return
 }
 
-func parseServicesJSON(resp []byte) (keys []resourceKey, services map[resourceKey]*serviceInfo, err error) {
-	var itemList struct {
-		Items []*serviceInfo
-	}
-
-	if err = json.Unmarshal(resp, &itemList); err != nil {
-		return
-	}
-
-	keys = make([]resourceKey, len(itemList.Items))
-	services = make(map[resourceKey]*serviceInfo)
-	for i, item := range itemList.Items {
-		keys[i] = resourceKey{item.Metadata.Namespace, item.Metadata.Name}
-		services[keys[i]] = item
-	}
-
-	return
-}
-
-func (lister *servicesLister) expand() {
-	resp, err := lister.kClient.getURL(servicesURL(lister.namespace))
-	if err != nil {
-		lister.l.Warningf("servicesLister.expand(): error while getting services list from API: %v", err)
-	}
-
-	keys, services, err := parseServicesJSON(resp)
-	if err != nil {
-		lister.l.Warningf("servicesLister.expand(): error while parsing services API response (%s): %v", string(resp), err)
-	}
-
-	lister.l.Debugf("servicesLister.expand(): got %d services", len(keys))
-
-	lister.mu.Lock()
-	defer lister.mu.Unlock()
-	lister.keys = keys
-	lister.cache = services
-}
-
-func newServicesLister(c *configpb.Services, namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) (*servicesLister, error) {
+func newServicesLister(namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) *servicesLister {
 	lister := &servicesLister{
-		c:         c,
-		kClient:   kc,
-		namespace: namespace,
-		l:         l,
+		kind:       "services",
+		apiPrefix:  "api/v1",
+		namespace:  namespace,
+		kClient:    kc,
+		nameInPath: true,
+		l:          l,
 	}
-
-	go func() {
-		lister.expand()
-		// Introduce a random delay between 0-reEvalInterval before
-		// starting the refresh loop. If there are multiple cloudprober
-		// gceInstances, this will make sure that each instance calls GCE
-		// API at a different point of time.
-		rand.Seed(time.Now().UnixNano())
-		randomDelaySec := rand.Intn(int(reEvalInterval.Seconds()))
-		time.Sleep(time.Duration(randomDelaySec) * time.Second)
-		ticker := time.NewTicker(reEvalInterval)
-		defer ticker.Stop()
-		for range ticker.C {
-			lister.expand()
-		}
-	}()
-
-	return lister, nil
+	lister.start(reEvalInterval)
+	return lister
 }

--- a/internal/rds/kubernetes/services_test.go
+++ b/internal/rds/kubernetes/services_test.go
@@ -181,7 +181,7 @@ func TestParseSvcResourceList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error reading test data file: %s", servicesListFile)
 	}
-	_, services, err := parseServicesJSON(data)
+	_, services, err := parseResourceList[*serviceInfo](data, nil)
 
 	if err != nil {
 		t.Fatalf("Error while parsing services JSON data: %v", err)


### PR DESCRIPTION
## Timeout (first commit)

The kubeapi client was built without an `http.Client` timeout and its requests carry no context, so only the cloned `DefaultTransport`'s dial (30s) and TLS handshake (10s) timeouts applied. An API server that completes the handshake and then never sends response headers hung `getURL` forever.

Each lister refreshes from a single goroutine driven by a ticker, so one stuck call froze that resource type's refresh permanently — targets went stale silently and never recovered without a restart.

Sets a 30s overall timeout, comfortably under the 60s default `re_eval_sec`. `Client.Timeout` covers the whole request lifecycle including the body read in `getURL`, and survives `newClient` wrapping the transport in `oauth2.Transport`.

## Deduplication (second commit)

pods, endpoints, services and ingresses each carried their own copy of the same lister: an identical struct, a URL builder differing only in the API prefix and resource kind, a `parseXJSON`, an `expand()`, and a byte-identical refresh goroutine.

All four are now a generic `resourceLister[T resourceInfo]` in `lister.go`. Each resource type supplies only what actually differs: its metadata, and how it expands into RDS resources. Net -392 lines.

### Cache wipe on error

The four copies of `expand()` shared a bug: on an API or parse error they logged a warning and fell through to overwrite the cache with `nil`, so a transient failure dropped every target for that resource type until the next successful refresh.

There's no net for this downstream — an emptied cache reaches the RDS client as a *successful* response with zero resources, not as an error, so `updateState` faithfully replaces its cache with empty.

This mattered little while calls could hang, since a hang preserved the cache. The timeout above turns API stalls into exactly the kind of fast error that hits this path, so `expand()` now keeps the last good result.

### Preserved asymmetries

- **Ingresses** filter name/labels *after* expansion, not on the Kubernetes object, because their resource names are derived per rule (`<ingress>_<host>_<path>`) and they carry their own `fqdn`/`relative_url` labels. The other types filter on the object, where a name filter matches the object name rather than derived per-port resource names. Flattening this either way would silently change target selection.
- **Pods** ignore a name in the resource path (`pods/pod-a`), which the other three honor. Kept behind the `nameInPath` field so existing configs don't silently narrow from all pods to one. Happy to unify this if you'd prefer — it's a one-word change.

### Also

Drops `rand.Seed` (deprecated since Go 1.20, called once per lister at startup) and jitters the first refresh at full resolution instead of whole seconds; drops the unused per-type config fields, as all four config messages are empty; drops the `error` return from the four constructors, which was never non-nil.

## Testing

The listers' test assertions are unchanged — only the call sites of the removed helpers were updated — which is the evidence the refactor preserves behavior. Added `TestGetURLTimeout` (httptest TLS server that blocks until the request context is cancelled) and an assertion that the constructed client carries the timeout.

`go build ./...`, `go test ./internal/rds/...` and `go test -race ./internal/rds/kubernetes/` all pass.

## Known gap, not addressed

`re_eval_sec: 0` panics in a refresh goroutine via `time.NewTicker(0)` and takes the process down. It panicked before this change too (`rand.Intn(0)`), so it's not a regression, but it's now in one place and would be cheap to turn into a config error out of `New()`.