### PR TITLE
[rds/kubernetes] Share one generic lister across the four resource types

### DIFF
--- a/internal/rds/kubernetes/endpoints.go
+++ b/internal/rds/kubernetes/endpoints.go
@@ -103,12 +103,11 @@ func (epi *epInfo) resources(f *listFilters, l *logger.Logger) (resources []*pb.
 
 func newEndpointsLister(namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) *epLister {
 	lister := &epLister{
-		kind:       "endpoints",
-		apiPrefix:  "api/v1",
-		namespace:  namespace,
-		kClient:    kc,
-		nameInPath: true,
-		l:          l,
+		kind:      "endpoints",
+		apiPrefix: "api/v1",
+		namespace: namespace,
+		kClient:   kc,
+		l:         l,
 	}
 	lister.start(reEvalInterval)
 	return lister

--- a/internal/rds/kubernetes/endpoints.go
+++ b/internal/rds/kubernetes/endpoints.go
@@ -15,81 +15,16 @@
 package kubernetes
 
 import (
-	"encoding/json"
 	"fmt"
-	"math/rand"
 	"strconv"
-	"strings"
-	"sync"
 	"time"
 
-	configpb "github.com/cloudprober/cloudprober/internal/rds/kubernetes/proto"
 	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
-	"github.com/cloudprober/cloudprober/internal/rds/server/filter"
 	"github.com/cloudprober/cloudprober/logger"
 	"google.golang.org/protobuf/proto"
 )
 
-type epLister struct {
-	c         *configpb.Endpoints
-	namespace string
-	kClient   *client
-
-	mu    sync.RWMutex // Mutex for names and cache
-	keys  []resourceKey
-	cache map[resourceKey]*epInfo
-	l     *logger.Logger
-}
-
-func epURL(ns string) string {
-	if ns == "" {
-		return "api/v1/endpoints"
-	}
-	return fmt.Sprintf("api/v1/namespaces/%s/endpoints", ns)
-}
-
-func (lister *epLister) listResources(req *pb.ListResourcesRequest) ([]*pb.Resource, error) {
-	var resources []*pb.Resource
-
-	var epName string
-	tok := strings.SplitN(req.GetResourcePath(), "/", 2)
-	if len(tok) == 2 {
-		epName = tok[1]
-	}
-
-	allFilters, err := filter.ParseFilters(req.GetFilter(), SupportedFilters.RegexFilterKeys, "")
-	if err != nil {
-		return nil, err
-	}
-
-	nameFilter, nsFilter, labelsFilter := allFilters.RegexFilters["name"], allFilters.RegexFilters["namespace"], allFilters.LabelsFilter
-
-	lister.mu.RLock()
-	defer lister.mu.RUnlock()
-
-	for _, key := range lister.keys {
-		if epName != "" && key.name != epName {
-			continue
-		}
-
-		if nameFilter != nil && !nameFilter.Match(key.name, lister.l) {
-			continue
-		}
-
-		epi := lister.cache[key]
-		if nsFilter != nil && !nsFilter.Match(epi.Metadata.Namespace, lister.l) {
-			continue
-		}
-		if labelsFilter != nil && !labelsFilter.Match(epi.Metadata.Labels, lister.l) {
-			continue
-		}
-
-		resources = append(resources, epi.resources(allFilters.RegexFilters["port"], lister.l)...)
-	}
-
-	lister.l.Debugf("kubernetes.endpoints.listResources: returning %d resources", len(resources))
-	return resources, nil
-}
+type epLister = resourceLister[*epInfo]
 
 type epSubset struct {
 	Addresses []struct {
@@ -111,12 +46,21 @@ type epInfo struct {
 	Subsets  []epSubset
 }
 
+func (epi *epInfo) metadata() kMetadata {
+	return epi.Metadata
+}
+
 // resources returns RDS resources corresponding to an endpoints resource. Each
 // endpoints object can have multiple endpoint subsets and each subset in turn
 // is composed of multiple addresses and ports. If an endpoint subset as 3
 // addresses and 2 ports, there will be 6 resources corresponding to that
 // subset.
-func (epi *epInfo) resources(portFilter *filter.RegexFilter, l *logger.Logger) (resources []*pb.Resource) {
+func (epi *epInfo) resources(f *listFilters, l *logger.Logger) (resources []*pb.Resource) {
+	if !f.matches(epi.Metadata.Name, epi.Metadata.Labels, l) {
+		return nil
+	}
+
+	portFilter := f.regex("port")
 	for _, eps := range epi.Subsets {
 		// There is usually one port, but there can be multiple ports, e.g. 9313
 		// and 9314.
@@ -157,67 +101,15 @@ func (epi *epInfo) resources(portFilter *filter.RegexFilter, l *logger.Logger) (
 	return
 }
 
-func parseEndpointsJSON(resp []byte) (keys []resourceKey, endpoints map[resourceKey]*epInfo, err error) {
-	var itemList struct {
-		Items []*epInfo
-	}
-
-	if err = json.Unmarshal(resp, &itemList); err != nil {
-		return
-	}
-
-	keys = make([]resourceKey, len(itemList.Items))
-	endpoints = make(map[resourceKey]*epInfo)
-	for i, item := range itemList.Items {
-		keys[i] = resourceKey{item.Metadata.Namespace, item.Metadata.Name}
-		endpoints[keys[i]] = item
-	}
-
-	return
-}
-
-func (lister *epLister) expand() {
-	resp, err := lister.kClient.getURL(epURL(lister.namespace))
-	if err != nil {
-		lister.l.Warningf("epLister.expand(): error while getting endpoints list from API: %v", err)
-	}
-
-	keys, endpoints, err := parseEndpointsJSON(resp)
-	if err != nil {
-		lister.l.Warningf("epLister.expand(): error while parsing endpoints API response (%s): %v", string(resp), err)
-	}
-
-	lister.l.Debugf("epLister.expand(): got %d endpoints", len(keys))
-
-	lister.mu.Lock()
-	defer lister.mu.Unlock()
-	lister.keys = keys
-	lister.cache = endpoints
-}
-
-func newEndpointsLister(c *configpb.Endpoints, namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) (*epLister, error) {
+func newEndpointsLister(namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) *epLister {
 	lister := &epLister{
-		c:         c,
-		namespace: namespace,
-		kClient:   kc,
-		l:         l,
+		kind:       "endpoints",
+		apiPrefix:  "api/v1",
+		namespace:  namespace,
+		kClient:    kc,
+		nameInPath: true,
+		l:          l,
 	}
-
-	go func() {
-		lister.expand()
-		// Introduce a random delay between 0-reEvalInterval before
-		// starting the refresh loop. If there are multiple cloudprober
-		// gceInstances, this will make sure that each instance calls GCE
-		// API at a different point of time.
-		rand.Seed(time.Now().UnixNano())
-		randomDelaySec := rand.Intn(int(reEvalInterval.Seconds()))
-		time.Sleep(time.Duration(randomDelaySec) * time.Second)
-		ticker := time.NewTicker(reEvalInterval)
-		defer ticker.Stop()
-		for range ticker.C {
-			lister.expand()
-		}
-	}()
-
-	return lister, nil
+	lister.start(reEvalInterval)
+	return lister
 }

--- a/internal/rds/kubernetes/endpoints_test.go
+++ b/internal/rds/kubernetes/endpoints_test.go
@@ -15,7 +15,7 @@ func TestParseEndpoints(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error reading test data file: %s", epListFile)
 	}
-	_, epByKey, err := parseEndpointsJSON(data)
+	_, epByKey, err := parseResourceList[*epInfo](data, nil)
 	if err != nil {
 		t.Fatalf("error reading test data file: %s", epListFile)
 	}
@@ -129,7 +129,10 @@ func TestEndpointsToResources(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resources := epi.resources(portFilter, nil)
+	f := &listFilters{Filters: &filter.Filters{
+		RegexFilters: map[string]*filter.RegexFilter{"port": portFilter},
+	}}
+	resources := epi.resources(f, nil)
 
 	// We'll get 4 resources = 2 ports x 2 IPs
 	if len(resources) != 4 {

--- a/internal/rds/kubernetes/ingresses.go
+++ b/internal/rds/kubernetes/ingresses.go
@@ -122,12 +122,11 @@ func (i *ingressInfo) resources(f *listFilters, l *logger.Logger) (resources []*
 
 func newIngressesLister(namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) *ingressesLister {
 	lister := &ingressesLister{
-		kind:       "ingresses",
-		apiPrefix:  "apis/networking.k8s.io/v1",
-		namespace:  namespace,
-		kClient:    kc,
-		nameInPath: true,
-		l:          l,
+		kind:      "ingresses",
+		apiPrefix: "apis/networking.k8s.io/v1",
+		namespace: namespace,
+		kClient:   kc,
+		l:         l,
 	}
 	lister.start(reEvalInterval)
 	return lister

--- a/internal/rds/kubernetes/ingresses.go
+++ b/internal/rds/kubernetes/ingresses.go
@@ -15,81 +15,16 @@
 package kubernetes
 
 import (
-	"encoding/json"
 	"fmt"
-	"math/rand"
 	"strings"
-	"sync"
 	"time"
 
-	configpb "github.com/cloudprober/cloudprober/internal/rds/kubernetes/proto"
 	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
-	"github.com/cloudprober/cloudprober/internal/rds/server/filter"
 	"github.com/cloudprober/cloudprober/logger"
 	"google.golang.org/protobuf/proto"
 )
 
-type ingressesLister struct {
-	c         *configpb.Ingresses
-	namespace string
-	kClient   *client
-
-	mu    sync.RWMutex // Mutex for names and cache
-	keys  []resourceKey
-	cache map[resourceKey]*ingressInfo
-	l     *logger.Logger
-}
-
-func ingressesURL(ns string) string {
-	if ns == "" {
-		return "apis/networking.k8s.io/v1/ingresses"
-	}
-	return fmt.Sprintf("apis/networking.k8s.io/v1/namespaces/%s/ingresses", ns)
-}
-
-func (lister *ingressesLister) listResources(req *pb.ListResourcesRequest) ([]*pb.Resource, error) {
-	var resources []*pb.Resource
-
-	var resName string
-	tok := strings.SplitN(req.GetResourcePath(), "/", 2)
-	if len(tok) == 2 {
-		resName = tok[1]
-	}
-
-	allFilters, err := filter.ParseFilters(req.GetFilter(), SupportedFilters.RegexFilterKeys, "")
-	if err != nil {
-		return nil, err
-	}
-
-	nameFilter, nsFilter, labelsFilter := allFilters.RegexFilters["name"], allFilters.RegexFilters["namespace"], allFilters.LabelsFilter
-
-	lister.mu.RLock()
-	defer lister.mu.RUnlock()
-
-	for _, key := range lister.keys {
-		if resName != "" && key.name != resName {
-			continue
-		}
-
-		ingress := lister.cache[key]
-		if nsFilter != nil && !nsFilter.Match(ingress.Metadata.Namespace, lister.l) {
-			continue
-		}
-
-		for _, res := range ingress.resources() {
-			if nameFilter != nil && !nameFilter.Match(res.GetName(), lister.l) {
-				continue
-			}
-			if labelsFilter != nil && !labelsFilter.Match(res.GetLabels(), lister.l) {
-				continue
-			}
-			resources = append(resources, res)
-		}
-	}
-
-	lister.l.Debugf("kubernetes.listResources: returning %d ingresses", len(resources))
-	return resources, nil
-}
+type ingressesLister = resourceLister[*ingressInfo]
 
 type ingressRule struct {
 	Host string
@@ -110,8 +45,18 @@ type ingressInfo struct {
 	}
 }
 
+func (i *ingressInfo) metadata() kMetadata {
+	return i.Metadata
+}
+
 // resources returns RDS resources corresponding to an ingress resource.
-func (i *ingressInfo) resources() (resources []*pb.Resource) {
+//
+// Unlike the other resource types, the name and labels filters are applied to
+// the expanded resources rather than to the ingress object: an ingress expands
+// into one resource per rule path, each with a derived name and its own fqdn
+// and relative_url labels, and filtering on the object would make those
+// unselectable.
+func (i *ingressInfo) resources(f *listFilters, l *logger.Logger) (resources []*pb.Resource) {
 	resName := i.Metadata.Name
 	baseLabels := i.Metadata.Labels
 
@@ -128,14 +73,19 @@ func (i *ingressInfo) resources() (resources []*pb.Resource) {
 		}
 	}
 
-	if len(i.Spec.Rules) == 0 {
-		return []*pb.Resource{
-			{
-				Name:   proto.String(resName),
-				Labels: baseLabels,
-				Ip:     proto.String(ip),
-			},
+	appendIfMatches := func(res *pb.Resource) {
+		if f.matches(res.GetName(), res.GetLabels(), l) {
+			resources = append(resources, res)
 		}
+	}
+
+	if len(i.Spec.Rules) == 0 {
+		appendIfMatches(&pb.Resource{
+			Name:   proto.String(resName),
+			Labels: baseLabels,
+			Ip:     proto.String(ip),
+		})
+		return
 	}
 
 	for _, rule := range i.Spec.Rules {
@@ -159,7 +109,7 @@ func (i *ingressInfo) resources() (resources []*pb.Resource) {
 				labels["relative_url"] = p.Path
 			}
 
-			resources = append(resources, &pb.Resource{
+			appendIfMatches(&pb.Resource{
 				Name:   proto.String(nameWithPath),
 				Labels: labels,
 				Ip:     proto.String(ip),
@@ -170,67 +120,15 @@ func (i *ingressInfo) resources() (resources []*pb.Resource) {
 	return
 }
 
-func parseIngressesJSON(resp []byte) (keys []resourceKey, ingresses map[resourceKey]*ingressInfo, err error) {
-	var itemList struct {
-		Items []*ingressInfo
-	}
-
-	if err = json.Unmarshal(resp, &itemList); err != nil {
-		return
-	}
-
-	keys = make([]resourceKey, len(itemList.Items))
-	ingresses = make(map[resourceKey]*ingressInfo)
-	for i, item := range itemList.Items {
-		keys[i] = resourceKey{item.Metadata.Namespace, item.Metadata.Name}
-		ingresses[keys[i]] = item
-	}
-
-	return
-}
-
-func (lister *ingressesLister) expand() {
-	resp, err := lister.kClient.getURL(ingressesURL(lister.namespace))
-	if err != nil {
-		lister.l.Warningf("ingressesLister.expand(): error while getting ingresses list from API: %v", err)
-	}
-
-	keys, ingresses, err := parseIngressesJSON(resp)
-	if err != nil {
-		lister.l.Warningf("ingressesLister.expand(): error while parsing ingresses API response (%s): %v", string(resp), err)
-	}
-
-	lister.l.Debugf("ingressesLister.expand(): got %d ingresses", len(keys))
-
-	lister.mu.Lock()
-	defer lister.mu.Unlock()
-	lister.keys = keys
-	lister.cache = ingresses
-}
-
-func newIngressesLister(c *configpb.Ingresses, namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) (*ingressesLister, error) {
+func newIngressesLister(namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) *ingressesLister {
 	lister := &ingressesLister{
-		c:         c,
-		kClient:   kc,
-		namespace: namespace,
-		l:         l,
+		kind:       "ingresses",
+		apiPrefix:  "apis/networking.k8s.io/v1",
+		namespace:  namespace,
+		kClient:    kc,
+		nameInPath: true,
+		l:          l,
 	}
-
-	go func() {
-		lister.expand()
-		// Introduce a random delay between 0-reEvalInterval before
-		// starting the refresh loop. If there are multiple cloudprober
-		// gceInstances, this will make sure that each instance calls GCE
-		// API at a different point of time.
-		rand.Seed(time.Now().UnixNano())
-		randomDelaySec := rand.Intn(int(reEvalInterval.Seconds()))
-		time.Sleep(time.Duration(randomDelaySec) * time.Second)
-		ticker := time.NewTicker(reEvalInterval)
-		defer ticker.Stop()
-		for range ticker.C {
-			lister.expand()
-		}
-	}()
-
-	return lister, nil
+	lister.start(reEvalInterval)
+	return lister
 }

--- a/internal/rds/kubernetes/ingresses_test.go
+++ b/internal/rds/kubernetes/ingresses_test.go
@@ -46,7 +46,7 @@ func listerFromDataFile(t *testing.T) *ingressesLister {
 	if err != nil {
 		t.Fatalf("error reading test data file: %s", ingressesListFile)
 	}
-	keys, ingresses, err := parseIngressesJSON(data)
+	keys, ingresses, err := parseResourceList[*ingressInfo](data, nil)
 
 	if err != nil {
 		t.Fatalf("Error while parsing ingresses JSON data: %v", err)

--- a/internal/rds/kubernetes/kubernetes.go
+++ b/internal/rds/kubernetes/kubernetes.go
@@ -140,6 +140,13 @@ func (p *Provider) ListResources(req *pb.ListResourcesRequest) (*pb.ListResource
 // New creates a Kubernetes (k8s) provider for RDS server, based on the
 // provided config.
 func New(c *configpb.ProviderConfig, l *logger.Logger) (*Provider, error) {
+	// Guard the refresh loop's ticker, which panics on a non-positive
+	// interval. Note that an unset re_eval_sec defaults to 60, so this
+	// catches only an explicit zero or a negative value.
+	if c.GetReEvalSec() <= 0 {
+		return nil, fmt.Errorf("kubernetes: re_eval_sec (%d) must be positive", c.GetReEvalSec())
+	}
+
 	client, err := newClient(c, l)
 	if err != nil {
 		return nil, fmt.Errorf("error while creating the kubernetes client: %v", err)

--- a/internal/rds/kubernetes/kubernetes.go
+++ b/internal/rds/kubernetes/kubernetes.go
@@ -151,40 +151,18 @@ func New(c *configpb.ProviderConfig, l *logger.Logger) (*Provider, error) {
 
 	reEvalInterval := time.Duration(c.GetReEvalSec()) * time.Second
 
-	// Enable Pods lister if configured.
+	// Enable a lister for each resource type that is configured.
 	if c.GetPods() != nil {
-		lr, err := newPodsLister(c.GetPods(), c.GetNamespace(), reEvalInterval, client, l)
-		if err != nil {
-			return nil, err
-		}
-		p.listers[ResourceTypes.Pods] = lr
+		p.listers[ResourceTypes.Pods] = newPodsLister(c.GetNamespace(), reEvalInterval, client, l)
 	}
-
-	// Enable Endpoints lister if configured.
 	if c.GetEndpoints() != nil {
-		lr, err := newEndpointsLister(c.GetEndpoints(), c.GetNamespace(), reEvalInterval, client, l)
-		if err != nil {
-			return nil, err
-		}
-		p.listers[ResourceTypes.Endpoints] = lr
+		p.listers[ResourceTypes.Endpoints] = newEndpointsLister(c.GetNamespace(), reEvalInterval, client, l)
 	}
-
-	// Enable Services lister if configured.
 	if c.GetServices() != nil {
-		lr, err := newServicesLister(c.GetServices(), c.GetNamespace(), reEvalInterval, client, l)
-		if err != nil {
-			return nil, err
-		}
-		p.listers[ResourceTypes.Services] = lr
+		p.listers[ResourceTypes.Services] = newServicesLister(c.GetNamespace(), reEvalInterval, client, l)
 	}
-
-	// Enable Ingresses lister if configured.
 	if c.GetIngresses() != nil {
-		lr, err := newIngressesLister(c.GetIngresses(), c.GetNamespace(), reEvalInterval, client, l)
-		if err != nil {
-			return nil, err
-		}
-		p.listers[ResourceTypes.Ingresses] = lr
+		p.listers[ResourceTypes.Ingresses] = newIngressesLister(c.GetNamespace(), reEvalInterval, client, l)
 	}
 
 	return p, nil

--- a/internal/rds/kubernetes/lister.go
+++ b/internal/rds/kubernetes/lister.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Cloudprober Authors.
+// Copyright 2026 The Cloudprober Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -96,6 +96,9 @@ type resourceLister[T resourceInfo] struct {
 	// only the pods that are running.
 	keep func(T) bool
 
+	// keys preserves the API server's ordering and cache has an entry for
+	// every key in it. expand() replaces the two together, so they never
+	// disagree.
 	mu    sync.RWMutex // protects keys and cache
 	keys  []resourceKey
 	cache map[resourceKey]T
@@ -126,6 +129,7 @@ func (rl *resourceLister[T]) listResources(req *pb.ListResourcesRequest) ([]*pb.
 			continue
 		}
 
+		// Always found: every key has a cache entry, see the field comment.
 		info := rl.cache[key]
 		if nsFilter != nil && !nsFilter.Match(info.metadata().Namespace, rl.l) {
 			continue
@@ -139,7 +143,8 @@ func (rl *resourceLister[T]) listResources(req *pb.ListResourcesRequest) ([]*pb.
 }
 
 // parseResourceList parses an API server list response into cache keys and the
-// objects they map to. Objects rejected by keep are left out of both.
+// objects they map to. Objects rejected by keep are left out of both, so every
+// returned key has an entry in the returned map.
 func parseResourceList[T resourceInfo](resp []byte, keep func(T) bool) ([]resourceKey, map[resourceKey]T, error) {
 	var itemList struct {
 		Items []T

--- a/internal/rds/kubernetes/lister.go
+++ b/internal/rds/kubernetes/lister.go
@@ -1,0 +1,214 @@
+// Copyright 2019 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+
+	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
+	"github.com/cloudprober/cloudprober/internal/rds/server/filter"
+	"github.com/cloudprober/cloudprober/logger"
+)
+
+// resourceInfo is implemented by the Kubernetes objects that we cache:
+// podInfo, epInfo, serviceInfo, and ingressInfo. It provides the two things
+// the shared lister machinery needs from each object type: its metadata, and
+// how it expands into RDS resources.
+type resourceInfo interface {
+	metadata() kMetadata
+
+	// resources expands a Kubernetes object into the RDS resources it
+	// represents: zero or more, depending on the type. Implementations are
+	// responsible for applying the name and labels filters, as the two are
+	// intertwined with the expansion (see listFilters.matchesObject).
+	resources(f *listFilters, l *logger.Logger) []*pb.Resource
+}
+
+// listFilters holds everything a lister needs from a ListResources request:
+// the filters, and the object name if the request's resource path named one
+// (e.g. "services/service-a").
+type listFilters struct {
+	*filter.Filters
+	name   string
+	ipType pb.IPConfig_IPType
+}
+
+func parseListFilters(req *pb.ListResourcesRequest) (*listFilters, error) {
+	filters, err := filter.ParseFilters(req.GetFilter(), SupportedFilters.RegexFilterKeys, "")
+	if err != nil {
+		return nil, err
+	}
+
+	f := &listFilters{Filters: filters, ipType: req.GetIpConfig().GetIpType()}
+	if tok := strings.SplitN(req.GetResourcePath(), "/", 2); len(tok) == 2 {
+		f.name = tok[1]
+	}
+	return f, nil
+}
+
+// regex returns the regex filter for a key, nil if the request didn't set it.
+func (f *listFilters) regex(key string) *filter.RegexFilter {
+	return f.RegexFilters[key]
+}
+
+// matches reports whether a name and a set of labels pass the request's name
+// and labels filters. Callers differ in what they pass: pods, endpoints and
+// services match on the Kubernetes object's own name and labels, while
+// ingresses match the resources they expand into, whose names and labels are
+// derived per rule.
+func (f *listFilters) matches(name string, labels map[string]string, l *logger.Logger) bool {
+	if nameFilter := f.regex("name"); nameFilter != nil && !nameFilter.Match(name, l) {
+		return false
+	}
+	if f.LabelsFilter != nil && !f.LabelsFilter.Match(labels, l) {
+		return false
+	}
+	return true
+}
+
+// resourceLister caches one Kubernetes resource type and refreshes it from the
+// API server every reEvalInterval. Everything that varies by resource type is
+// either a field here or lives in the type's resources() method.
+type resourceLister[T resourceInfo] struct {
+	kind      string // e.g. "pods"; used in the API URL and in log messages
+	apiPrefix string // e.g. "api/v1"
+	namespace string // empty means all namespaces
+	kClient   *client
+
+	// keep, if set, filters objects at parse time. Only pods use it, to cache
+	// only the pods that are running.
+	keep func(T) bool
+
+	// nameInPath indicates that a request's resource path may name a single
+	// object, e.g. "services/service-a". Pods don't support that today.
+	nameInPath bool
+
+	mu    sync.RWMutex // protects keys and cache
+	keys  []resourceKey
+	cache map[resourceKey]T
+	l     *logger.Logger
+}
+
+func (rl *resourceLister[T]) url() string {
+	if rl.namespace == "" {
+		return fmt.Sprintf("%s/%s", rl.apiPrefix, rl.kind)
+	}
+	return fmt.Sprintf("%s/namespaces/%s/%s", rl.apiPrefix, rl.namespace, rl.kind)
+}
+
+func (rl *resourceLister[T]) listResources(req *pb.ListResourcesRequest) ([]*pb.Resource, error) {
+	f, err := parseListFilters(req)
+	if err != nil {
+		return nil, err
+	}
+
+	nsFilter := f.regex("namespace")
+
+	rl.mu.RLock()
+	defer rl.mu.RUnlock()
+
+	var resources []*pb.Resource
+	for _, key := range rl.keys {
+		if rl.nameInPath && f.name != "" && key.name != f.name {
+			continue
+		}
+
+		info := rl.cache[key]
+		if nsFilter != nil && !nsFilter.Match(info.metadata().Namespace, rl.l) {
+			continue
+		}
+
+		resources = append(resources, info.resources(f, rl.l)...)
+	}
+
+	rl.l.Debugf("kubernetes.%s.listResources: returning %d resources", rl.kind, len(resources))
+	return resources, nil
+}
+
+// parseResourceList parses an API server list response into cache keys and the
+// objects they map to. Objects rejected by keep are left out of both.
+func parseResourceList[T resourceInfo](resp []byte, keep func(T) bool) ([]resourceKey, map[resourceKey]T, error) {
+	var itemList struct {
+		Items []T
+	}
+
+	if err := json.Unmarshal(resp, &itemList); err != nil {
+		return nil, nil, err
+	}
+
+	keys := make([]resourceKey, 0, len(itemList.Items))
+	cache := make(map[resourceKey]T, len(itemList.Items))
+	for _, item := range itemList.Items {
+		if keep != nil && !keep(item) {
+			continue
+		}
+		md := item.metadata()
+		key := resourceKey{md.Namespace, md.Name}
+		keys = append(keys, key)
+		cache[key] = item
+	}
+
+	return keys, cache, nil
+}
+
+// expand refreshes the cache from the API server. If the refresh fails we keep
+// the resources we already have: an empty cache means "these targets are gone"
+// to everyone downstream, which is not what a failed API call tells us.
+func (rl *resourceLister[T]) expand() {
+	resp, err := rl.kClient.getURL(rl.url())
+	if err != nil {
+		rl.l.Warningf("kubernetes.%s: error getting %s list from API, keeping existing resources: %v", rl.kind, rl.kind, err)
+		return
+	}
+
+	keys, cache, err := parseResourceList(resp, rl.keep)
+	if err != nil {
+		rl.l.Warningf("kubernetes.%s: error parsing %s API response (%s), keeping existing resources: %v", rl.kind, rl.kind, string(resp), err)
+		return
+	}
+
+	rl.l.Debugf("kubernetes.%s: got %d %s", rl.kind, len(keys), rl.kind)
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	rl.keys = keys
+	rl.cache = cache
+}
+
+// start does the initial expansion and then refreshes in the background.
+func (rl *resourceLister[T]) start(reEvalInterval time.Duration) {
+	go func() {
+		rl.expand()
+
+		// Introduce a random delay between 0-reEvalInterval before starting
+		// the refresh loop. If there are multiple cloudprober instances, this
+		// makes sure that each one calls the API server at a different point
+		// of time.
+		if reEvalInterval > 0 {
+			time.Sleep(time.Duration(rand.Int63n(int64(reEvalInterval))))
+		}
+
+		ticker := time.NewTicker(reEvalInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			rl.expand()
+		}
+	}()
+}

--- a/internal/rds/kubernetes/lister.go
+++ b/internal/rds/kubernetes/lister.go
@@ -43,7 +43,7 @@ type resourceInfo interface {
 
 // listFilters holds everything a lister needs from a ListResources request:
 // the filters, and the object name if the request's resource path named one
-// (e.g. "services/service-a").
+// (e.g. "services/service-a"), which selects just that object.
 type listFilters struct {
 	*filter.Filters
 	name   string
@@ -96,12 +96,6 @@ type resourceLister[T resourceInfo] struct {
 	// only the pods that are running.
 	keep func(T) bool
 
-	// nameInPath indicates that a request's resource path may name a single
-	// object, e.g. "services/service-a". It is false for pods, which have
-	// always ignored such a name and returned every pod. That is preserved
-	// for compatibility rather than because it's desirable.
-	nameInPath bool
-
 	mu    sync.RWMutex // protects keys and cache
 	keys  []resourceKey
 	cache map[resourceKey]T
@@ -128,7 +122,7 @@ func (rl *resourceLister[T]) listResources(req *pb.ListResourcesRequest) ([]*pb.
 
 	var resources []*pb.Resource
 	for _, key := range rl.keys {
-		if rl.nameInPath && f.name != "" && key.name != f.name {
+		if f.name != "" && key.name != f.name {
 			continue
 		}
 

--- a/internal/rds/kubernetes/lister.go
+++ b/internal/rds/kubernetes/lister.go
@@ -37,7 +37,7 @@ type resourceInfo interface {
 	// resources expands a Kubernetes object into the RDS resources it
 	// represents: zero or more, depending on the type. Implementations are
 	// responsible for applying the name and labels filters, as the two are
-	// intertwined with the expansion (see listFilters.matchesObject).
+	// intertwined with the expansion (see listFilters.matches).
 	resources(f *listFilters, l *logger.Logger) []*pb.Resource
 }
 
@@ -97,7 +97,9 @@ type resourceLister[T resourceInfo] struct {
 	keep func(T) bool
 
 	// nameInPath indicates that a request's resource path may name a single
-	// object, e.g. "services/service-a". Pods don't support that today.
+	// object, e.g. "services/service-a". It is false for pods, which have
+	// always ignored such a name and returned every pod. That is preserved
+	// for compatibility rather than because it's desirable.
 	nameInPath bool
 
 	mu    sync.RWMutex // protects keys and cache
@@ -201,9 +203,7 @@ func (rl *resourceLister[T]) start(reEvalInterval time.Duration) {
 		// the refresh loop. If there are multiple cloudprober instances, this
 		// makes sure that each one calls the API server at a different point
 		// of time.
-		if reEvalInterval > 0 {
-			time.Sleep(time.Duration(rand.Int63n(int64(reEvalInterval))))
-		}
+		time.Sleep(time.Duration(rand.Int63n(int64(reEvalInterval))))
 
 		ticker := time.NewTicker(reEvalInterval)
 		defer ticker.Stop()

--- a/internal/rds/kubernetes/lister_test.go
+++ b/internal/rds/kubernetes/lister_test.go
@@ -1,0 +1,249 @@
+// Copyright 2026 The Cloudprober Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	cpb "github.com/cloudprober/cloudprober/internal/rds/kubernetes/proto"
+	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+// testK8sClient returns a kubeapi client that talks to a test server running
+// the given handler.
+func testK8sClient(t *testing.T, handler http.HandlerFunc) *client {
+	t.Helper()
+
+	ts := httptest.NewTLSServer(handler)
+	t.Cleanup(ts.Close)
+
+	return &client{
+		cfg:     &cpb.ProviderConfig{},
+		apiHost: strings.TrimPrefix(ts.URL, "https://"),
+		httpC:   ts.Client(),
+	}
+}
+
+// TestListerAPIPaths verifies that each lister asks the API server for the
+// right resource, in both the all-namespaces and single-namespace cases. It
+// goes through the real constructors on purpose: an api prefix or kind wired
+// up wrong is invisible to every other test, and in production it just returns
+// no targets.
+func TestListerAPIPaths(t *testing.T) {
+	listers := []struct {
+		kind    string
+		start   func(ns string, kc *client)
+		wantAll string
+		wantNS  string
+	}{
+		{
+			kind:    "pods",
+			start:   func(ns string, kc *client) { newPodsLister(ns, time.Hour, kc, nil) },
+			wantAll: "/api/v1/pods",
+			wantNS:  "/api/v1/namespaces/test-ns/pods",
+		},
+		{
+			kind:    "endpoints",
+			start:   func(ns string, kc *client) { newEndpointsLister(ns, time.Hour, kc, nil) },
+			wantAll: "/api/v1/endpoints",
+			wantNS:  "/api/v1/namespaces/test-ns/endpoints",
+		},
+		{
+			kind:    "services",
+			start:   func(ns string, kc *client) { newServicesLister(ns, time.Hour, kc, nil) },
+			wantAll: "/api/v1/services",
+			wantNS:  "/api/v1/namespaces/test-ns/services",
+		},
+		{
+			kind:    "ingresses",
+			start:   func(ns string, kc *client) { newIngressesLister(ns, time.Hour, kc, nil) },
+			wantAll: "/apis/networking.k8s.io/v1/ingresses",
+			wantNS:  "/apis/networking.k8s.io/v1/namespaces/test-ns/ingresses",
+		},
+	}
+
+	for _, lister := range listers {
+		for _, test := range []struct {
+			desc, ns, want string
+		}{
+			{"all-namespaces", "", lister.wantAll},
+			{"single-namespace", "test-ns", lister.wantNS},
+		} {
+			t.Run(lister.kind+"/"+test.desc, func(t *testing.T) {
+				paths := make(chan string, 1)
+				kc := testK8sClient(t, func(w http.ResponseWriter, r *http.Request) {
+					select {
+					case paths <- r.URL.Path:
+					default:
+					}
+					w.Write([]byte(`{"items":[]}`))
+				})
+
+				lister.start(test.ns, kc)
+
+				select {
+				case got := <-paths:
+					assert.Equal(t, test.want, got, "API server path")
+				case <-time.After(10 * time.Second):
+					t.Fatal("timed out waiting for the lister to call the API server")
+				}
+			})
+		}
+	}
+}
+
+// TestExpandOnError verifies that a failed refresh keeps the resources we
+// already have. Replacing them with an empty list would tell everything
+// downstream that these targets are gone, which is not what a failed API call
+// means: an emptied cache reaches the RDS client as a successful response with
+// zero resources, not as an error.
+func TestExpandOnError(t *testing.T) {
+	const onePod = `{"items":[{"metadata":{"name":"pod-b","namespace":"ns"},"status":{"phase":"Running","podIP":"10.0.0.2"}}]}`
+
+	tests := []struct {
+		desc      string
+		handler   http.HandlerFunc
+		wantNames []string
+	}{
+		{
+			desc:      "API error keeps existing resources",
+			handler:   func(w http.ResponseWriter, r *http.Request) { http.Error(w, "boom", http.StatusInternalServerError) },
+			wantNames: []string{"pod-a"},
+		},
+		{
+			desc:      "unparseable response keeps existing resources",
+			handler:   func(w http.ResponseWriter, r *http.Request) { w.Write([]byte("not json")) },
+			wantNames: []string{"pod-a"},
+		},
+		{
+			desc:      "empty response clears resources",
+			handler:   func(w http.ResponseWriter, r *http.Request) { w.Write([]byte(`{"items":[]}`)) },
+			wantNames: nil,
+		},
+		{
+			desc:      "good response replaces resources",
+			handler:   func(w http.ResponseWriter, r *http.Request) { w.Write([]byte(onePod)) },
+			wantNames: []string{"pod-b"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			existing := resourceKey{"ns", "pod-a"}
+			pl := &podsLister{
+				kind:      "pods",
+				apiPrefix: "api/v1",
+				keep:      runningPod,
+				kClient:   testK8sClient(t, test.handler),
+				keys:      []resourceKey{existing},
+				cache: map[resourceKey]*podInfo{
+					existing: testPodInfo("pod-a", "ns", "10.0.0.1", map[string]string{}),
+				},
+			}
+
+			pl.expand()
+
+			var gotNames []string
+			for _, key := range pl.keys {
+				gotNames = append(gotNames, key.name)
+			}
+			assert.Equal(t, test.wantNames, gotNames, "cached resource names")
+			assert.Len(t, pl.cache, len(test.wantNames), "cache size")
+		})
+	}
+}
+
+// waitForCache waits for a lister's first refresh to land.
+func waitForCache[T resourceInfo](t *testing.T, rl *resourceLister[T]) {
+	t.Helper()
+
+	assert.Eventually(t, func() bool {
+		rl.mu.RLock()
+		defer rl.mu.RUnlock()
+		return rl.cache != nil
+	}, 10*time.Second, 5*time.Millisecond, "lister did not populate its cache")
+}
+
+func listRequest(resourcePath string) *pb.ListResourcesRequest {
+	return &pb.ListResourcesRequest{ResourcePath: proto.String(resourcePath)}
+}
+
+const (
+	podsFixture = `{"items":[
+		{"metadata":{"name":"pod-a","namespace":"ns"},"status":{"phase":"Running","podIP":"10.0.0.1"}},
+		{"metadata":{"name":"pod-b","namespace":"ns"},"status":{"phase":"Running","podIP":"10.0.0.2"}},
+		{"metadata":{"name":"pod-pending","namespace":"ns"},"status":{"phase":"Pending","podIP":"10.0.0.3"}}
+	]}`
+
+	servicesFixture = `{"items":[
+		{"metadata":{"name":"svc-a","namespace":"ns"},"spec":{"clusterIP":"10.1.1.1","ports":[{"port":80}]}},
+		{"metadata":{"name":"svc-b","namespace":"ns"},"spec":{"clusterIP":"10.1.1.2","ports":[{"port":80}]}}
+	]}`
+)
+
+func serveFixture(t *testing.T, body string) *client {
+	return testK8sClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(body))
+	})
+}
+
+func resourceNames(resources []*pb.Resource) []string {
+	var names []string
+	for _, res := range resources {
+		names = append(names, res.GetName())
+	}
+	return names
+}
+
+// TestNameInPath pins the deliberate difference in how the listers treat a
+// name in the resource path: services, endpoints and ingresses select a single
+// object with it, pods ignore it and return everything. It builds the listers
+// through their real constructors so that the wiring is covered too.
+func TestNameInPath(t *testing.T) {
+	pl := newPodsLister("", time.Hour, serveFixture(t, podsFixture), nil)
+	waitForCache(t, pl)
+
+	got, err := pl.listResources(listRequest("pods/pod-a"))
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"pod-a", "pod-b"}, resourceNames(got), "pods ignore a name in the resource path")
+
+	sl := newServicesLister("", time.Hour, serveFixture(t, servicesFixture), nil)
+	waitForCache(t, sl)
+
+	got, err = sl.listResources(listRequest("services/svc-a"))
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"svc-a"}, resourceNames(got), "services select a single object by resource path")
+
+	got, err = sl.listResources(listRequest("services"))
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"svc-a", "svc-b"}, resourceNames(got), "no name in path returns everything")
+}
+
+// TestPodsListerCachesOnlyRunningPods covers the pods lister's parse-time
+// filter, including its wiring in newPodsLister.
+func TestPodsListerCachesOnlyRunningPods(t *testing.T) {
+	pl := newPodsLister("", time.Hour, serveFixture(t, podsFixture), nil)
+	waitForCache(t, pl)
+
+	got, err := pl.listResources(listRequest("pods"))
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"pod-a", "pod-b"}, resourceNames(got), "pods that are not running should not be cached")
+}

--- a/internal/rds/kubernetes/lister_test.go
+++ b/internal/rds/kubernetes/lister_test.go
@@ -213,28 +213,35 @@ func resourceNames(resources []*pb.Resource) []string {
 	return names
 }
 
-// TestNameInPath pins the deliberate difference in how the listers treat a
-// name in the resource path: services, endpoints and ingresses select a single
-// object with it, pods ignore it and return everything. It builds the listers
-// through their real constructors so that the wiring is covered too.
+// TestNameInPath verifies that a name in the resource path selects a single
+// object, for every resource type. Pods used to ignore it and return every
+// pod; they now behave like services, endpoints and ingresses.
 func TestNameInPath(t *testing.T) {
 	pl := newPodsLister("", time.Hour, serveFixture(t, podsFixture), nil)
 	waitForCache(t, pl)
 
 	got, err := pl.listResources(listRequest("pods/pod-a"))
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"pod-a", "pod-b"}, resourceNames(got), "pods ignore a name in the resource path")
+	assert.Equal(t, []string{"pod-a"}, resourceNames(got), "a name in the path selects one pod")
+
+	got, err = pl.listResources(listRequest("pods"))
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"pod-a", "pod-b"}, resourceNames(got), "no name in the path returns every pod")
 
 	sl := newServicesLister("", time.Hour, serveFixture(t, servicesFixture), nil)
 	waitForCache(t, sl)
 
 	got, err = sl.listResources(listRequest("services/svc-a"))
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"svc-a"}, resourceNames(got), "services select a single object by resource path")
+	assert.Equal(t, []string{"svc-a"}, resourceNames(got), "a name in the path selects one service")
 
 	got, err = sl.listResources(listRequest("services"))
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"svc-a", "svc-b"}, resourceNames(got), "no name in path returns everything")
+	assert.Equal(t, []string{"svc-a", "svc-b"}, resourceNames(got), "no name in the path returns every service")
+
+	got, err = pl.listResources(listRequest("pods/no-such-pod"))
+	assert.NoError(t, err)
+	assert.Empty(t, got, "a name that matches nothing returns nothing")
 }
 
 // TestPodsListerCachesOnlyRunningPods covers the pods lister's parse-time

--- a/internal/rds/kubernetes/lister_test.go
+++ b/internal/rds/kubernetes/lister_test.go
@@ -247,3 +247,13 @@ func TestPodsListerCachesOnlyRunningPods(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"pod-a", "pod-b"}, resourceNames(got), "pods that are not running should not be cached")
 }
+
+func TestNewRejectsNonPositiveReEvalSec(t *testing.T) {
+	for _, reEvalSec := range []int32{0, -1} {
+		_, err := New(&cpb.ProviderConfig{
+			Pods:      &cpb.Pods{},
+			ReEvalSec: proto.Int32(reEvalSec),
+		}, nil)
+		assert.ErrorContains(t, err, "re_eval_sec", "re_eval_sec=%d", reEvalSec)
+	}
+}

--- a/internal/rds/kubernetes/pods.go
+++ b/internal/rds/kubernetes/pods.go
@@ -15,73 +15,14 @@
 package kubernetes
 
 import (
-	"encoding/json"
-	"fmt"
-	"math/rand"
-	"sync"
 	"time"
 
-	configpb "github.com/cloudprober/cloudprober/internal/rds/kubernetes/proto"
 	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
-	"github.com/cloudprober/cloudprober/internal/rds/server/filter"
 	"github.com/cloudprober/cloudprober/logger"
 	"google.golang.org/protobuf/proto"
 )
 
-type podsLister struct {
-	c         *configpb.Pods
-	namespace string
-	kClient   *client
-
-	mu    sync.RWMutex // Mutex for names and cache
-	keys  []resourceKey
-	cache map[resourceKey]*podInfo
-	l     *logger.Logger
-}
-
-func podsURL(ns string) string {
-	if ns == "" {
-		return "api/v1/pods"
-	}
-	return fmt.Sprintf("api/v1/namespaces/%s/pods", ns)
-}
-
-func (pl *podsLister) listResources(req *pb.ListResourcesRequest) ([]*pb.Resource, error) {
-	var resources []*pb.Resource
-
-	allFilters, err := filter.ParseFilters(req.GetFilter(), SupportedFilters.RegexFilterKeys, "")
-	if err != nil {
-		return nil, err
-	}
-
-	nameFilter, nsFilter, labelsFilter := allFilters.RegexFilters["name"], allFilters.RegexFilters["namespace"], allFilters.LabelsFilter
-
-	pl.mu.RLock()
-	defer pl.mu.RUnlock()
-
-	for _, key := range pl.keys {
-		if nameFilter != nil && !nameFilter.Match(key.name, pl.l) {
-			continue
-		}
-
-		pod := pl.cache[key]
-		if nsFilter != nil && !nsFilter.Match(pod.Metadata.Namespace, pl.l) {
-			continue
-		}
-		if labelsFilter != nil && !labelsFilter.Match(pod.Metadata.Labels, pl.l) {
-			continue
-		}
-
-		resources = append(resources, &pb.Resource{
-			Name:   proto.String(key.name),
-			Ip:     proto.String(pod.Status.PodIP),
-			Labels: pod.Metadata.Labels,
-		})
-	}
-
-	pl.l.Debugf("kubernetes.listResources: returning %d pods", len(resources))
-	return resources, nil
-}
+type podsLister = resourceLister[*podInfo]
 
 type podInfo struct {
 	Metadata kMetadata
@@ -91,71 +32,40 @@ type podInfo struct {
 	}
 }
 
-func parsePodsJSON(resp []byte) (keys []resourceKey, pods map[resourceKey]*podInfo, err error) {
-	var itemList struct {
-		Items []*podInfo
-	}
-
-	if err = json.Unmarshal(resp, &itemList); err != nil {
-		return
-	}
-
-	keys = make([]resourceKey, 0, len(itemList.Items))
-	pods = make(map[resourceKey]*podInfo)
-	for _, item := range itemList.Items {
-		if item.Status.Phase != "Running" {
-			continue
-		}
-		key := resourceKey{item.Metadata.Namespace, item.Metadata.Name}
-		keys = append(keys, key)
-		pods[key] = item
-	}
-
-	return
+func (pi *podInfo) metadata() kMetadata {
+	return pi.Metadata
 }
 
-func (pl *podsLister) expand() {
-	resp, err := pl.kClient.getURL(podsURL(pl.namespace))
-	if err != nil {
-		pl.l.Warningf("podsLister.expand(): error while getting pods list from API: %v", err)
-	}
-
-	keys, pods, err := parsePodsJSON(resp)
-	if err != nil {
-		pl.l.Warningf("podsLister.expand(): error while parsing pods API response (%s): %v", string(resp), err)
-	}
-
-	pl.l.Debugf("podsLister.expand(): got %d pods", len(keys))
-
-	pl.mu.Lock()
-	defer pl.mu.Unlock()
-	pl.keys = keys
-	pl.cache = pods
+// runningPod is the pods lister's parse-time filter: we cache only the pods
+// that are running.
+func runningPod(pi *podInfo) bool {
+	return pi.Status.Phase == "Running"
 }
 
-func newPodsLister(c *configpb.Pods, namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) (*podsLister, error) {
+// resources returns the RDS resource for a pod. Pods map one-to-one.
+func (pi *podInfo) resources(f *listFilters, l *logger.Logger) []*pb.Resource {
+	if !f.matches(pi.Metadata.Name, pi.Metadata.Labels, l) {
+		return nil
+	}
+
+	return []*pb.Resource{
+		{
+			Name:   proto.String(pi.Metadata.Name),
+			Ip:     proto.String(pi.Status.PodIP),
+			Labels: pi.Metadata.Labels,
+		},
+	}
+}
+
+func newPodsLister(namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) *podsLister {
 	pl := &podsLister{
-		c:         c,
+		kind:      "pods",
+		apiPrefix: "api/v1",
 		namespace: namespace,
 		kClient:   kc,
+		keep:      runningPod,
 		l:         l,
 	}
-
-	go func() {
-		pl.expand()
-		// Introduce a random delay between 0-reEvalInterval before
-		// starting the refresh loop. If there are multiple cloudprober
-		// gceInstances, this will make sure that each instance calls GCE
-		// API at a different point of time.
-		rand.Seed(time.Now().UnixNano())
-		randomDelaySec := rand.Intn(int(reEvalInterval.Seconds()))
-		time.Sleep(time.Duration(randomDelaySec) * time.Second)
-		ticker := time.NewTicker(reEvalInterval)
-		defer ticker.Stop()
-		for range ticker.C {
-			pl.expand()
-		}
-	}()
-
-	return pl, nil
+	pl.start(reEvalInterval)
+	return pl
 }

--- a/internal/rds/kubernetes/pods_test.go
+++ b/internal/rds/kubernetes/pods_test.go
@@ -116,7 +116,7 @@ func TestParseResourceList(t *testing.T) {
 		t.Fatalf("error reading test data file: %s", podsListFile)
 	}
 
-	keys, cache, err := parsePodsJSON(data)
+	keys, cache, err := parseResourceList(data, runningPod)
 	if err != nil {
 		t.Fatalf("Error while parsing pods JSON data: %v", err)
 	}

--- a/internal/rds/kubernetes/services.go
+++ b/internal/rds/kubernetes/services.go
@@ -15,81 +15,17 @@
 package kubernetes
 
 import (
-	"encoding/json"
 	"fmt"
-	"math/rand"
 	"strconv"
-	"strings"
-	"sync"
 	"time"
 
-	configpb "github.com/cloudprober/cloudprober/internal/rds/kubernetes/proto"
 	pb "github.com/cloudprober/cloudprober/internal/rds/proto"
 	"github.com/cloudprober/cloudprober/internal/rds/server/filter"
 	"github.com/cloudprober/cloudprober/logger"
 	"google.golang.org/protobuf/proto"
 )
 
-type servicesLister struct {
-	c         *configpb.Services
-	namespace string
-	kClient   *client
-
-	mu    sync.RWMutex // Mutex for names and cache
-	keys  []resourceKey
-	cache map[resourceKey]*serviceInfo
-	l     *logger.Logger
-}
-
-func servicesURL(ns string) string {
-	if ns == "" {
-		return "api/v1/services"
-	}
-	return fmt.Sprintf("api/v1/namespaces/%s/services", ns)
-}
-
-func (lister *servicesLister) listResources(req *pb.ListResourcesRequest) ([]*pb.Resource, error) {
-	var resources []*pb.Resource
-
-	var svcName string
-	tok := strings.SplitN(req.GetResourcePath(), "/", 2)
-	if len(tok) == 2 {
-		svcName = tok[1]
-	}
-
-	allFilters, err := filter.ParseFilters(req.GetFilter(), SupportedFilters.RegexFilterKeys, "")
-	if err != nil {
-		return nil, err
-	}
-
-	nameFilter, nsFilter, labelsFilter := allFilters.RegexFilters["name"], allFilters.RegexFilters["namespace"], allFilters.LabelsFilter
-
-	lister.mu.RLock()
-	defer lister.mu.RUnlock()
-
-	for _, key := range lister.keys {
-		if svcName != "" && key.name != svcName {
-			continue
-		}
-
-		if nameFilter != nil && !nameFilter.Match(key.name, lister.l) {
-			continue
-		}
-
-		svc := lister.cache[key]
-		if nsFilter != nil && !nsFilter.Match(svc.Metadata.Namespace, lister.l) {
-			continue
-		}
-		if labelsFilter != nil && !labelsFilter.Match(svc.Metadata.Labels, lister.l) {
-			continue
-		}
-
-		resources = append(resources, svc.resources(allFilters.RegexFilters["port"], req.GetIpConfig().GetIpType(), lister.l)...)
-	}
-
-	lister.l.Debugf("kubernetes.listResources: returning %d services", len(resources))
-	return resources, nil
-}
+type servicesLister = resourceLister[*serviceInfo]
 
 type loadBalancerStatus struct {
 	Ingress []struct {
@@ -110,6 +46,10 @@ type serviceInfo struct {
 	Status struct {
 		LoadBalancer loadBalancerStatus
 	}
+}
+
+func (si *serviceInfo) metadata() kMetadata {
+	return si.Metadata
 }
 
 func (si *serviceInfo) matchPorts(portFilter *filter.RegexFilter, l *logger.Logger) ([]int, map[int]string) {
@@ -138,8 +78,12 @@ func (si *serviceInfo) matchPorts(portFilter *filter.RegexFilter, l *logger.Logg
 // service name.
 // b) If there are multiple ports, we create one RDS resource for each port and
 // name each resource as: <service_name>_<port_name>
-func (si *serviceInfo) resources(portFilter *filter.RegexFilter, reqIPType pb.IPConfig_IPType, l *logger.Logger) (resources []*pb.Resource) {
-	ports, portNameMap := si.matchPorts(portFilter, l)
+func (si *serviceInfo) resources(f *listFilters, l *logger.Logger) (resources []*pb.Resource) {
+	if !f.matches(si.Metadata.Name, si.Metadata.Labels, l) {
+		return nil
+	}
+
+	ports, portNameMap := si.matchPorts(f.regex("port"), l)
 	for _, port := range ports {
 		resName := si.Metadata.Name
 		if len(ports) != 1 {
@@ -152,7 +96,7 @@ func (si *serviceInfo) resources(portFilter *filter.RegexFilter, reqIPType pb.IP
 			Labels: si.Metadata.Labels,
 		}
 
-		if reqIPType == pb.IPConfig_PUBLIC {
+		if f.ipType == pb.IPConfig_PUBLIC {
 			// If there is no ingress IP, skip the resource.
 			if len(si.Status.LoadBalancer.Ingress) == 0 {
 				continue
@@ -172,67 +116,15 @@ func (si *serviceInfo) resources(portFilter *filter.RegexFilter, reqIPType pb.IP
 	return
 }
 
-func parseServicesJSON(resp []byte) (keys []resourceKey, services map[resourceKey]*serviceInfo, err error) {
-	var itemList struct {
-		Items []*serviceInfo
-	}
-
-	if err = json.Unmarshal(resp, &itemList); err != nil {
-		return
-	}
-
-	keys = make([]resourceKey, len(itemList.Items))
-	services = make(map[resourceKey]*serviceInfo)
-	for i, item := range itemList.Items {
-		keys[i] = resourceKey{item.Metadata.Namespace, item.Metadata.Name}
-		services[keys[i]] = item
-	}
-
-	return
-}
-
-func (lister *servicesLister) expand() {
-	resp, err := lister.kClient.getURL(servicesURL(lister.namespace))
-	if err != nil {
-		lister.l.Warningf("servicesLister.expand(): error while getting services list from API: %v", err)
-	}
-
-	keys, services, err := parseServicesJSON(resp)
-	if err != nil {
-		lister.l.Warningf("servicesLister.expand(): error while parsing services API response (%s): %v", string(resp), err)
-	}
-
-	lister.l.Debugf("servicesLister.expand(): got %d services", len(keys))
-
-	lister.mu.Lock()
-	defer lister.mu.Unlock()
-	lister.keys = keys
-	lister.cache = services
-}
-
-func newServicesLister(c *configpb.Services, namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) (*servicesLister, error) {
+func newServicesLister(namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) *servicesLister {
 	lister := &servicesLister{
-		c:         c,
-		kClient:   kc,
-		namespace: namespace,
-		l:         l,
+		kind:       "services",
+		apiPrefix:  "api/v1",
+		namespace:  namespace,
+		kClient:    kc,
+		nameInPath: true,
+		l:          l,
 	}
-
-	go func() {
-		lister.expand()
-		// Introduce a random delay between 0-reEvalInterval before
-		// starting the refresh loop. If there are multiple cloudprober
-		// gceInstances, this will make sure that each instance calls GCE
-		// API at a different point of time.
-		rand.Seed(time.Now().UnixNano())
-		randomDelaySec := rand.Intn(int(reEvalInterval.Seconds()))
-		time.Sleep(time.Duration(randomDelaySec) * time.Second)
-		ticker := time.NewTicker(reEvalInterval)
-		defer ticker.Stop()
-		for range ticker.C {
-			lister.expand()
-		}
-	}()
-
-	return lister, nil
+	lister.start(reEvalInterval)
+	return lister
 }

--- a/internal/rds/kubernetes/services.go
+++ b/internal/rds/kubernetes/services.go
@@ -118,12 +118,11 @@ func (si *serviceInfo) resources(f *listFilters, l *logger.Logger) (resources []
 
 func newServicesLister(namespace string, reEvalInterval time.Duration, kc *client, l *logger.Logger) *servicesLister {
 	lister := &servicesLister{
-		kind:       "services",
-		apiPrefix:  "api/v1",
-		namespace:  namespace,
-		kClient:    kc,
-		nameInPath: true,
-		l:          l,
+		kind:      "services",
+		apiPrefix: "api/v1",
+		namespace: namespace,
+		kClient:   kc,
+		l:         l,
 	}
 	lister.start(reEvalInterval)
 	return lister

--- a/internal/rds/kubernetes/services_test.go
+++ b/internal/rds/kubernetes/services_test.go
@@ -181,7 +181,7 @@ func TestParseSvcResourceList(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error reading test data file: %s", servicesListFile)
 	}
-	_, services, err := parseServicesJSON(data)
+	_, services, err := parseResourceList[*serviceInfo](data, nil)
 
 	if err != nil {
 		t.Fatalf("Error while parsing services JSON data: %v", err)


### PR DESCRIPTION
pods, endpoints, services and ingresses each carried their own copy of the same lister: an identical struct, a URL builder differing only in the API prefix and resource kind, a `parseXJSON`, an `expand()`, and a byte-identical refresh goroutine.

All four are now a generic `resourceLister[T resourceInfo]` in `lister.go`. Each resource type supplies only what actually differs — its metadata, and how it expands into RDS resources:

```go
type resourceInfo interface {
	metadata() kMetadata
	resources(f *listFilters, l *logger.Logger) []*pb.Resource
}
```

## Cache wipe on error

The four copies of `expand()` shared a bug: on an API or parse error they logged a warning and fell through to overwrite the cache with `nil`, dropping every target for that resource type until the next successful refresh.

There's no net for this downstream — an emptied cache reaches the RDS client as a *successful* response with zero resources, not as an error, so `updateState` faithfully replaces its cache with empty.

It mattered little while calls could hang, since a hang preserved the cache. It matters more once API calls time out (#1485), because a stall then surfaces as exactly this kind of fast error. `expand()` now keeps the last good result.

That PR and this one touch no overlapping files and can merge in either order.

## Behavior changes

- **A name in the resource path now selects a single pod.** `k8s://pods/my-pod` used to return every pod in the cluster; services, endpoints and ingresses have always treated the name as a selector. Pods now match them. A config using such a path gets the one pod it asked for rather than all of them. This is the only change here that can alter an existing deployment's target set.
- **`re_eval_sec` must be positive.** An explicit `0` used to panic the refresh goroutine on `time.NewTicker(0)`, taking the process down; it is now a config error from `New()`. An unset value still defaults to 60, and `k8s_targets` forces 30, so only an explicit zero or a negative value is affected.

## Preserved asymmetry

Ingresses filter name/labels *after* expansion, not on the Kubernetes object, because their resource names are derived per rule (`<ingress>_<host>_<path>`) and they carry their own `fqdn`/`relative_url` labels. The other types filter on the object, where a name filter matches the object name rather than derived per-port resource names. Flattening this either way would silently change target selection.

## Also

Drops `rand.Seed` (deprecated since Go 1.20, called once per lister at startup) and jitters the first refresh at full resolution instead of whole seconds; drops the unused per-type config fields, as all four config messages are empty; drops the `error` return from the four constructors, which was never non-nil; documents the `keys`/`cache` invariant that `listResources` relies on when it dereferences a cache entry.

## Testing

Coverage went from 65.2% to 83.9%. The starting number was badly distributed: the existing tests covered the filtering and expansion logic well, and everything the refactor *introduced* — `url()`, `expand()`, `start()`, all four constructors — was at zero, so a wrong api prefix or resource kind would compile, pass every test, and silently return no targets.

The listers' original test assertions are unchanged, which is the evidence the refactor preserves behavior. New tests cover the API path each lister requests (with and without a namespace), `expand()` keeping the last good result on API and parse failures, the resource-path selector, the running-pods filter, and the `re_eval_sec` rejection — all driven through the real constructors so the per-type wiring is observable.

Verified by mutation rather than by the coverage number: breaking the implementation eleven ways (wrong api prefix, wrong kind, `url()` ignoring the namespace, `expand()` reverted to the old fall-through, `keep` removed, `runningPod` accepting every phase, `matches()` ignoring either filter, `listResources` dropping the namespace filter or the path selector, ingresses filtering the object instead of expanded resources) fails the tests in every case.

Still uncovered, pre-existing and not addressed: `ListResources()` in `kubernetes.go`.

## Review

A cold review of the branch raised three items, all addressed: the half-guarded `NewTicker` panic (now rejected in `New()`), the pods resource-path inconsistency (now unified), and a stale doc reference to `listFilters.matchesObject` left over from collapsing two identical match helpers into `matches`.