### PR TITLE
[servers.udp] Support large-datagram in echo server

### DIFF
--- a/docs/content/docs/how-to/built-in-servers.md
+++ b/docs/content/docs/how-to/built-in-servers.md
@@ -78,7 +78,8 @@ HTTP server configuration options.
 ## UDP
 
 UDP server can either echo packets back or completely ignore them. In echo mode,
-you can use it along with the UDP probe type.
+you can use it along with the UDP probe type. `max_payload_size` controls the
+largest UDP payload that can be received and defaults to 4098 bytes.
 
 ```shell
 server {
@@ -86,6 +87,7 @@ server {
   udp_server {
     port: 85
     type: ECHO
+    max_payload_size: 8192
   }
 }
 

--- a/internal/servers/udp/proto/config.pb.go
+++ b/internal/servers/udp/proto/config.pb.go
@@ -25,8 +25,6 @@ type ServerConf_Type int32
 
 const (
 	// Echos the incoming packet back.
-	// Note that UDP echo server limits reads to 4098 bytes. For messages longer
-	// than 4098 bytes it won't work as expected.
 	ServerConf_ECHO ServerConf_Type = 0
 	// Discard the incoming packet. Return nothing.
 	ServerConf_DISCARD ServerConf_Type = 1
@@ -82,12 +80,19 @@ func (ServerConf_Type) EnumDescriptor() ([]byte, []int) {
 }
 
 type ServerConf struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Port          *int32                 `protobuf:"varint,1,req,name=port" json:"port,omitempty"`
-	Type          *ServerConf_Type       `protobuf:"varint,2,req,name=type,enum=cloudprober.servers.udp.ServerConf_Type" json:"type,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Port  *int32                 `protobuf:"varint,1,req,name=port" json:"port,omitempty"`
+	Type  *ServerConf_Type       `protobuf:"varint,2,req,name=type,enum=cloudprober.servers.udp.ServerConf_Type" json:"type,omitempty"`
+	// Maximum UDP payload size, in bytes, that can be received. Must be between 1 and 65535.
+	MaxPayloadSize *int32 `protobuf:"varint,3,opt,name=max_payload_size,json=maxPayloadSize,def=4098" json:"max_payload_size,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
+
+// Default values for ServerConf fields.
+const (
+	Default_ServerConf_MaxPayloadSize = int32(4098)
+)
 
 func (x *ServerConf) Reset() {
 	*x = ServerConf{}
@@ -133,15 +138,23 @@ func (x *ServerConf) GetType() ServerConf_Type {
 	return ServerConf_ECHO
 }
 
+func (x *ServerConf) GetMaxPayloadSize() int32 {
+	if x != nil && x.MaxPayloadSize != nil {
+		return *x.MaxPayloadSize
+	}
+	return Default_ServerConf_MaxPayloadSize
+}
+
 var File_github_com_cloudprober_cloudprober_internal_servers_udp_proto_config_proto protoreflect.FileDescriptor
 
 const file_github_com_cloudprober_cloudprober_internal_servers_udp_proto_config_proto_rawDesc = "" +
 	"\n" +
-	"Jgithub.com/cloudprober/cloudprober/internal/servers/udp/proto/config.proto\x12\x17cloudprober.servers.udp\"}\n" +
+	"Jgithub.com/cloudprober/cloudprober/internal/servers/udp/proto/config.proto\x12\x17cloudprober.servers.udp\"\xad\x01\n" +
 	"\n" +
 	"ServerConf\x12\x12\n" +
 	"\x04port\x18\x01 \x02(\x05R\x04port\x12<\n" +
-	"\x04type\x18\x02 \x02(\x0e2(.cloudprober.servers.udp.ServerConf.TypeR\x04type\"\x1d\n" +
+	"\x04type\x18\x02 \x02(\x0e2(.cloudprober.servers.udp.ServerConf.TypeR\x04type\x12.\n" +
+	"\x10max_payload_size\x18\x03 \x01(\x05:\x044098R\x0emaxPayloadSize\"\x1d\n" +
 	"\x04Type\x12\b\n" +
 	"\x04ECHO\x10\x00\x12\v\n" +
 	"\aDISCARD\x10\x01B?Z=github.com/cloudprober/cloudprober/internal/servers/udp/proto"

--- a/internal/servers/udp/proto/config.proto
+++ b/internal/servers/udp/proto/config.proto
@@ -9,12 +9,13 @@ message ServerConf {
 
   enum Type {
     // Echos the incoming packet back.
-    // Note that UDP echo server limits reads to 4098 bytes. For messages longer
-    // than 4098 bytes it won't work as expected.
     ECHO = 0;
 
     // Discard the incoming packet. Return nothing.
     DISCARD = 1;
   }
   required Type type = 2;
+
+  // Maximum UDP payload size, in bytes, that can be received. Must be between 1 and 65535.
+  optional int32 max_payload_size = 3 [default = 4098];
 }

--- a/internal/servers/udp/udp.go
+++ b/internal/servers/udp/udp.go
@@ -39,19 +39,14 @@ const (
 
 	// Number of messages to batch read.
 	batchSize = 16
-
-	// Maximum packet size.
-	// TODO(manugarg): We read and echo back only 4098 bytes. We should look at raising this
-	// limit or making it configurable. Also of note, ReadFromUDP reads a single UDP datagram
-	// (up to the max size of 64K-sizeof(UDPHdr)) and discards the rest.
-	maxPacketSize = 4098
 )
 
 // Server implements a basic UDP server.
 type Server struct {
-	c    *configpb.ServerConf
-	conn *net.UDPConn
-	l    *logger.Logger
+	c              *configpb.ServerConf
+	conn           *net.UDPConn
+	l              *logger.Logger
+	maxPayloadSize int
 
 	advancedReadWrite bool // Set to true on non-windows systems
 	p6                *ipv6.PacketConn
@@ -90,6 +85,11 @@ func (s *Server) configureAdvancedReadWrite() error {
 
 // New returns an UDP server.
 func New(initCtx context.Context, c *configpb.ServerConf, l *logger.Logger) (*Server, error) {
+	maxPayloadSize := c.GetMaxPayloadSize()
+	if maxPayloadSize < 1 || maxPayloadSize > 65535 {
+		return nil, fmt.Errorf("max_payload_size must be between 1 and %d bytes, got %d", 65535, maxPayloadSize)
+	}
+
 	conn, err := Listen(&net.UDPAddr{Port: int(c.GetPort())}, l)
 	if err != nil {
 		return nil, err
@@ -100,9 +100,10 @@ func New(initCtx context.Context, c *configpb.ServerConf, l *logger.Logger) (*Se
 	}()
 
 	s := &Server{
-		c:    c,
-		conn: conn,
-		l:    l,
+		c:              c,
+		conn:           conn,
+		l:              l,
+		maxPayloadSize: int(maxPayloadSize),
 	}
 
 	return s, s.configureAdvancedReadWrite()
@@ -209,13 +210,13 @@ func (s *Server) readAndEchoSimple(buf []byte) *readWriteErr {
 
 // Start starts the UDP server. It returns only when context is canceled.
 func (s *Server) Start(ctx context.Context, dataChan chan<- *metrics.EventMetrics) error {
-	var ms []ipv6.Message              // Used for batch read-write
-	buf := make([]byte, maxPacketSize) // Used for single packet read-write (windows)
+	var ms []ipv6.Message                 // Used for batch read-write
+	buf := make([]byte, s.maxPayloadSize) // Used for single packet read-write (windows)
 
 	if s.advancedReadWrite {
 		ms = make([]ipv6.Message, batchSize)
 		for i := 0; i < batchSize; i++ {
-			ms[i].Buffers = [][]byte{make([]byte, maxPacketSize)}
+			ms[i].Buffers = [][]byte{make([]byte, s.maxPayloadSize)}
 			ms[i].OOB = ipv6.NewControlMessage(ipv6.FlagDst)
 		}
 	}

--- a/internal/servers/udp/udp_test.go
+++ b/internal/servers/udp/udp_test.go
@@ -38,7 +38,10 @@ func isClientTimeout(err error) bool {
 }
 
 func sendAndTestResponse(t *testing.T, c *configpb.ServerConf, conn net.Conn) {
-	size := rand.Intn(1024)
+	sendAndTestResponseSize(t, c, conn, rand.Intn(1024))
+}
+
+func sendAndTestResponseSize(t *testing.T, c *configpb.ServerConf, conn net.Conn, size int) {
 	data := make([]byte, size)
 	rand.Read(data)
 
@@ -90,6 +93,63 @@ func TestEchoServer(t *testing.T) {
 		Type: configpb.ServerConf_ECHO.Enum(),
 	}
 	testServer(t, testConfig)
+}
+
+func TestEchoServerConfiguredMaxPayloadSize(t *testing.T) {
+	const payloadSize = 8192
+
+	for _, tc := range []struct {
+		name        string
+		forceSimple bool
+	}{
+		{name: "simple", forceSimple: true},
+		{name: "batch"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testConfig := &configpb.ServerConf{
+				Port:           proto.Int32(0),
+				Type:           configpb.ServerConf_ECHO.Enum(),
+				MaxPayloadSize: proto.Int32(payloadSize),
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			server, err := New(ctx, testConfig, &logger.Logger{})
+			if err != nil {
+				t.Fatalf("Error creating a new server: %v", err)
+			}
+			if tc.forceSimple {
+				server.advancedReadWrite = false
+			} else if !server.advancedReadWrite {
+				t.Skip("batch receive is not supported")
+			}
+			if server.maxPayloadSize != payloadSize {
+				t.Fatalf("maxPayloadSize=%d, want %d", server.maxPayloadSize, payloadSize)
+			}
+			go server.Start(ctx, nil)
+
+			serverAddr := fmt.Sprintf("localhost:%d", server.conn.LocalAddr().(*net.UDPAddr).Port)
+			conn, err := net.Dial("udp", serverAddr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer conn.Close()
+
+			sendAndTestResponseSize(t, testConfig, conn, payloadSize)
+		})
+	}
+}
+
+func TestInvalidMaxPayloadSize(t *testing.T) {
+	for _, size := range []int32{-1, 0, 65536} {
+		_, err := New(context.Background(), &configpb.ServerConf{
+			Port:           proto.Int32(0),
+			Type:           configpb.ServerConf_ECHO.Enum(),
+			MaxPayloadSize: proto.Int32(size),
+		}, &logger.Logger{})
+		if err == nil {
+			t.Errorf("New() with max_payload_size %d succeeded, want error", size)
+		}
+	}
 }
 
 func TestDiscardServer(t *testing.T) {


### PR DESCRIPTION
Allow configuring the maximum udp payload that can be received.