### PR TITLE
[rds/kubernetes] Time out calls to the API server

### DIFF
--- a/internal/rds/kubernetes/client.go
+++ b/internal/rds/kubernetes/client.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/cloudprober/cloudprober/common/oauth"
 	"github.com/cloudprober/cloudprober/common/tlsconfig"
@@ -36,6 +37,11 @@ var (
 	LocalCACert    = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	LocalTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )
+
+// apiCallTimeout is the overall timeout (connection, headers, and body) for a
+// call to the Kubernetes API server. Without it, an API server that accepts
+// the connection but never responds stalls the lister's refresh loop forever.
+const apiCallTimeout = 30 * time.Second
 
 // client encapsulates an in-cluster kubeapi client.
 type client struct {
@@ -143,6 +149,7 @@ func newClientWithoutToken(cfg *configpb.ProviderConfig, l *logger.Logger) (*cli
 
 	c.httpC = &http.Client{
 		Transport: transport,
+		Timeout:   apiCallTimeout,
 	}
 
 	if err := c.initAPIHost(); err != nil {

--- a/internal/rds/kubernetes/client_test.go
+++ b/internal/rds/kubernetes/client_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	tlsconfigpb "github.com/cloudprober/cloudprober/common/tlsconfig/proto"
 	cpb "github.com/cloudprober/cloudprober/internal/rds/kubernetes/proto"
@@ -117,6 +118,22 @@ func TestNewClientWithTLS(t *testing.T) {
 	if tc.httpC == nil || tc.httpC.Transport.(*http.Transport).TLSClientConfig == nil {
 		t.Errorf("Client's HTTP client or TLS config are unexpectedly nil.")
 	}
+
+	assert.Equal(t, apiCallTimeout, tc.httpC.Timeout, "HTTP client timeout")
+}
+
+// TestGetURLTimeout verifies that a call to an API server that accepts the
+// connection but never responds gives up instead of blocking forever.
+func TestGetURLTimeout(t *testing.T) {
+	tc := testK8sClient(t, func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	})
+	tc.httpC.Timeout = 100 * time.Millisecond
+
+	start := time.Now()
+	_, err := tc.getURL("api/v1/pods")
+	assert.ErrorContains(t, err, "Client.Timeout")
+	assert.Less(t, time.Since(start), 5*time.Second, "getURL should return as soon as the timeout fires")
 }
 
 func TestClientHTTPRequest(t *testing.T) {


### PR DESCRIPTION
The kubeapi client was built without an `http.Client` timeout and its requests carry no context, so only the cloned `DefaultTransport`'s dial (30s) and TLS handshake (10s) timeouts applied. An API server that completes the handshake and then never sends response headers hangs `getURL` forever.

Each lister refreshes from a single goroutine driven by a ticker, so one stuck call freezes that resource type's refresh permanently: targets go stale silently and never recover without a restart.

Sets a 30s overall timeout, comfortably under the 60s default `re_eval_sec` so a slow call is abandoned before the next tick. `Client.Timeout` covers the whole request lifecycle including the body read in `getURL`, and survives `newClient` wrapping the transport in `oauth2.Transport`. `oauth.K8STokenSource` is local-file based, so nothing else in this path does I/O.

## Testing

`TestGetURLTimeout` exercises the real `getURL` path against a test server that blocks until the request context is cancelled, plus an assertion in `TestNewClientWithTLS` that the constructed client carries the timeout. Removing `Timeout` from the `http.Client` fails the tests.

Rebased onto #1486, which landed first. That merge added a `testK8sClient` helper covering exactly this setup, so the test now uses it instead of standing up its own TLS server. Verified `go build ./...` and `go test -race ./internal/rds/...` on the combined tree, not just on this branch's original base.

## Interaction with #1486

This was the riskier half when the two PRs were opened together: turning stalls into fast errors fed a bug where `expand()` emptied the cache on any error, so an API outage would have flapped targets in and out every 60s instead of leaving them quietly stale.

That is fixed on `main` as of #1486 — `expand()` now keeps the last good result when a refresh fails — so this change is strictly safer to merge than when it was written. A stall now surfaces as a logged warning and a retry on the next tick, with the existing targets left in place.