### PR TITLE
[rds.kubernetes] Add a namespace label to discovered resources

### DIFF
--- a/docs/content/docs/how-to/k8s_targets.md
+++ b/docs/content/docs/how-to/k8s_targets.md
@@ -103,9 +103,10 @@ You can filter k8s resources using the following options:
 ### Target Labels
 
 Discovered targets carry the Kubernetes resource's labels, plus a `namespace`
-label set to the resource's namespace (unless the resource already has a label
-with that name). Endpoints targets also get `node` and `pod` labels, and
-ingress targets get `fqdn` and `relative_url` labels.
+label set to the resource's namespace. Endpoints targets also get a `node`
+label, and a `pod` label if the address belongs to a pod. Ingress targets get
+`fqdn` and `relative_url` labels. If the resource already has a label with one
+of these names, its value is kept.
 
 You can use these labels in
 [additional labels]({{< ref "additional-labels.md" >}}), e.g. to add the

--- a/docs/content/docs/how-to/k8s_targets.md
+++ b/docs/content/docs/how-to/k8s_targets.md
@@ -100,6 +100,34 @@ You can filter k8s resources using the following options:
   }
   ```
 
+### Target Labels
+
+Discovered targets carry the Kubernetes resource's labels, plus a `namespace`
+label set to the resource's namespace (unless the resource already has a label
+with that name). Endpoints targets also get `node` and `pod` labels, and
+ingress targets get `fqdn` and `relative_url` labels.
+
+You can use these labels in
+[additional labels]({{< ref "additional-labels.md" >}}), e.g. to add the
+target's namespace to the probe metrics:
+
+```shell
+probe {
+  name: "services"
+  type: HTTP
+  targets {
+    k8s {
+      services: ".*"
+    }
+  }
+  additional_label {
+    key: "namespace"
+    value: "@target.label.namespace@"
+  }
+  http_probe {}
+}
+```
+
 ### Cluster Resources Access
 
 Note: If you've installed Cloudprober using

--- a/internal/rds/kubernetes/endpoints.go
+++ b/internal/rds/kubernetes/endpoints.go
@@ -56,7 +56,8 @@ func (epi *epInfo) metadata() kMetadata {
 // addresses and 2 ports, there will be 6 resources corresponding to that
 // subset.
 func (epi *epInfo) resources(f *listFilters, l *logger.Logger) (resources []*pb.Resource) {
-	if !f.matches(epi.Metadata.Name, epi.Metadata.Labels, l) {
+	baseLabels := epi.Metadata.resourceLabels()
+	if !f.matches(epi.Metadata.Name, baseLabels, l) {
 		return nil
 	}
 
@@ -79,8 +80,8 @@ func (epi *epInfo) resources(f *listFilters, l *logger.Logger) (resources []*pb.
 				// We name the resource as <endpoints_name>_<IP>_<port>
 				resName := fmt.Sprintf("%s_%s_%s", epi.Metadata.Name, addr.IP, portName)
 
-				labels := make(map[string]string)
-				for k, v := range epi.Metadata.Labels {
+				labels := make(map[string]string, len(baseLabels)+2)
+				for k, v := range baseLabels {
 					labels[k] = v
 				}
 				labels["node"] = addr.NodeName

--- a/internal/rds/kubernetes/endpoints.go
+++ b/internal/rds/kubernetes/endpoints.go
@@ -84,9 +84,11 @@ func (epi *epInfo) resources(f *listFilters, l *logger.Logger) (resources []*pb.
 				for k, v := range baseLabels {
 					labels[k] = v
 				}
-				labels["node"] = addr.NodeName
-				// If adding labels, make a copy of the metadata labels.
-				if addr.TargetRef.Kind == "Pod" {
+				// As with namespace, the object's own labels take precedence.
+				if _, ok := labels["node"]; !ok {
+					labels["node"] = addr.NodeName
+				}
+				if _, ok := labels["pod"]; !ok && addr.TargetRef.Kind == "Pod" {
 					labels["pod"] = addr.TargetRef.Name
 				}
 

--- a/internal/rds/kubernetes/endpoints_test.go
+++ b/internal/rds/kubernetes/endpoints_test.go
@@ -87,7 +87,7 @@ func TestEndpointsToResources(t *testing.T) {
 		Metadata: kMetadata{
 			Name:      epName,
 			Namespace: "prod",
-			Labels:    map[string]string{"app": appLabel},
+			Labels:    map[string]string{"app": appLabel, "node": "lNode"}, // node label is kept
 		},
 		Subsets: make([]epSubset, 1),
 	}
@@ -158,10 +158,10 @@ func TestEndpointsToResources(t *testing.T) {
 	}
 
 	expectedLabels := []map[string]string{
-		{"app": "lCloudprober", "namespace": "prod", "node": "n1", "pod": "test-pod"},
-		{"app": "lCloudprober", "namespace": "prod", "node": "n2"},
-		{"app": "lCloudprober", "namespace": "prod", "node": "n1", "pod": "test-pod"},
-		{"app": "lCloudprober", "namespace": "prod", "node": "n2"},
+		{"app": "lCloudprober", "namespace": "prod", "node": "lNode", "pod": "test-pod"},
+		{"app": "lCloudprober", "namespace": "prod", "node": "lNode"},
+		{"app": "lCloudprober", "namespace": "prod", "node": "lNode", "pod": "test-pod"},
+		{"app": "lCloudprober", "namespace": "prod", "node": "lNode"},
 	}
 	if !reflect.DeepEqual(labels, expectedLabels) {
 		t.Errorf("Cloudprober endpoints resource labels=%v, want=%v", labels, expectedLabels)

--- a/internal/rds/kubernetes/endpoints_test.go
+++ b/internal/rds/kubernetes/endpoints_test.go
@@ -85,8 +85,9 @@ func TestEndpointsToResources(t *testing.T) {
 
 	epi := &epInfo{
 		Metadata: kMetadata{
-			Name:   epName,
-			Labels: map[string]string{"app": appLabel},
+			Name:      epName,
+			Namespace: "prod",
+			Labels:    map[string]string{"app": appLabel},
 		},
 		Subsets: make([]epSubset, 1),
 	}
@@ -157,10 +158,10 @@ func TestEndpointsToResources(t *testing.T) {
 	}
 
 	expectedLabels := []map[string]string{
-		{"app": "lCloudprober", "node": "n1", "pod": "test-pod"},
-		{"app": "lCloudprober", "node": "n2"},
-		{"app": "lCloudprober", "node": "n1", "pod": "test-pod"},
-		{"app": "lCloudprober", "node": "n2"},
+		{"app": "lCloudprober", "namespace": "prod", "node": "n1", "pod": "test-pod"},
+		{"app": "lCloudprober", "namespace": "prod", "node": "n2"},
+		{"app": "lCloudprober", "namespace": "prod", "node": "n1", "pod": "test-pod"},
+		{"app": "lCloudprober", "namespace": "prod", "node": "n2"},
 	}
 	if !reflect.DeepEqual(labels, expectedLabels) {
 		t.Errorf("Cloudprober endpoints resource labels=%v, want=%v", labels, expectedLabels)

--- a/internal/rds/kubernetes/ingresses.go
+++ b/internal/rds/kubernetes/ingresses.go
@@ -58,7 +58,7 @@ func (i *ingressInfo) metadata() kMetadata {
 // unselectable.
 func (i *ingressInfo) resources(f *listFilters, l *logger.Logger) (resources []*pb.Resource) {
 	resName := i.Metadata.Name
-	baseLabels := i.Metadata.Labels
+	baseLabels := i.Metadata.resourceLabels()
 
 	// Note that for ingress we don't check the type of the IP in the request.
 	// That is mainly because ingresses typically have only one ingress

--- a/internal/rds/kubernetes/ingresses_test.go
+++ b/internal/rds/kubernetes/ingresses_test.go
@@ -99,6 +99,14 @@ func TestListIngressResources(t *testing.T) {
 			wantIPs:   []string{"cloudprober.monitoring.com"},
 		},
 		{
+			desc:      "namespace label filter",
+			filters:   map[string]string{"labels.namespace": "default"},
+			wantNames: []string{"rds-ingress_foo.bar.com__health", "rds-ingress_foo.bar.com__rds", "rds-ingress_prometheus.bar.com"},
+			wantFQDNs: []string{"foo.bar.com", "foo.bar.com", "prometheus.bar.com"},
+			wantURLs:  []string{"/health", "/rds", "/"},
+			wantIPs:   []string{"241.120.51.35", "241.120.51.35", "241.120.51.35"},
+		},
+		{
 			desc:      "name filter for host regex",
 			filters:   map[string]string{"name": ".*foo.bar.com.*"},
 			wantNames: []string{"rds-ingress_foo.bar.com__health", "rds-ingress_foo.bar.com__rds"},

--- a/internal/rds/kubernetes/kubernetes.go
+++ b/internal/rds/kubernetes/kubernetes.go
@@ -102,6 +102,21 @@ type kMetadata struct {
 	Labels    map[string]string
 }
 
+// resourceLabels returns the labels for the RDS resources created from this
+// object: a copy of the object's labels, plus a "namespace" label (unless the
+// object already has a label with that name). The copy lets callers add more
+// labels without modifying the cached object.
+func (md kMetadata) resourceLabels() map[string]string {
+	labels := make(map[string]string, len(md.Labels)+1)
+	for k, v := range md.Labels {
+		labels[k] = v
+	}
+	if _, ok := labels["namespace"]; !ok {
+		labels["namespace"] = md.Namespace
+	}
+	return labels
+}
+
 type resourceKey struct {
 	namespace, name string
 }

--- a/internal/rds/kubernetes/kubernetes_test.go
+++ b/internal/rds/kubernetes/kubernetes_test.go
@@ -81,3 +81,13 @@ func Test_sanitizeRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestResourceLabels(t *testing.T) {
+	md := kMetadata{Name: "a", Namespace: "prod", Labels: map[string]string{"app": "web"}}
+	assert.Equal(t, map[string]string{"app": "web", "namespace": "prod"}, md.resourceLabels())
+	assert.Equal(t, map[string]string{"app": "web"}, md.Labels, "object labels modified")
+
+	// An object label named "namespace" is left alone.
+	md.Labels["namespace"] = "custom"
+	assert.Equal(t, map[string]string{"app": "web", "namespace": "custom"}, md.resourceLabels())
+}

--- a/internal/rds/kubernetes/pods.go
+++ b/internal/rds/kubernetes/pods.go
@@ -44,7 +44,8 @@ func runningPod(pi *podInfo) bool {
 
 // resources returns the RDS resource for a pod. Pods map one-to-one.
 func (pi *podInfo) resources(f *listFilters, l *logger.Logger) []*pb.Resource {
-	if !f.matches(pi.Metadata.Name, pi.Metadata.Labels, l) {
+	labels := pi.Metadata.resourceLabels()
+	if !f.matches(pi.Metadata.Name, labels, l) {
 		return nil
 	}
 
@@ -52,7 +53,7 @@ func (pi *podInfo) resources(f *listFilters, l *logger.Logger) []*pb.Resource {
 		{
 			Name:   proto.String(pi.Metadata.Name),
 			Ip:     proto.String(pi.Status.PodIP),
-			Labels: pi.Metadata.Labels,
+			Labels: labels,
 		},
 	}
 }

--- a/internal/rds/kubernetes/pods_test.go
+++ b/internal/rds/kubernetes/pods_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func testPodInfo(name, ns, ip string, labels map[string]string) *podInfo {
-	labels["namespace"] = ns
 	pi := &podInfo{Metadata: kMetadata{Name: name, Namespace: ns, Labels: labels}}
 	pi.Status.PodIP = ip
 	return pi
@@ -78,6 +77,11 @@ func TestListResources(t *testing.T) {
 			desc:     "only namespace filter for podA and podB",
 			filters:  map[string]string{"namespace": "nsAB"},
 			wantPods: []resourceKey{{"nsAB", "podA"}, {"nsAB", "podB"}},
+		},
+		{
+			desc:     "namespace label filter for podC",
+			filters:  map[string]string{"name": "podC", "labels.namespace": "devC"},
+			wantPods: []resourceKey{{"devC", "podC"}},
 		},
 	}
 

--- a/internal/rds/kubernetes/services.go
+++ b/internal/rds/kubernetes/services.go
@@ -79,7 +79,8 @@ func (si *serviceInfo) matchPorts(portFilter *filter.RegexFilter, l *logger.Logg
 // b) If there are multiple ports, we create one RDS resource for each port and
 // name each resource as: <service_name>_<port_name>
 func (si *serviceInfo) resources(f *listFilters, l *logger.Logger) (resources []*pb.Resource) {
-	if !f.matches(si.Metadata.Name, si.Metadata.Labels, l) {
+	labels := si.Metadata.resourceLabels()
+	if !f.matches(si.Metadata.Name, labels, l) {
 		return nil
 	}
 
@@ -93,7 +94,7 @@ func (si *serviceInfo) resources(f *listFilters, l *logger.Logger) (resources []
 		res := &pb.Resource{
 			Name:   proto.String(resName),
 			Port:   proto.Int32(int32(port)),
-			Labels: si.Metadata.Labels,
+			Labels: labels,
 		}
 
 		if f.ipType == pb.IPConfig_PUBLIC {

--- a/internal/rds/kubernetes/services_test.go
+++ b/internal/rds/kubernetes/services_test.go
@@ -121,6 +121,13 @@ func TestListSvcResources(t *testing.T) {
 			wantIPs:      []string{"10.2.1.4"},
 			wantPorts:    []int32{3141},
 		},
+		{
+			desc:         "namespace label filter",
+			filters:      map[string]string{"labels.namespace": "nsAB"},
+			wantServices: []string{"serviceA_9313", "serviceA_9314", "serviceB"},
+			wantIPs:      []string{"10.1.1.1", "10.1.1.1", "10.1.1.2"},
+			wantPorts:    []int32{9313, 9314, 443},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Resources for all four Kubernetes kinds (pods, services, endpoints, ingresses) now carry a `namespace` label, so probes can use it via `@target.label.namespace@` (e.g. in `additional_label`) and filter on it with `labels.namespace`.

- A new `kMetadata.resourceLabels()` helper returns a copy of the object's labels plus `namespace`, so cached objects aren't modified.
- If the object already has a label named `namespace`, it takes precedence (same convention as ingress `fqdn`/`relative_url`).
- Pods, services, and endpoints now match the labels filter against these labels, so `labels.namespace` works for every kind.
- Endpoints no longer overwrite object labels named `node` or `pod`, so all labels Cloudprober adds (`namespace`, `node`, `pod`, `fqdn`, `relative_url`) follow the same rule. **Behavior change:** endpoints targets whose object has its own `node` or `pod` label (e.g. copied from the Service) now report that value.
- Docs: added a "Target Labels" section to the Kubernetes targets how-to.

This picks up the namespace label part of #1274. It doesn't prefix service names with the namespace, since that would rename existing targets.
